### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,34 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC_ZONE = TimeZone.getTimeZone("UTC");
+
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC_ZONE);
+  }
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar());
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar());
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }


### PR DESCRIPTION
## Summary

Weekly SonarQube code quality sweep fixing the top 5 open issues ranked by severity → type → effort → recency. All issues sourced from SonarQube project `choikh0423_demo-spring-boot-test-coverage`.

### Issues Fixed

| # | Key | Severity | Rule | File | Fix |
|---|-----|----------|------|------|-----|
| 1 | `AZ1u3HBdEnUkF3fpjVtN` | **CRITICAL** | `java:S1948` | `InvalidRequestException.java` | Made `errors` field `transient` — `Errors` is not `Serializable`, so the field must be excluded from serialization |
| 2 | `AZ1u3HBkEnUkF3fpjVtQ` | **CRITICAL** | `java:S1452` | `CommentsApi.java:41` | Replaced `ResponseEntity<?>` with `ResponseEntity<Map<String, Object>>` to remove generic wildcard |
| 3 | `AZ1u3HCaEnUkF3fpjVtj` | **CRITICAL** | `java:S1452` | `ArticleApi.java:36` | Same wildcard fix on `article()` method |
| 4 | `AZ1u3HCaEnUkF3fpjVtk` | **CRITICAL** | `java:S1452` | `ArticleApi.java:45` | Same wildcard fix on `updateArticle()` method |
| 5 | `AZ1u3HAmEnUkF3fpjVtC` | **MAJOR** | `java:S2885` | `DateTimeHandler.java:18` | Replaced shared `static Calendar` with a `utcCalendar()` factory method — `Calendar` is mutable and not thread-safe |

### Key Changes

```java
// S1948: InvalidRequestException — mark non-serializable field transient
- private final Errors errors;
+ private final transient Errors errors;

// S1452: CommentsApi, ArticleApi — explicit type parameter
- public ResponseEntity<?> createComment(...)
+ public ResponseEntity<Map<String, Object>> createComment(...)

// S2885: DateTimeHandler — per-call Calendar instead of shared static
- private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+ private static final TimeZone UTC_ZONE = TimeZone.getTimeZone("UTC");
+ private static Calendar utcCalendar() { return Calendar.getInstance(UTC_ZONE); }
```

**Note:** `./gradlew spotlessCheck` fails on master due to a pre-existing JDK module compatibility issue with google-java-format (unrelated to these changes). All tests pass.

Link to Devin session: https://app.devin.ai/sessions/4e6337631d0b4c0cb6d72259fbeb654d
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/654?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->