### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
@@ -62,7 +62,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
     Assertions.assertTrue(optional.isPresent());
 
     ArticleData fetched = optional.get();
-    Assertions.assertEquals(fetched.getFavoritesCount(), 0);
+    Assertions.assertEquals(0, fetched.getFavoritesCount());
     Assertions.assertFalse(fetched.isFavorited());
     Assertions.assertNotNull(fetched.getCreatedAt());
     Assertions.assertNotNull(fetched.getUpdatedAt());

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Weekly SonarQube code quality sweep — fixes the top 5 open issues ranked by severity, type, effort, and recency from the `choikh0423_demo-spring-boot-test-coverage` SonarQube project.

### Issues Fixed

| # | SonarQube Key | Severity | Rule | File | Fix |
|---|--------------|----------|------|------|-----|
| 1 | `AZ1u3HBdEnUkF3fpjVtN` | CRITICAL | `java:S1948` | `InvalidRequestException.java:7` | Added `transient` to `Errors errors` field — `Errors` is not `Serializable`, so the field in this `RuntimeException` subclass must be marked transient |
| 2 | `AZ1u3HCaEnUkF3fpjVtj` | CRITICAL | `java:S1452` | `ArticleApi.java:36` | `ResponseEntity<?>` → `ResponseEntity<Map<String, Object>>` — removes generic wildcard from public API return type |
| 3 | `AZ1u3HCaEnUkF3fpjVtk` | CRITICAL | `java:S1452` | `ArticleApi.java:45` | Same wildcard fix for `updateArticle()` |
| 4 | `AZ1u3HBkEnUkF3fpjVtQ` | CRITICAL | `java:S1452` | `CommentsApi.java:41` | Same wildcard fix for `createComment()` |
| 5 | `AZ1u3HJJEnUkF3fpjVwb` | MAJOR | `java:S3415` | `ArticleQueryServiceTest.java:65` | Swapped `assertEquals(actual, expected)` → `assertEquals(expected, actual)` — JUnit 5 convention is `(expected, actual)` |

Also includes a spotless formatting fix in `DefaultJwtServiceTest.java` (line-wrapping applied by `spotlessApply`).

Link to Devin session: https://app.devin.ai/sessions/86b870f8d8ef43a9acdb97c208edb2be
Requested by: @choikh0423
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->