### PR TITLE
Fix Snyk vulnerabilities: upgrade Spring Boot 2.6.3 → 2.7.18 and patch transitive deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,26 @@
 plugins {
-    id 'org.springframework.boot' version '2.6.3'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.springframework.boot' version '2.7.18'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'java'
-    id "com.netflix.dgs.codegen" version "5.0.6"
+    id "com.netflix.dgs.codegen" version "5.6.2"
     id "com.diffplug.spotless" version "6.2.1"
 }
 
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
+
+// Override versions managed by the Spring Boot 2.7.18 BOM with the latest patched
+// releases that remain compatible with Spring Boot 2.7 / Java 11. This pulls in
+// security fixes for transitive dependencies without requiring a Spring Boot 3.x
+// (Jakarta EE) migration.
+ext['spring-framework.version'] = '5.3.39'
+ext['spring-security.version'] = '5.7.14'
+ext['tomcat.version'] = '9.0.119'
+ext['jackson-bom.version'] = '2.17.3'
+ext['snakeyaml.version'] = '2.6'
+ext['logback.version'] = '1.2.13'
+ext['commons-lang3.version'] = '3.18.0'
 
 spotless {
     java {
@@ -24,6 +36,15 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:5.6.2"
+    }
+    // Keep all rest-assured modules (including transitive rest-assured-common)
+    // on a single, patched version so they don't mix with the Spring Boot BOM default.
+    properties['rest-assured.version'] = '5.3.2'
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -35,25 +56,25 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
-    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.2'
+    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:5.6.2'
     implementation 'org.flywaydb:flyway-core'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
-                'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
+                'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'joda-time:joda-time:2.10.13'
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.45.3.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'io.rest-assured:rest-assured:4.5.1'
-    testImplementation 'io.rest-assured:json-path:4.5.1'
-    testImplementation 'io.rest-assured:xml-path:4.5.1'
-    testImplementation 'io.rest-assured:spring-mock-mvc:4.5.1'
+    testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'io.rest-assured:json-path'
+    testImplementation 'io.rest-assured:xml-path'
+    testImplementation 'io.rest-assured:spring-mock-mvc'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ ext['jackson-bom.version'] = '2.17.3'
 ext['snakeyaml.version'] = '2.6'
 ext['logback.version'] = '1.2.13'
 ext['commons-lang3.version'] = '3.18.0'
+// Keep all rest-assured modules (including transitive rest-assured-common) on a
+// single patched version instead of the 4.5.1 default from the Spring Boot BOM.
+ext['rest-assured.version'] = '5.3.2'
 
 spotless {
     java {
@@ -40,9 +43,6 @@ dependencyManagement {
     imports {
         mavenBom "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:5.6.2"
     }
-    // Keep all rest-assured modules (including transitive rest-assured-common)
-    // on a single, patched version so they don't mix with the Spring Boot BOM default.
-    properties['rest-assured.version'] = '5.3.2'
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ configurations {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.2'
     implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:5.6.2'

--- a/src/main/java/io/spring/api/security/WebSecurityConfig.java
+++ b/src/main/java/io/spring/api/security/WebSecurityConfig.java
@@ -35,6 +35,17 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
   @Override
   protected void configure(HttpSecurity http) throws Exception {
 
+    // CSRF protection is intentionally disabled.
+    //
+    // This API is fully stateless and authenticates every request with a JWT bearer
+    // token carried in the "Authorization" header (see JwtTokenFilter), never with a
+    // session cookie. Session creation is STATELESS and CORS is configured with
+    // allowCredentials=false, so the browser never attaches ambient credentials
+    // (cookies) to cross-site requests. CSRF attacks rely on such ambient credentials
+    // being sent automatically; because authentication requires a token that an
+    // attacker's site cannot read or forge, CSRF is not applicable here. Enabling CSRF
+    // (e.g. CookieCsrfTokenRepository) would add a cookie/token exchange that this
+    // token-based model does not use and would break the stateless API contract.
     http.csrf()
         .disable()
         .cors()

--- a/src/main/java/io/spring/api/security/WebSecurityConfig.java
+++ b/src/main/java/io/spring/api/security/WebSecurityConfig.java
@@ -80,9 +80,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     final CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOrigins(asList("*"));
     configuration.setAllowedMethods(asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
-    // setAllowCredentials(true) is important, otherwise:
-    // The value of the 'Access-Control-Allow-Origin' header in the response must not be the
-    // wildcard '*' when the request's credentials mode is 'include'.
+    // Credentials are intentionally disabled: this is a stateless, token-based API, so the
+    // browser must never send ambient cookies cross-site. Keeping this false also lets the
+    // wildcard "*" origin remain valid (a wildcard origin is forbidden when credentials are
+    // included). Do not set this to true while the allowed origin is "*".
     configuration.setAllowCredentials(false);
     // setAllowedHeaders is important! Without it, OPTIONS preflight request
     // will fail with 403 Invalid CORS request

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Remediates the security findings from the Snyk scan. The root cause was the EOL **Spring Boot 2.6.3** managing vulnerable transitive dependencies. This stays on the latest **2.7.x** line (avoids the invasive Jakarta EE / Spring Boot 3 migration) and additionally pins the latest patched releases of BOM-managed libraries that are still compatible with Spring Boot 2.7 / Java 11.

No application code logic changed. The CSRF finding is addressed with a documented justification (see below). All tests pass, Spotless is clean, and the app still boots and serves both REST (`/tags`) and GraphQL (`/graphql`).

### 1. CSRF (HIGH, first-party) — `WebSecurityConfig.java`

Kept `.csrf().disable()` **with a documented justification** rather than enabling a `CookieCsrfTokenRepository`. Rationale (added as a code comment): the API is fully stateless, authenticates every request via a **JWT bearer token in the `Authorization` header** (`JwtTokenFilter`), uses `SessionCreationPolicy.STATELESS`, and CORS is configured with `allowCredentials=false`. No session/cookie ambient credentials are ever sent, so CSRF is not applicable; enabling a cookie-based CSRF token would contradict the stateless token model and break the existing auth/tests. Also fixed a stale CORS comment that incorrectly said `setAllowCredentials(true) is important`.

### 2. Dependency vulnerabilities (SCA)

`build.gradle` version bumps:

```diff
- id 'org.springframework.boot' version '2.6.3'
- id 'io.spring.dependency-management' version '1.0.11.RELEASE'
- id "com.netflix.dgs.codegen" version "5.0.6"
+ id 'org.springframework.boot' version '2.7.18'
+ id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+ id "com.netflix.dgs.codegen" version "5.6.2"

  // graphql-dgs-spring-boot-starter 4.9.21 -> 5.6.2 (graphql-java 17.3 -> 19.11)
  // + import graphql-dgs-platform-dependencies:5.6.2 BOM to align graphql-java/federation
  // mybatis-spring-boot-starter(-test) 2.2.2 -> 2.3.2
  // jjwt 0.11.2 -> 0.11.5
  // sqlite-jdbc 3.36.0.3 -> 3.45.3.0
- // removed unused spring-boot-starter-hateoas (no source references; dropped 2 high vulns)
```

Patched versions pinned over the Spring Boot 2.7.18 BOM (latest still-compatible with 2.7 / Java 11), via project-level `ext[...]` overrides:

```
spring-framework  5.3.31 -> 5.3.39
spring-security   5.7.11 -> 5.7.14
tomcat            9.0.83 -> 9.0.119
jackson-bom       2.13.5 -> 2.17.3
snakeyaml         1.30   -> 2.6
logback           1.2.11 -> 1.2.13
commons-lang3     3.12.0 -> 3.18.0   (transitive via rest-assured)
rest-assured      4.5.1  -> 5.3.2    (test scope)
```

Notes:
- DGS 5.6.2 (not 8.x) is the newest line that still supports Spring Boot 2.7 / Java 11; importing `graphql-dgs-platform-dependencies` was required so federation support doesn't downgrade `graphql-java` back to a vulnerable 18.x.
- `jackson-bom` is held at 2.17.3 because 2.18/2.19 break DGS 5.6.2's pinned `jackson-module-kotlin` (`NoClassDefFoundError` on `KotlinModule`).
- `spring-boot-starter-hateoas` had no references anywhere in `src/` and pulled in 2 high-severity advisories on the 2.7-managed `spring-hateoas` 1.5.6, so it was removed.
- All `ext[...]` overrides use the project-level form, which is the mechanism the `io.spring.dependency-management` plugin honors (the `properties[...]`-inside-`dependencyManagement` form is a no-op).

### Snyk before / after (`npx snyk test --all-projects`)

| Severity | Before | After |
|----------|-------:|------:|
| Critical | 23 | 7 |
| High | 100 | 43 |
| Medium | 94 | 37 |
| Low | 36 | 21 |
| **Total issues** | **145** | **55** |
| Vulnerable paths | 471 | 229 |

This PR introduces **zero new vulnerability IDs** relative to `master` — every remaining finding already existed on the base branch (verified by diffing the Snyk vuln IDs of both scans).

### Remaining vulnerabilities (not fixable without a Spring Boot 3.x migration)

The remaining critical/high findings are in the Spring Boot 2.7 / Spring Framework 5.3 / Spring Security 5.7 core and `jackson-databind`, fixed only in releases that require Spring Boot 3.x (Spring Framework 6 / Security 6 / Jakarta EE):
- `spring-boot-autoconfigure` 2.7.18, `spring-core`/`spring-web`/`spring-webmvc`/`spring-beans`/`spring-expression` 5.3.39 — 5.3.x is the terminal line; fixes are in 6.x.
- `spring-security-web`/`spring-security-crypto` 5.7.14 — 5.7.x is terminal; tested bumping to 5.8.16 but it cleared none of these and was reverted to keep the BOM-aligned line.
- `jackson-databind`/`jackson-core` 2.17.3 — see DGS Kotlin-module note above.

Per the task constraints, the Spring Boot 3.x migration was judged too invasive for this change and is left as documented follow-up. The `security/snyk` PR check therefore stays red on these threshold-exceeding findings (it is red on `master` as well, which has strictly more issues); this PR does not introduce any new ones.

## Verification

- `./gradlew compileJava` — BUILD SUCCESSFUL
- `./gradlew test` — BUILD SUCCESSFUL (all tests pass)
- `./gradlew spotlessCheck` — BUILD SUCCESSFUL
- `./gradlew bootRun` then requests succeed:

```
 :: Spring Boot ::               (v2.7.18)
Tomcat started on port(s): 8080 (http) with context path ''
Started RealWorldApplication in ~1.6 seconds

$ curl -i http://localhost:8080/tags   ->  HTTP/1.1 200   {"tags":[]}
$ curl -X POST /graphql -d '{"query":"{ tags }"}'  ->  {"data":{"tags":[]}}
```


Link to Devin session: https://app.devin.ai/sessions/1165df526fee486fbb3d91e1fe75d9ff
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/731?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->