### PR TITLE
Upgrade to Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+# google-java-format (used by Spotless) accesses jdk.compiler internals,
+# which are not exported by default on JDK 16+. Required for spotless on Java 17.
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Moves the project's language/bytecode level from Java 11 to Java 17. The existing toolchain
(Gradle 7.4, Spring Boot 2.6.3, DGS 4.9.21, Lombok 1.18.22) already supports Java 17, so no
application source changes were needed — the change is config plus one unblocked formatting fix.

Changes:
- `build.gradle`: `sourceCompatibility`/`targetCompatibility` `11` → `17`.
- `README.md`: "You'll need Java 11 installed." → Java 17.
- `gradle.properties` (new): adds `--add-exports jdk.compiler/...` JVM args. Spotless's
  google-java-format reaches into `com.sun.tools.javac` internals, which JDK 16+ no longer exports
  by default; without these flags `spotlessCheck` fails with `IllegalAccessError`. This is the
  documented fix for running google-java-format on JDK 17.
- `DefaultJwtServiceTest.java`: one-line reformat from `./gradlew spotlessApply`. This was a
  pre-existing google-java-format violation that was previously masked because Spotless could not
  execute on JDK 17 at all.

Verified locally on JDK 17: `./gradlew clean build` (compile + full test suite + spotlessCheck)
passes.

Out of scope (flagged for follow-up): bumping Spring Boot to 2.7.x / 3.x, Gradle to 7.6.x, and
adding a CI workflow.

Link to Devin session: https://app.devin.ai/sessions/2d592c6a0c5b4c8aa3239eff4c27a765
Requested by: @araza-cog
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->