### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,30 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private final Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar);
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar);
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar);
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar);
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,32 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private final Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar);
+        i,
+        parameter != null ? new Timestamp(parameter.getMillis()) : null,
+        Calendar.getInstance(UTC));
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar);
+    Timestamp timestamp = rs.getTimestamp(columnName, Calendar.getInstance(UTC));
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, Calendar.getInstance(UTC));
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar);
+    Timestamp ts = cs.getTimestamp(columnIndex, Calendar.getInstance(UTC));
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Weekly SonarQube sweep for `choikh0423_demo-spring-boot-test-coverage` (the SonarQube project analyzing this repo). Ranked the 265 open issues by severity → type → effort → recency and fixed the top 5. No BLOCKER-severity or VULNERABILITY/SECURITY_HOTSPOT issues exist; the highest tier is CRITICAL, then MAJOR.

### Issues fixed
| # | Key | Rule | Severity | Type | Location | Fix |
|---|-----|------|----------|------|----------|-----|
| 1 | `AZ1u3HBdEnUkF3fpjVtN` | java:S1948 | CRITICAL | BUG | `InvalidRequestException.java:7` | Field `Errors errors` is non-serializable in a `Serializable` exception → marked `transient` |
| 2 | `AZ1u3HCaEnUkF3fpjVtj` | java:S1452 | CRITICAL | CODE_SMELL | `ArticleApi.java:36` | `ResponseEntity<?>` → `ResponseEntity<Map<String, Object>>` (`article`) |
| 3 | `AZ1u3HCaEnUkF3fpjVtk` | java:S1452 | CRITICAL | CODE_SMELL | `ArticleApi.java:45` | `ResponseEntity<?>` → `ResponseEntity<Map<String, Object>>` (`updateArticle`) |
| 4 | `AZ1u3HBkEnUkF3fpjVtQ` | java:S1452 | CRITICAL | CODE_SMELL | `CommentsApi.java:41` | `ResponseEntity<?>` → `ResponseEntity<Map<String, Object>>` (`createComment`) |
| 5 | `AZ1u3HAmEnUkF3fpjVtC` | java:S2885 | MAJOR | BUG | `DateTimeHandler.java:18` | Non-thread-safe `static Calendar` → instance field (also renamed `UTC_CALENDAR` → `utcCalendar` for camelCase to avoid a new S116 smell) |

### Ranking rationale
- All 4 CRITICAL issues selected first. Within CRITICAL, the S1948 BUG outranks the three S1452 CODE_SMELLs; among the S1452s, `ArticleApi` (2021-03-16) is more recent than `CommentsApi` (2021-03-03).
- 5th slot drops to MAJOR; the S2885 BUG outranks the MAJOR CODE_SMELLs (S6813 field injection, S3415 assertion order).

### Pseudo-diff
```java
// InvalidRequestException
- private final Errors errors;
+ private final transient Errors errors;

// ArticleApi / CommentsApi
- public ResponseEntity<?> article(...) {
+ public ResponseEntity<Map<String, Object>> article(...) {

// DateTimeHandler
- private static final Calendar UTC_CALENDAR = Calendar.getInstance(...);
+ private final Calendar utcCalendar = Calendar.getInstance(...);
```

## Notes
- `DefaultJwtServiceTest.java` has a one-line `spotlessApply` reformat — a **preexisting** formatting violation unrelated to these fixes. It's included only because `spotlessCheck` is repo-wide and would otherwise fail on it.
- Verified with Java 11 (project's `sourceCompatibility`): `./gradlew spotlessCheck` and `./gradlew test` both pass. Note: spotless fails under Java 17 due to google-java-format 1.13.0 incompatibility (environment, not this change).

Link to Devin session: https://app.devin.ai/sessions/010d46d491da465ba0756bad814dec6c
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/733?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->