### PR TITLE
Upgrade project from Java 11 to Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Upgrades the build toolchain target from Java 11 to Java 17. The runtime stack (Spring Boot 2.6.3, Gradle 7.4) already supports Java 17 and no `javax.*` → `jakarta.*` migration is needed (Spring Boot 2.x stays on `javax.*`).

Changes:
- `build.gradle`: `sourceCompatibility`/`targetCompatibility` `'11'` → `'17'`.
- `gradle.properties` (new): adds `org.gradle.jvmargs` with `--add-exports jdk.compiler/...=ALL-UNNAMED`. Required because Spotless' `googleJavaFormat` reflects into `jdk.compiler` internals, which the JDK 17 module system blocks — without it `:spotlessJava` fails with `IllegalAccessError: ... cannot access class com.sun.tools.javac.parser.Tokens$TokenKind ... module jdk.compiler does not export com.sun.tools.javac.parser`.
- `DefaultJwtServiceTest.java`: applies a one-line google-java-format wrap. This violation is **pre-existing on `master`** (fails `spotlessCheck` even under JDK 11; it slipped in because Gradle CI was removed), and it blocks `./gradlew clean build`, so it's fixed here to keep the build green.

## Verification
`./gradlew clean build` is green under `openjdk 17.0.13`: compiles + all **68 tests pass** (20 test classes, 0 failures).

Link to Devin session: https://app.devin.ai/sessions/ee5509b88e324cc6b1d394b8cfbba348
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/636?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->