### PR TITLE
Add pure JUnit unit tests for io.spring.core domain types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -56,8 +57,31 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.0
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/RealworldApplicationTests.java
+++ b/src/test/java/io/spring/RealworldApplicationTests.java
@@ -1,9 +1,15 @@
 package io.spring;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public class RealworldApplicationTests {
 
   @Test

--- a/src/test/java/io/spring/api/TestWithCurrentUser.java
+++ b/src/test/java/io/spring/api/TestWithCurrentUser.java
@@ -10,8 +10,11 @@ import io.spring.core.user.UserRepository;
 import io.spring.infrastructure.mybatis.readservice.UserReadService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 abstract class TestWithCurrentUser {
   @MockBean protected UserRepository userRepository;
 

--- a/src/test/java/io/spring/api/UsersApiTest.java
+++ b/src/test/java/io/spring/api/UsersApiTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,6 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
   BCryptPasswordEncoder.class,
   JacksonCustomizations.class
 })
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 public class UsersApiTest {
   @Autowired private MockMvc mvc;
 

--- a/src/test/java/io/spring/core/article/TagTest.java
+++ b/src/test/java/io/spring/core/article/TagTest.java
@@ -1,0 +1,58 @@
+package io.spring.core.article;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class TagTest {
+
+  @Test
+  public void should_set_name_and_generate_uuid_id_in_constructor() {
+    Tag tag = new Tag("java");
+
+    assertEquals("java", tag.getName());
+    assertNotNull(tag.getId());
+    assertEquals(tag.getId(), UUID.fromString(tag.getId()).toString());
+  }
+
+  @Test
+  public void should_expose_setters_from_data_annotation() {
+    Tag tag = new Tag();
+    tag.setId("id-1");
+    tag.setName("spring");
+
+    assertEquals("id-1", tag.getId());
+    assertEquals("spring", tag.getName());
+  }
+
+  @Test
+  public void should_be_equal_and_share_hashcode_when_names_are_equal() {
+    Tag first = new Tag("java");
+    Tag second = new Tag("java");
+
+    assertNotEquals(first.getId(), second.getId());
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_names_differ() {
+    Tag first = new Tag("java");
+    Tag second = new Tag("spring");
+
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    Tag tag = new Tag("java");
+
+    assertNotEquals(tag, null);
+    assertNotEquals(tag, "a string");
+    assertTrue(tag.equals(tag));
+  }
+}

--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -1,0 +1,69 @@
+package io.spring.core.comment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+
+  private static void setId(Comment comment, String id) throws Exception {
+    Field field = Comment.class.getDeclaredField("id");
+    field.setAccessible(true);
+    field.set(comment, id);
+  }
+
+  @Test
+  public void should_set_all_fields_and_generate_uuid_id_in_constructor() {
+    Comment comment = new Comment("nice article", "user-1", "article-1");
+
+    assertEquals("nice article", comment.getBody());
+    assertEquals("user-1", comment.getUserId());
+    assertEquals("article-1", comment.getArticleId());
+    assertNotNull(comment.getCreatedAt());
+    assertNotNull(comment.getId());
+    assertEquals(comment.getId(), UUID.fromString(comment.getId()).toString());
+  }
+
+  @Test
+  public void should_generate_distinct_ids_for_distinct_comments() {
+    Comment first = new Comment("body", "user-1", "article-1");
+    Comment second = new Comment("body", "user-1", "article-1");
+
+    assertNotEquals(first.getId(), second.getId());
+  }
+
+  @Test
+  public void should_be_equal_and_share_hashcode_when_ids_are_equal() throws Exception {
+    Comment first = new Comment("body-a", "user-a", "article-a");
+    Comment second = new Comment("body-b", "user-b", "article-b");
+    setId(first, "same-id");
+    setId(second, "same-id");
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_differ() throws Exception {
+    Comment first = new Comment("body", "user-1", "article-1");
+    Comment second = new Comment("body", "user-1", "article-1");
+    setId(first, "id-1");
+    setId(second, "id-2");
+
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    Comment comment = new Comment("body", "user-1", "article-1");
+
+    assertNotEquals(comment, null);
+    assertNotEquals(comment, "a string");
+    assertTrue(comment.equals(comment));
+  }
+}

--- a/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
+++ b/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
@@ -1,0 +1,44 @@
+package io.spring.core.favorite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ArticleFavoriteTest {
+
+  @Test
+  public void should_set_all_fields_in_constructor() {
+    ArticleFavorite favorite = new ArticleFavorite("article-1", "user-1");
+
+    assertEquals("article-1", favorite.getArticleId());
+    assertEquals("user-1", favorite.getUserId());
+  }
+
+  @Test
+  public void should_be_equal_and_share_hashcode_when_all_fields_are_equal() {
+    ArticleFavorite first = new ArticleFavorite("article-1", "user-1");
+    ArticleFavorite second = new ArticleFavorite("article-1", "user-1");
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_any_field_differs() {
+    ArticleFavorite base = new ArticleFavorite("article-1", "user-1");
+
+    assertNotEquals(base, new ArticleFavorite("article-2", "user-1"));
+    assertNotEquals(base, new ArticleFavorite("article-1", "user-2"));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    ArticleFavorite favorite = new ArticleFavorite("article-1", "user-1");
+
+    assertNotEquals(favorite, null);
+    assertNotEquals(favorite, "a string");
+    assertTrue(favorite.equals(favorite));
+  }
+}

--- a/src/test/java/io/spring/core/user/FollowRelationTest.java
+++ b/src/test/java/io/spring/core/user/FollowRelationTest.java
@@ -1,0 +1,54 @@
+package io.spring.core.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class FollowRelationTest {
+
+  @Test
+  public void should_set_all_fields_in_constructor() {
+    FollowRelation relation = new FollowRelation("user-1", "target-1");
+
+    assertEquals("user-1", relation.getUserId());
+    assertEquals("target-1", relation.getTargetId());
+  }
+
+  @Test
+  public void should_expose_setters_from_data_annotation() {
+    FollowRelation relation = new FollowRelation();
+    relation.setUserId("user-2");
+    relation.setTargetId("target-2");
+
+    assertEquals("user-2", relation.getUserId());
+    assertEquals("target-2", relation.getTargetId());
+  }
+
+  @Test
+  public void should_be_equal_and_share_hashcode_when_all_fields_are_equal() {
+    FollowRelation first = new FollowRelation("user-1", "target-1");
+    FollowRelation second = new FollowRelation("user-1", "target-1");
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_any_field_differs() {
+    FollowRelation base = new FollowRelation("user-1", "target-1");
+
+    assertNotEquals(base, new FollowRelation("user-2", "target-1"));
+    assertNotEquals(base, new FollowRelation("user-1", "target-2"));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    FollowRelation relation = new FollowRelation("user-1", "target-1");
+
+    assertNotEquals(relation, null);
+    assertNotEquals(relation, "a string");
+    assertTrue(relation.equals(relation));
+  }
+}

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -1,0 +1,109 @@
+package io.spring.core.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+  private static void setId(User user, String id) throws Exception {
+    Field field = User.class.getDeclaredField("id");
+    field.setAccessible(true);
+    field.set(user, id);
+  }
+
+  @Test
+  public void should_set_all_fields_and_generate_uuid_id_in_constructor() {
+    User user = new User("jake@jake.jake", "jake", "secret", "I work at statefarm", "image-url");
+
+    assertEquals("jake@jake.jake", user.getEmail());
+    assertEquals("jake", user.getUsername());
+    assertEquals("secret", user.getPassword());
+    assertEquals("I work at statefarm", user.getBio());
+    assertEquals("image-url", user.getImage());
+    assertNotNull(user.getId());
+    assertEquals(user.getId(), UUID.fromString(user.getId()).toString());
+  }
+
+  @Test
+  public void should_generate_distinct_ids_for_distinct_users() {
+    User first = new User("a@a.com", "a", "p", "", "");
+    User second = new User("b@b.com", "b", "p", "", "");
+
+    assertNotEquals(first.getId(), second.getId());
+  }
+
+  @Test
+  public void should_update_all_fields_when_values_are_not_empty() {
+    User user = new User("old@mail.com", "old", "oldpass", "old bio", "old image");
+
+    user.update("new@mail.com", "new", "newpass", "new bio", "new image");
+
+    assertEquals("new@mail.com", user.getEmail());
+    assertEquals("new", user.getUsername());
+    assertEquals("newpass", user.getPassword());
+    assertEquals("new bio", user.getBio());
+    assertEquals("new image", user.getImage());
+  }
+
+  @Test
+  public void should_keep_existing_values_when_update_values_are_empty_or_null() {
+    User user = new User("old@mail.com", "old", "oldpass", "old bio", "old image");
+
+    user.update("", null, "", null, "");
+
+    assertEquals("old@mail.com", user.getEmail());
+    assertEquals("old", user.getUsername());
+    assertEquals("oldpass", user.getPassword());
+    assertEquals("old bio", user.getBio());
+    assertEquals("old image", user.getImage());
+  }
+
+  @Test
+  public void should_only_update_provided_fields() {
+    User user = new User("old@mail.com", "old", "oldpass", "old bio", "old image");
+
+    user.update("new@mail.com", "", null, "new bio", "");
+
+    assertEquals("new@mail.com", user.getEmail());
+    assertEquals("old", user.getUsername());
+    assertEquals("oldpass", user.getPassword());
+    assertEquals("new bio", user.getBio());
+    assertEquals("old image", user.getImage());
+  }
+
+  @Test
+  public void should_be_equal_and_share_hashcode_when_ids_are_equal() throws Exception {
+    User first = new User("a@a.com", "a", "p", "", "");
+    User second = new User("b@b.com", "b", "p", "", "");
+    setId(first, "same-id");
+    setId(second, "same-id");
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_differ() throws Exception {
+    User first = new User("a@a.com", "a", "p", "", "");
+    User second = new User("a@a.com", "a", "p", "", "");
+    setId(first, "id-1");
+    setId(second, "id-2");
+
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    User user = new User("a@a.com", "a", "p", "", "");
+
+    assertNotEquals(user, null);
+    assertNotEquals(user, "a string");
+    assertTrue(user.equals(user));
+  }
+}

--- a/src/test/java/io/spring/infrastructure/DbTestBase.java
+++ b/src/test/java/io/spring/infrastructure/DbTestBase.java
@@ -1,5 +1,9 @@
 package io.spring.infrastructure;
 
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
@@ -8,4 +12,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @MybatisTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public abstract class DbTestBase {}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
Adds plain JUnit 5 unit tests (no Spring context, no DB) for the core domain entities/value objects that previously had no coverage, complementing the existing `ArticleTest`. New tests cover:

- `User` — constructor (UUID id generation), getters, `update(...)` semantics (updates only non-empty/non-null fields via `Util.isEmpty`), and the id-only `equals`/`hashCode` contract.
- `Comment` — constructor (UUID id, `createdAt` set), getters, id-only `equals`/`hashCode`.
- `Tag` — constructor (UUID id), `@Data` setters, name-only `equals`/`hashCode`.
- `FollowRelation` — constructor, `@Data` setters, all-field `equals`/`hashCode`.
- `ArticleFavorite` — constructor, getters, all-field `equals`/`hashCode`.

Each `equals`/`hashCode` suite checks equal objects, unequal objects, and `null`/other-type comparisons. For the id-only entities (`User`, `Comment`) whose id is a private UUID with no setter, tests use reflection to set matching ids to verify the equality contract.

Style follows `ArticleTest`: pure JUnit 5, no `@SpringBootTest`/`DbTestBase`, inherently parallel-safe (no parallel annotations added). Only new test files under `src/test/java/io/spring/core/...` — no production code, `build.gradle`, or `junit-platform.properties` changes.

## Stacking / build
Stacked on #785 (`devin/1783646746-jacoco-parallel-tests`, adds JaCoCo + parallel config) — **merge #785 first**. Base is `master`.

Verified with:
```
./gradlew clean test jacocoTestReport -x spotlessJava -x spotlessJavaCheck
```
(Spotless is broken under JDK17 and excluded per repo convention.)

## Results
- Full suite: **green**.
- Tests added: **27** (User 8, Comment 5, Tag 5, FollowRelation 5, ArticleFavorite 4).
- `io.spring.core` instruction coverage: **69.2% → 86.2%** (line 93.3% → 95.2%).

No production bugs found.

Link to Devin session: https://app.devin.ai/sessions/3be3add395d54c5682b57c464a307c98
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/786?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->