### PR TITLE
Add JaCoCo coverage + safe JUnit 5 parallel test execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ jacocoTestReport {
     }
 }
 
+// Non-blocking scaffold: raise `minimum` (and wire into `check`) to enforce a
+// coverage floor once the suite's coverage has been ratcheted up.
 jacocoTestCoverageVerification {
     violationRules {
         rule {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -56,8 +57,31 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.0
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/RealworldApplicationTests.java
+++ b/src/test/java/io/spring/RealworldApplicationTests.java
@@ -1,9 +1,15 @@
 package io.spring;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public class RealworldApplicationTests {
 
   @Test

--- a/src/test/java/io/spring/api/TestWithCurrentUser.java
+++ b/src/test/java/io/spring/api/TestWithCurrentUser.java
@@ -10,8 +10,11 @@ import io.spring.core.user.UserRepository;
 import io.spring.infrastructure.mybatis.readservice.UserReadService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 abstract class TestWithCurrentUser {
   @MockBean protected UserRepository userRepository;
 

--- a/src/test/java/io/spring/api/UsersApiTest.java
+++ b/src/test/java/io/spring/api/UsersApiTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,6 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
   BCryptPasswordEncoder.class,
   JacksonCustomizations.class
 })
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 public class UsersApiTest {
   @Autowired private MockMvc mvc;
 

--- a/src/test/java/io/spring/infrastructure/DbTestBase.java
+++ b/src/test/java/io/spring/infrastructure/DbTestBase.java
@@ -1,5 +1,9 @@
 package io.spring.infrastructure;
 
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
@@ -8,4 +12,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @MybatisTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public abstract class DbTestBase {}

--- a/src/test/java/io/spring/infrastructure/article/ArticleRepositoryTransactionTest.java
+++ b/src/test/java/io/spring/infrastructure/article/ArticleRepositoryTransactionTest.java
@@ -8,6 +8,10 @@ import io.spring.infrastructure.mybatis.mapper.ArticleMapper;
 import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +20,8 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public class ArticleRepositoryTransactionTest {
   @Autowired private ArticleRepository articleRepository;
 

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
Adds coverage measurement (JaCoCo) and enables JUnit 5 parallel test execution, keeping stateful tests serialized so the suite stays green.

**Coverage tooling** (`build.gradle`): added the `jacoco` plugin, wired `test` to `finalizedBy jacocoTestReport`, enabled XML + HTML reports (`build/reports/jacoco/test/`), and added a (currently non-blocking, `minimum = 0.0`) `jacocoTestCoverageVerification` rule as a hook for a future threshold. Baseline coverage measured: **33.3% instructions / 34.1% lines**.

**Parallel execution** (`src/test/resources/junit-platform.properties`):
```
parallel.enabled=true
parallel.mode.default=same_thread        # methods within a class: serial
parallel.mode.classes.default=concurrent # classes: run in parallel
```

**Serialization of stateful tests** — two shared, non-thread-safe resources would break under naive concurrency, so each is guarded by a JUnit `@ResourceLock` (classes holding the same lock never run simultaneously, but still overlap with everything else):
- `"DB"` — the SQLite `./dev.db` file is shared by all DB integration tests. Lock + `@Execution(SAME_THREAD)` added to `DbTestBase` (inherited by all MyBatis/query-service tests) and to the `@SpringBootTest` `RealworldApplicationTests`.
- `"MOCKMVC"` — `RestAssuredMockMvc.mockMvc(...)` stores the `MockMvc` in a **global static**, so concurrent `@WebMvcTest` classes stomp each other's config (verified: 13 spurious assertion failures without this). Lock added on the `TestWithCurrentUser` base (covers 7 api tests) and on `UsersApiTest` (which doesn't extend it).

The two lock groups use different resource names, so DB tests, api (MockMvc) tests, and pure unit tests still run concurrently with one another.

Verified: `./gradlew clean test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` runs green (68 tests) and produces the coverage report. (Spotless is excluded per the repo's documented JDK17 incompatibility.)

This is the first of several PRs; follow-ups add GraphQL, `TagsApi`, core-domain, and command-service tests to close the coverage gaps.


Link to Devin session: https://app.devin.ai/sessions/bd6793344e1f45b4ac7d59a29b5a99dd
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/785?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->