### PR TITLE
Add TagsApiTest covering GET /tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -56,8 +57,31 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.0
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/RealworldApplicationTests.java
+++ b/src/test/java/io/spring/RealworldApplicationTests.java
@@ -1,9 +1,15 @@
 package io.spring;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public class RealworldApplicationTests {
 
   @Test

--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -1,0 +1,66 @@
+package io.spring.api;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.JacksonCustomizations;
+import io.spring.api.security.WebSecurityConfig;
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest({TagsApi.class})
+@Import({WebSecurityConfig.class, JacksonCustomizations.class})
+public class TagsApiTest extends TestWithCurrentUser {
+  @Autowired private MockMvc mvc;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @Override
+  @BeforeEach
+  public void setUp() throws Exception {
+    super.setUp();
+    RestAssuredMockMvc.mockMvc(mvc);
+  }
+
+  @Test
+  public void should_get_tags_success() throws Exception {
+    List<String> tags = Arrays.asList("java", "spring", "jpg");
+    when(tagsQueryService.allTags()).thenReturn(tags);
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .then()
+        .statusCode(200)
+        .body("tags", equalTo(tags));
+  }
+
+  @Test
+  public void should_get_empty_tags_success() throws Exception {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .then()
+        .statusCode(200)
+        .body("tags", equalTo(Collections.emptyList()));
+  }
+
+  @Test
+  public void should_get_tags_without_authentication() throws Exception {
+    List<String> tags = Arrays.asList("java", "spring");
+    when(tagsQueryService.allTags()).thenReturn(tags);
+
+    given().when().get("/tags").then().statusCode(200).body("tags", equalTo(tags));
+  }
+}

--- a/src/test/java/io/spring/api/TestWithCurrentUser.java
+++ b/src/test/java/io/spring/api/TestWithCurrentUser.java
@@ -10,8 +10,11 @@ import io.spring.core.user.UserRepository;
 import io.spring.infrastructure.mybatis.readservice.UserReadService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 abstract class TestWithCurrentUser {
   @MockBean protected UserRepository userRepository;
 

--- a/src/test/java/io/spring/api/UsersApiTest.java
+++ b/src/test/java/io/spring/api/UsersApiTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,6 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
   BCryptPasswordEncoder.class,
   JacksonCustomizations.class
 })
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 public class UsersApiTest {
   @Autowired private MockMvc mvc;
 

--- a/src/test/java/io/spring/infrastructure/DbTestBase.java
+++ b/src/test/java/io/spring/infrastructure/DbTestBase.java
@@ -1,5 +1,9 @@
 package io.spring.infrastructure;
 
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
@@ -8,4 +12,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @MybatisTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public abstract class DbTestBase {}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
`TagsApi` was the only REST controller without a matching `*ApiTest`. This adds `src/test/java/io/spring/api/TagsApiTest.java`, bringing `TagsApi` to 100% coverage.

The test follows `ArticleApiTest` exactly: `@WebMvcTest({TagsApi.class})`, `@Import({WebSecurityConfig.class, JacksonCustomizations.class})`, extends `TestWithCurrentUser`, mocks `TagsQueryService`, and drives requests via `RestAssuredMockMvc`. Extending `TestWithCurrentUser` inherits the class-level `@ResourceLock("MOCKMVC")` for parallel-safety.

Cases covered:
- `should_get_tags_success` — non-empty list, asserts `200` + `body("tags", equalTo(tags))`.
- `should_get_empty_tags_success` — empty-list case returns `200`.
- `should_get_tags_without_authentication` — anonymous GET returns `200` (allowed per `WebSecurityConfig`).

Only the test file is added; no production code, `build.gradle`, `junit-platform.properties`, or `TestWithCurrentUser` changes.

**Stacked on #785** (`devin/1783646746-jacoco-parallel-tests`, JaCoCo + JUnit5 parallel config) — that PR merges first.

## Verification
`./gradlew clean test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` — BUILD SUCCESSFUL, full suite green. `TagsApi` shows 100% instruction coverage in `build/reports/jacoco/test/`.


Link to Devin session: https://app.devin.ai/sessions/d680a4a60364424687beda0a25145a3a
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/787?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->