### PR TITLE
Upgrade Java version from 11 to 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         distribution: zulu
-        java-version: '11'
+        java-version: '17'
     - uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,12 +22,12 @@ jobs:
       with:
         distribution: zulu
         java-version: '17'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Test with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
-    id "com.diffplug.spotless" version "6.2.1"
+    id "com.diffplug.spotless" version "6.11.0"
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
# Upgrade Java version from 11 to 17

## Summary
This PR upgrades the project from Java 11 to Java 17 by updating the build configuration and CI/CD pipeline. The changes include:

- Updated `sourceCompatibility` and `targetCompatibility` to `'17'` in `build.gradle`
- Updated GitHub Actions workflow to use JDK 17 instead of JDK 11
- Upgraded Spotless plugin from 6.2.1 to 6.11.0 (required for Java 17 compatibility due to module system changes)
- Upgraded `actions/cache` from v2 to v4 (v2 was deprecated and blocking CI)
- Applied automatic code formatting changes from the updated Spotless version (one test file affected)

The build and all tests pass successfully with Java 17. Spring Boot 2.6.3 officially supports Java 17.

## Review & Testing Checklist for Human

- [ ] **Run the application locally with Java 17** and verify it starts up without errors or warnings (especially watch for illegal reflective access warnings or module-related errors in the logs)
- [ ] **Test critical user flows** that may not be covered by the automated test suite (user registration, login, article creation, etc.)
- [ ] **Review the formatting change** in `DefaultJwtServiceTest.java` to confirm it's purely cosmetic (line break added by Spotless, no functional change)
- [ ] **Check for any dependency warnings** during build or runtime that might indicate compatibility issues with Java 17

### Recommended Test Plan
1. Build and run the application locally: `./gradlew bootRun`
2. Verify the application starts without errors
3. Test basic API endpoints (user registration, login, article CRUD operations)
4. Check application logs for any warnings about deprecated APIs or module access issues

### Notes
- The Spotless plugin upgrade was necessary because the old version (6.2.1) used GoogleJavaFormat that couldn't access JDK compiler internals due to Java 17's stricter module encapsulation
- The `actions/cache` upgrade was required because GitHub deprecated v2 and was blocking CI runs
- All existing tests pass with Java 17, but runtime behavior should be verified with real usage

---
**Link to Devin run:** https://app.devin.ai/sessions/b46dee345f9c4df6aafaaeab0c61f07e  
**Requested by:** Roshan Fernando (@rdf004)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
