### PR TITLE
test: add JaCoCo coverage reporting and unit tests for core/application layers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -58,6 +59,23 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['io/spring/graphql/types/**', 'io/spring/graphql/DgsConstants*', 'io/spring/graphql/client/**'])
+        }))
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/application/CursorPagerTest.java
+++ b/src/test/java/io/spring/application/CursorPagerTest.java
@@ -1,0 +1,99 @@
+package io.spring.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.spring.application.CursorPager.Direction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+public class CursorPagerTest {
+
+  private static class FakeNode implements Node {
+    private final DateTime at;
+
+    FakeNode(long millis) {
+      this.at = new DateTime(millis, DateTimeZone.UTC);
+    }
+
+    @Override
+    public PageCursor getCursor() {
+      return new DateTimeCursor(at);
+    }
+  }
+
+  @Test
+  public void next_direction_should_report_next_when_extra() {
+    CursorPager<FakeNode> pager =
+        new CursorPager<>(Collections.singletonList(new FakeNode(1000)), Direction.NEXT, true);
+
+    assertTrue(pager.hasNext());
+    assertFalse(pager.hasPrevious());
+  }
+
+  @Test
+  public void prev_direction_should_report_previous_when_extra() {
+    CursorPager<FakeNode> pager =
+        new CursorPager<>(Collections.singletonList(new FakeNode(1000)), Direction.PREV, true);
+
+    assertFalse(pager.hasNext());
+    assertTrue(pager.hasPrevious());
+  }
+
+  @Test
+  public void cursors_should_be_null_for_empty_data() {
+    CursorPager<FakeNode> pager =
+        new CursorPager<>(Collections.emptyList(), Direction.NEXT, false);
+
+    assertNull(pager.getStartCursor());
+    assertNull(pager.getEndCursor());
+    assertFalse(pager.hasNext());
+  }
+
+  @Test
+  public void cursors_should_come_from_first_and_last_elements() {
+    List<FakeNode> data = Arrays.asList(new FakeNode(1000), new FakeNode(2000));
+    CursorPager<FakeNode> pager = new CursorPager<>(data, Direction.NEXT, false);
+
+    assertEquals("1000", pager.getStartCursor().toString());
+    assertEquals("2000", pager.getEndCursor().toString());
+  }
+
+  @Test
+  public void datetime_cursor_should_parse_millis() {
+    DateTime parsed = DateTimeCursor.parse("5000");
+    assertEquals(5000, parsed.getMillis());
+    assertNull(DateTimeCursor.parse(null));
+  }
+
+  @Test
+  public void cursor_page_parameter_should_clamp_limit() {
+    CursorPageParameter<DateTime> param =
+        new CursorPageParameter<>(null, 5000, Direction.NEXT);
+    assertEquals(1000, param.getLimit());
+    assertEquals(1001, param.getQueryLimit());
+    assertTrue(param.isNext());
+
+    CursorPageParameter<DateTime> defaulted =
+        new CursorPageParameter<>(null, -1, Direction.PREV);
+    assertEquals(20, defaulted.getLimit());
+    assertFalse(defaulted.isNext());
+  }
+
+  @Test
+  public void page_should_clamp_offset_and_limit() {
+    Page page = new Page(-5, 500);
+    assertEquals(0, page.getOffset());
+    assertEquals(100, page.getLimit());
+
+    Page normal = new Page(10, 30);
+    assertEquals(10, normal.getOffset());
+    assertEquals(30, normal.getLimit());
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,61 @@
+package io.spring.application.article;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ArticleCommandServiceTest {
+
+  private ArticleRepository articleRepository;
+  private ArticleCommandService articleCommandService;
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    articleRepository = mock(ArticleRepository.class);
+    articleCommandService = new ArticleCommandService(articleRepository);
+    user = new User("jane@example.com", "jane", "secret", "", "");
+  }
+
+  @Test
+  public void should_create_article_and_save() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("How To Test")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "testing"))
+            .build();
+
+    Article article = articleCommandService.createArticle(param, user);
+
+    assertEquals("How To Test", article.getTitle());
+    assertEquals("how-to-test", article.getSlug());
+    assertEquals(user.getId(), article.getUserId());
+    assertEquals(2, article.getTags().size());
+    verify(articleRepository).save(any(Article.class));
+  }
+
+  @Test
+  public void should_update_article_and_save() {
+    Article article =
+        new Article("Old Title", "old desc", "old body", Arrays.asList("tag"), user.getId());
+    UpdateArticleParam param = new UpdateArticleParam("New Title", "new body", "new desc");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertEquals("New Title", updated.getTitle());
+    assertEquals("new-title", updated.getSlug());
+    assertEquals("new desc", updated.getDescription());
+    assertEquals("new body", updated.getBody());
+    verify(articleRepository).save(article);
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,54 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class UserServiceTest {
+
+  private UserRepository userRepository;
+  private PasswordEncoder passwordEncoder;
+  private UserService userService;
+
+  @BeforeEach
+  public void setUp() {
+    userRepository = mock(UserRepository.class);
+    passwordEncoder = mock(PasswordEncoder.class);
+    userService = new UserService(userRepository, "default.png", passwordEncoder);
+  }
+
+  @Test
+  public void should_create_user_with_encoded_password_and_default_image() {
+    when(passwordEncoder.encode("secret")).thenReturn("encoded");
+    RegisterParam param = new RegisterParam("jane@example.com", "jane", "secret");
+
+    User user = userService.createUser(param);
+
+    assertEquals("jane@example.com", user.getEmail());
+    assertEquals("jane", user.getUsername());
+    assertEquals("encoded", user.getPassword());
+    assertEquals("default.png", user.getImage());
+    verify(userRepository).save(any(User.class));
+  }
+
+  @Test
+  public void should_update_target_user_and_save() {
+    User target = new User("old@example.com", "old", "pw", "bio", "img");
+    UpdateUserParam param =
+        UpdateUserParam.builder().email("new@example.com").username("new").build();
+
+    userService.updateUser(new UpdateUserCommand(target, param));
+
+    assertEquals("new@example.com", target.getEmail());
+    assertEquals("new", target.getUsername());
+    verify(userRepository).save(target);
+  }
+}

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -1,0 +1,64 @@
+package io.spring.core.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("jane@example.com", "jane", "secret", "bio", "image.png");
+  }
+
+  @Test
+  public void should_expose_constructor_values() {
+    assertNotNull(user.getId());
+    assertEquals("jane@example.com", user.getEmail());
+    assertEquals("jane", user.getUsername());
+    assertEquals("secret", user.getPassword());
+    assertEquals("bio", user.getBio());
+    assertEquals("image.png", user.getImage());
+  }
+
+  @Test
+  public void should_update_only_non_empty_fields() {
+    user.update("new@example.com", "", null, "new bio", "");
+
+    assertEquals("new@example.com", user.getEmail());
+    assertEquals("jane", user.getUsername());
+    assertEquals("secret", user.getPassword());
+    assertEquals("new bio", user.getBio());
+    assertEquals("image.png", user.getImage());
+  }
+
+  @Test
+  public void should_update_all_fields_when_present() {
+    user.update("a@b.c", "amy", "pw2", "b2", "img2");
+
+    assertEquals("a@b.c", user.getEmail());
+    assertEquals("amy", user.getUsername());
+    assertEquals("pw2", user.getPassword());
+    assertEquals("b2", user.getBio());
+    assertEquals("img2", user.getImage());
+  }
+
+  @Test
+  public void equality_should_be_based_on_id() {
+    User other = new User("jane@example.com", "jane", "secret", "bio", "image.png");
+    assertNotEquals(user, other);
+    assertEquals(user, user);
+  }
+
+  @Test
+  public void follow_relation_should_hold_ids() {
+    FollowRelation relation = new FollowRelation("u1", "u2");
+    assertEquals("u1", relation.getUserId());
+    assertEquals("u2", relation.getTargetId());
+  }
+}


### PR DESCRIPTION
## Summary
Adds JaCoCo coverage reporting and pure unit tests for previously untested core/application classes; overall instruction coverage 46%→50%.

- `build.gradle`: applies `jacoco` (0.8.8, XML+HTML reports, `test.finalizedBy jacocoTestReport`) and excludes DGS-generated classes (`io/spring/graphql/types/**`, `DgsConstants*`, `graphql/client/**`) from reports
- New tests (JUnit 5 + Mockito, no Spring context):
  - `UserTest` — `User.update` empty-field skipping, id-based equality, `FollowRelation`
  - `CursorPagerTest` — `CursorPager` NEXT/PREV/empty behavior, `DateTimeCursor.parse`, `CursorPageParameter`/`Page` limit clamping
  - `ArticleCommandServiceTest` — create/update with mocked `ArticleRepository`, slug regeneration
  - `UserServiceTest` — password encoding + default image on create, update delegation with mocked `UserRepository`/`PasswordEncoder`

All tests pass locally via `./gradlew test`.

Link to Devin session: https://app.devin.ai/sessions/6470b9f1515a4129aba016e3724bceaa
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/750?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->