### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,30 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private final Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar);
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar);
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar);
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar);
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Weekly SonarQube sweep for the project (`choikh0423_demo-spring-boot-test-coverage`). Ranked all open issues by severity → type → effort → recency and fixed the top 5. The four CRITICAL issues plus the single MAJOR **BUG** were selected (all remaining MAJOR issues are CODE_SMELLs, so the bug outranks them).

`./gradlew spotlessCheck` and `./gradlew test` both pass.

### Issues fixed

| # | Key | Severity | Type | Rule | File | Fix |
|---|-----|----------|------|------|------|-----|
| 1 | `AZ1u3HCaEnUkF3fpjVtj` | CRITICAL | CODE_SMELL | java:S1452 | `ArticleApi.java:36` | Wildcard return type removed |
| 2 | `AZ1u3HCaEnUkF3fpjVtk` | CRITICAL | CODE_SMELL | java:S1452 | `ArticleApi.java:45` | Wildcard return type removed |
| 3 | `AZ1u3HBkEnUkF3fpjVtQ` | CRITICAL | CODE_SMELL | java:S1452 | `CommentsApi.java:41` | Wildcard return type removed |
| 4 | `AZ1u3HBdEnUkF3fpjVtN` | CRITICAL | CODE_SMELL | java:S1948 | `InvalidRequestException.java:7` | Non-serializable field made `transient` |
| 5 | `AZ1u3HAmEnUkF3fpjVtC` | MAJOR | BUG | java:S2885 | `DateTimeHandler.java:18` | Non-thread-safe static field made instance field |

### Details

**S1452 – Generic wildcard types should not be used in return types** (ArticleApi, CommentsApi)
These handlers already build a `Map<String, Object>` body, so the wildcard was unnecessary:
```diff
- public ResponseEntity<?> article(...)          -> public ResponseEntity<Map<String, Object>> article(...)
- public ResponseEntity<?> updateArticle(...)    -> public ResponseEntity<Map<String, Object>> updateArticle(...)
- public ResponseEntity<?> createComment(...)    -> public ResponseEntity<Map<String, Object>> createComment(...)
```

**S1948 – Fields in a Serializable class should be transient or serializable** (`InvalidRequestException`)
`Errors` is a Spring interface that isn't `Serializable`, and the exception extends `RuntimeException` (Serializable):
```diff
- private final Errors errors;
+ private final transient Errors errors;
```

**S2885 – Non-thread-safe fields should not be static** (`DateTimeHandler`) — the only MAJOR bug
`java.util.Calendar` is not thread-safe; sharing one static instance across threads risks data races. Made it a per-instance field (and renamed to camelCase to satisfy field-naming conventions):
```diff
- private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+ private final Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
```

### Note
`spotlessApply` also reformatted one line in `DefaultJwtServiceTest.java` — a **pre-existing** formatting violation unrelated to these fixes, required for `spotlessCheck` to pass.


Link to Devin session: https://app.devin.ai/sessions/7ea9761535c04963b139f0927c4c92ea
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/768?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->