### PR TITLE
Add JaCoCo coverage tooling + tests (GraphQL, app services, core domain, security)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -58,6 +59,29 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn test
+    reports {
+        html.required = true
+        xml.required = true
+    }
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.30
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -1,6 +1,5 @@
 package io.spring.api.security;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -39,13 +38,14 @@ public class JwtTokenFilterTest {
   private MockHttpServletRequest request;
   private MockHttpServletResponse response;
   private MockFilterChain chain;
+  private AutoCloseable closeable;
 
   private User user;
   private final String token = "valid.jwt.token";
 
   @BeforeEach
   public void setUp() {
-    MockitoAnnotations.openMocks(this);
+    closeable = MockitoAnnotations.openMocks(this);
     filter = new JwtTokenFilter();
     ReflectionTestUtils.setField(filter, "jwtService", jwtService);
     ReflectionTestUtils.setField(filter, "userRepository", userRepository);
@@ -59,8 +59,9 @@ public class JwtTokenFilterTest {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws Exception {
     SecurityContextHolder.clearContext();
+    closeable.close();
   }
 
   private void doFilter() {

--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -1,7 +1,7 @@
 package io.spring.api.security;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -138,7 +138,8 @@ public class JwtTokenFilterTest {
   @Test
   public void should_not_overwrite_existing_authentication() {
     Authentication existing =
-        new UsernamePasswordAuthenticationToken("existing-principal", null, Collections.emptyList());
+        new UsernamePasswordAuthenticationToken(
+            "existing-principal", null, Collections.emptyList());
     SecurityContextHolder.getContext().setAuthentication(existing);
 
     request.addHeader("Authorization", "Token " + token);

--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -119,7 +119,7 @@ public class JwtTokenFilterTest {
     doFilter();
 
     assertNull(currentAuthentication());
-    verify(userRepository, never()).findById(eq(user.getId()));
+    verifyNoInteractions(userRepository);
     assertNotNull(chain.getRequest());
   }
 

--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -1,0 +1,176 @@
+package io.spring.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class JwtTokenFilterTest {
+
+  @Mock private JwtService jwtService;
+  @Mock private UserRepository userRepository;
+
+  private JwtTokenFilter filter;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+  private MockFilterChain chain;
+
+  private User user;
+  private final String token = "valid.jwt.token";
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    filter = new JwtTokenFilter();
+    ReflectionTestUtils.setField(filter, "jwtService", jwtService);
+    ReflectionTestUtils.setField(filter, "userRepository", userRepository);
+
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+    chain = new MockFilterChain();
+
+    user = new User("email@example.com", "username", "123", "", "");
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void doFilter() {
+    ReflectionTestUtils.invokeMethod(filter, "doFilterInternal", request, response, chain);
+  }
+
+  private Authentication currentAuthentication() {
+    return SecurityContextHolder.getContext().getAuthentication();
+  }
+
+  @Test
+  public void should_populate_security_context_with_valid_token() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    doFilter();
+
+    Authentication authentication = currentAuthentication();
+    assertNotNull(authentication);
+    assertSame(user, authentication.getPrincipal());
+    assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+    assertTrue(authentication.getAuthorities().isEmpty());
+    assertTrue(authentication.getDetails() instanceof WebAuthenticationDetails);
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_header_missing() {
+    doFilter();
+
+    assertNull(currentAuthentication());
+    verifyNoInteractions(jwtService);
+    verifyNoInteractions(userRepository);
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_header_has_no_token_part() {
+    request.addHeader("Authorization", "Token");
+
+    doFilter();
+
+    assertNull(currentAuthentication());
+    verifyNoInteractions(jwtService);
+    verifyNoInteractions(userRepository);
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_token_is_invalid() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.empty());
+
+    doFilter();
+
+    assertNull(currentAuthentication());
+    verify(userRepository, never()).findById(eq(user.getId()));
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_user_not_found() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.empty());
+
+    doFilter();
+
+    assertNull(currentAuthentication());
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_overwrite_existing_authentication() {
+    Authentication existing =
+        new UsernamePasswordAuthenticationToken("existing-principal", null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(existing);
+
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+
+    doFilter();
+
+    assertSame(existing, currentAuthentication());
+    verify(userRepository, never()).findById(eq(user.getId()));
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_extract_token_by_position_regardless_of_scheme() {
+    request.addHeader("Authorization", "Bearer " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    doFilter();
+
+    Authentication authentication = currentAuthentication();
+    assertNotNull(authentication);
+    assertSame(user, authentication.getPrincipal());
+  }
+
+  @Test
+  public void should_always_continue_filter_chain() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.empty());
+
+    doFilter();
+
+    assertSame(request, chain.getRequest());
+    assertSame(response, chain.getResponse());
+  }
+}

--- a/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
+++ b/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
@@ -1,0 +1,89 @@
+package io.spring.api.security;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class WebSecurityConfigTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private JwtService jwtService;
+
+  @MockBean private UserRepository userRepository;
+
+  private User user;
+  private final String token = "valid.jwt.token";
+
+  @BeforeEach
+  public void setUp() {
+    RestAssuredMockMvc.mockMvc(mvc);
+    user = new User("secconfig@example.com", "secconfig", "123", "", "");
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+  }
+
+  @Test
+  public void public_get_tags_is_accessible_without_authentication() {
+    given().contentType("application/json").when().get("/tags").then().statusCode(200);
+  }
+
+  @Test
+  public void public_get_articles_is_accessible_without_authentication() {
+    given().contentType("application/json").when().get("/articles").then().statusCode(200);
+  }
+
+  @Test
+  public void public_post_login_passes_security_layer() {
+    given()
+        .contentType("application/json")
+        .body("{\"user\":{\"email\":\"nobody@example.com\",\"password\":\"whatever\"}}")
+        .when()
+        .post("/users/login")
+        .then()
+        .statusCode(422);
+  }
+
+  @Test
+  public void options_requests_are_permitted() {
+    given().when().options("/articles/feed").then().statusCode(200);
+  }
+
+  @Test
+  public void protected_feed_requires_authentication() {
+    given().contentType("application/json").when().get("/articles/feed").then().statusCode(401);
+  }
+
+  @Test
+  public void protected_current_user_requires_authentication() {
+    given().contentType("application/json").when().get("/user").then().statusCode(401);
+  }
+
+  @Test
+  public void protected_feed_is_accessible_with_valid_token() {
+    given()
+        .header("Authorization", "Token " + token)
+        .contentType("application/json")
+        .when()
+        .get("/articles/feed")
+        .then()
+        .statusCode(200);
+  }
+}

--- a/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
+++ b/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
@@ -52,6 +52,8 @@ public class WebSecurityConfigTest {
 
   @Test
   public void public_post_login_passes_security_layer() {
+    // Endpoint is public, so the request reaches the controller and fails on unknown
+    // credentials (422) rather than being rejected by the security layer (401/403).
     given()
         .contentType("application/json")
         .body("{\"user\":{\"email\":\"nobody@example.com\",\"password\":\"whatever\"}}")

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,87 @@
+package io.spring.application.article;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleCommandServiceTest {
+
+  @Mock private ArticleRepository articleRepository;
+
+  @InjectMocks private ArticleCommandService articleCommandService;
+
+  private User creator;
+
+  @BeforeEach
+  public void setUp() {
+    creator = new User("author@example.com", "author", "123", "", "");
+  }
+
+  @Test
+  public void should_create_article_from_param_and_save_it() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("a new title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(param, creator);
+
+    assertEquals("a new title", article.getTitle());
+    assertEquals("desc", article.getDescription());
+    assertEquals("body", article.getBody());
+    assertEquals("a-new-title", article.getSlug());
+    assertEquals(creator.getId(), article.getUserId());
+    assertEquals(2, article.getTags().size());
+
+    ArgumentCaptor<Article> captor = ArgumentCaptor.forClass(Article.class);
+    verify(articleRepository, times(1)).save(captor.capture());
+    assertSame(article, captor.getValue());
+  }
+
+  @Test
+  public void should_update_article_fields_and_save_it() {
+    Article article =
+        new Article("old title", "old desc", "old body", Arrays.asList("java"), creator.getId());
+    UpdateArticleParam param = new UpdateArticleParam("new title", "new body", "new desc");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertSame(article, updated);
+    assertEquals("new title", updated.getTitle());
+    assertEquals("new desc", updated.getDescription());
+    assertEquals("new body", updated.getBody());
+    assertEquals("new-title", updated.getSlug());
+    verify(articleRepository, times(1)).save(article);
+  }
+
+  @Test
+  public void should_keep_original_fields_when_update_param_is_empty() {
+    Article article =
+        new Article("old title", "old desc", "old body", Arrays.asList("java"), creator.getId());
+    UpdateArticleParam param = new UpdateArticleParam("", "", "");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertEquals("old title", updated.getTitle());
+    assertEquals("old desc", updated.getDescription());
+    assertEquals("old body", updated.getBody());
+    verify(articleRepository, times(1)).save(article);
+  }
+}

--- a/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
+++ b/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
@@ -1,0 +1,44 @@
+package io.spring.application.article;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedArticleValidatorTest {
+
+  @Mock private ArticleQueryService articleQueryService;
+
+  @InjectMocks private DuplicatedArticleValidator validator;
+
+  @Test
+  public void should_be_valid_when_no_article_with_same_slug_exists() {
+    String title = "a brand new title";
+    when(articleQueryService.findBySlug(eq(Article.toSlug(title)), isNull()))
+        .thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid(title, null));
+  }
+
+  @Test
+  public void should_be_invalid_when_article_with_same_slug_exists() {
+    String title = "an existing title";
+    when(articleQueryService.findBySlug(eq(Article.toSlug(title)), isNull()))
+        .thenReturn(Optional.of(mock(ArticleData.class)));
+
+    assertFalse(validator.isValid(title, null));
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
@@ -1,0 +1,43 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedEmailValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedEmailValidator validator;
+
+  @Test
+  public void should_be_valid_when_email_is_not_used() {
+    when(userRepository.findByEmail("free@example.com")).thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid("free@example.com", null));
+  }
+
+  @Test
+  public void should_be_invalid_when_email_is_already_used() {
+    User existing = new User("used@example.com", "someone", "123", "", "");
+    when(userRepository.findByEmail("used@example.com")).thenReturn(Optional.of(existing));
+
+    assertFalse(validator.isValid("used@example.com", null));
+  }
+
+  @Test
+  public void should_be_valid_when_email_is_null_or_empty() {
+    assertTrue(validator.isValid(null, null));
+    assertTrue(validator.isValid("", null));
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
@@ -1,0 +1,43 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedUsernameValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedUsernameValidator validator;
+
+  @Test
+  public void should_be_valid_when_username_is_not_used() {
+    when(userRepository.findByUsername("freename")).thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid("freename", null));
+  }
+
+  @Test
+  public void should_be_invalid_when_username_is_already_used() {
+    User existing = new User("someone@example.com", "usedname", "123", "", "");
+    when(userRepository.findByUsername("usedname")).thenReturn(Optional.of(existing));
+
+    assertFalse(validator.isValid("usedname", null));
+  }
+
+  @Test
+  public void should_be_valid_when_username_is_null_or_empty() {
+    assertTrue(validator.isValid(null, null));
+    assertTrue(validator.isValid("", null));
+  }
+}

--- a/src/test/java/io/spring/application/user/UpdateUserCommandTest.java
+++ b/src/test/java/io/spring/application/user/UpdateUserCommandTest.java
@@ -1,0 +1,86 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateUserCommandTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private UpdateUserValidator validator;
+
+  private User targetUser;
+
+  @BeforeEach
+  public void setUp() {
+    targetUser = new User("target@example.com", "target", "123", "", "");
+  }
+
+  private UpdateUserCommand command(String email, String username) {
+    UpdateUserParam param = UpdateUserParam.builder().email(email).username(username).build();
+    return new UpdateUserCommand(targetUser, param);
+  }
+
+  @Test
+  public void should_expose_target_user_and_param() {
+    UpdateUserParam param = UpdateUserParam.builder().email("a@example.com").build();
+    UpdateUserCommand cmd = new UpdateUserCommand(targetUser, param);
+
+    assertSame(targetUser, cmd.getTargetUser());
+    assertSame(param, cmd.getParam());
+  }
+
+  @Test
+  public void should_be_valid_when_email_and_username_are_unused() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+    when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid(command("new@example.com", "newname"), context));
+  }
+
+  @Test
+  public void should_be_valid_when_email_and_username_belong_to_target_user() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+    when(userRepository.findByEmail("target@example.com")).thenReturn(Optional.of(targetUser));
+    when(userRepository.findByUsername("target")).thenReturn(Optional.of(targetUser));
+
+    assertTrue(validator.isValid(command("target@example.com", "target"), context));
+  }
+
+  @Test
+  public void should_be_invalid_when_email_belongs_to_another_user() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+    User other = new User("other@example.com", "other", "123", "", "");
+    when(userRepository.findByEmail("other@example.com")).thenReturn(Optional.of(other));
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+
+    assertFalse(validator.isValid(command("other@example.com", "newname"), context));
+  }
+
+  @Test
+  public void should_be_invalid_when_username_belongs_to_another_user() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+    User other = new User("other@example.com", "other", "123", "", "");
+    when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("other")).thenReturn(Optional.of(other));
+
+    assertFalse(validator.isValid(command("new@example.com", "other"), context));
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,90 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+  private static final String DEFAULT_IMAGE = "https://example.com/default.jpg";
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private UserService userService;
+
+  @BeforeEach
+  public void setUp() {
+    userService = new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder);
+  }
+
+  @Test
+  public void should_create_user_with_encoded_password_and_default_image() {
+    RegisterParam param = new RegisterParam("new@example.com", "newuser", "plain-password");
+    when(passwordEncoder.encode("plain-password")).thenReturn("encoded-password");
+
+    User user = userService.createUser(param);
+
+    assertEquals("new@example.com", user.getEmail());
+    assertEquals("newuser", user.getUsername());
+    assertEquals("encoded-password", user.getPassword());
+    assertEquals("", user.getBio());
+    assertEquals(DEFAULT_IMAGE, user.getImage());
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    verify(passwordEncoder, times(1)).encode(eq("plain-password"));
+    verify(userRepository, times(1)).save(captor.capture());
+    assertSame(user, captor.getValue());
+  }
+
+  @Test
+  public void should_update_target_user_fields_and_save_it() {
+    User target = new User("old@example.com", "olduser", "password", "old bio", "old image");
+    UpdateUserParam param =
+        UpdateUserParam.builder()
+            .email("new@example.com")
+            .username("newuser")
+            .bio("new bio")
+            .image("new image")
+            .build();
+    UpdateUserCommand command = new UpdateUserCommand(target, param);
+
+    userService.updateUser(command);
+
+    assertEquals("new@example.com", target.getEmail());
+    assertEquals("newuser", target.getUsername());
+    assertEquals("new bio", target.getBio());
+    assertEquals("new image", target.getImage());
+    verify(userRepository, times(1)).save(target);
+  }
+
+  @Test
+  public void should_keep_original_fields_when_update_param_is_empty() {
+    User target = new User("old@example.com", "olduser", "password", "old bio", "old image");
+    UpdateUserParam param = UpdateUserParam.builder().build();
+    UpdateUserCommand command = new UpdateUserCommand(target, param);
+
+    userService.updateUser(command);
+
+    assertEquals("old@example.com", target.getEmail());
+    assertEquals("olduser", target.getUsername());
+    assertEquals("old bio", target.getBio());
+    assertEquals("old image", target.getImage());
+    verify(userRepository, times(1)).save(target);
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -59,6 +59,7 @@ public class UserServiceTest {
         UpdateUserParam.builder()
             .email("new@example.com")
             .username("newuser")
+            .password("new-password")
             .bio("new bio")
             .image("new image")
             .build();
@@ -68,6 +69,7 @@ public class UserServiceTest {
 
     assertEquals("new@example.com", target.getEmail());
     assertEquals("newuser", target.getUsername());
+    assertEquals("new-password", target.getPassword());
     assertEquals("new bio", target.getBio());
     assertEquals("new image", target.getImage());
     verify(userRepository, times(1)).save(target);

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -85,6 +85,7 @@ public class UserServiceTest {
 
     assertEquals("old@example.com", target.getEmail());
     assertEquals("olduser", target.getUsername());
+    assertEquals("password", target.getPassword());
     assertEquals("old bio", target.getBio());
     assertEquals("old image", target.getImage());
     verify(userRepository, times(1)).save(target);

--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.lang.reflect.Field;
 import org.junit.jupiter.api.Test;
 
 public class CommentTest {
@@ -27,10 +28,12 @@ public class CommentTest {
   }
 
   @Test
-  public void should_be_equal_when_ids_are_equal() {
-    Comment comment = new Comment("body", "userId", "articleId");
-    assertThat(comment, is(comment));
-    assertThat(comment.hashCode(), is(comment.hashCode()));
+  public void should_be_equal_for_distinct_instances_sharing_the_same_id() throws Exception {
+    Comment first = new Comment("body", "userId", "articleId");
+    Comment second = new Comment("other body", "otherUser", "otherArticle");
+    setId(second, first.getId());
+    assertThat(first, is(second));
+    assertThat(first.hashCode(), is(second.hashCode()));
   }
 
   @Test
@@ -38,5 +41,11 @@ public class CommentTest {
     Comment first = new Comment("body", "userId", "articleId");
     Comment second = new Comment("body", "userId", "articleId");
     assertThat(first, is(not(second)));
+  }
+
+  private static void setId(Comment comment, String id) throws Exception {
+    Field field = Comment.class.getDeclaredField("id");
+    field.setAccessible(true);
+    field.set(comment, id);
   }
 }

--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -1,0 +1,42 @@
+package io.spring.core.comment;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+
+  @Test
+  public void should_set_all_fields_and_generate_metadata_on_construction() {
+    Comment comment = new Comment("a comment body", "userId", "articleId");
+    assertThat(comment.getId(), is(notNullValue()));
+    assertThat(comment.getBody(), is("a comment body"));
+    assertThat(comment.getUserId(), is("userId"));
+    assertThat(comment.getArticleId(), is("articleId"));
+    assertThat(comment.getCreatedAt(), is(notNullValue()));
+  }
+
+  @Test
+  public void should_generate_unique_ids_for_different_comments() {
+    Comment first = new Comment("body", "userId", "articleId");
+    Comment second = new Comment("body", "userId", "articleId");
+    assertThat(first.getId(), is(not(second.getId())));
+  }
+
+  @Test
+  public void should_be_equal_when_ids_are_equal() {
+    Comment comment = new Comment("body", "userId", "articleId");
+    assertThat(comment, is(comment));
+    assertThat(comment.hashCode(), is(comment.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_differ() {
+    Comment first = new Comment("body", "userId", "articleId");
+    Comment second = new Comment("body", "userId", "articleId");
+    assertThat(first, is(not(second)));
+  }
+}

--- a/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
+++ b/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
@@ -1,0 +1,32 @@
+package io.spring.core.favorite;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ArticleFavoriteTest {
+
+  @Test
+  public void should_set_article_id_and_user_id_on_construction() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+    assertThat(favorite.getArticleId(), is("articleId"));
+    assertThat(favorite.getUserId(), is("userId"));
+  }
+
+  @Test
+  public void should_be_equal_for_same_article_and_user() {
+    ArticleFavorite first = new ArticleFavorite("articleId", "userId");
+    ArticleFavorite second = new ArticleFavorite("articleId", "userId");
+    assertThat(first, is(second));
+    assertThat(first.hashCode(), is(second.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_fields_differ() {
+    ArticleFavorite first = new ArticleFavorite("articleId", "userId");
+    ArticleFavorite second = new ArticleFavorite("articleId", "otherUser");
+    assertThat(first, is(not(second)));
+  }
+}

--- a/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
+++ b/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
@@ -14,8 +14,7 @@ public class AuthorizationServiceTest {
   @Test
   public void should_allow_author_to_write_article() {
     User author = new User("author@email.com", "author", "password", "bio", "image");
-    Article article =
-        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Article article = new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
     assertThat(AuthorizationService.canWriteArticle(author, article), is(true));
   }
 
@@ -23,8 +22,7 @@ public class AuthorizationServiceTest {
   public void should_forbid_non_author_to_write_article() {
     User author = new User("author@email.com", "author", "password", "bio", "image");
     User other = new User("other@email.com", "other", "password", "bio", "image");
-    Article article =
-        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Article article = new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
     assertThat(AuthorizationService.canWriteArticle(other, article), is(false));
   }
 
@@ -32,8 +30,7 @@ public class AuthorizationServiceTest {
   public void should_allow_article_author_to_write_comment() {
     User author = new User("author@email.com", "author", "password", "bio", "image");
     User commenter = new User("commenter@email.com", "commenter", "password", "bio", "image");
-    Article article =
-        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Article article = new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
     Comment comment = new Comment("body", commenter.getId(), article.getId());
     assertThat(AuthorizationService.canWriteComment(author, article, comment), is(true));
   }
@@ -42,8 +39,7 @@ public class AuthorizationServiceTest {
   public void should_allow_comment_author_to_write_comment() {
     User author = new User("author@email.com", "author", "password", "bio", "image");
     User commenter = new User("commenter@email.com", "commenter", "password", "bio", "image");
-    Article article =
-        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Article article = new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
     Comment comment = new Comment("body", commenter.getId(), article.getId());
     assertThat(AuthorizationService.canWriteComment(commenter, article, comment), is(true));
   }
@@ -53,8 +49,7 @@ public class AuthorizationServiceTest {
     User author = new User("author@email.com", "author", "password", "bio", "image");
     User commenter = new User("commenter@email.com", "commenter", "password", "bio", "image");
     User stranger = new User("stranger@email.com", "stranger", "password", "bio", "image");
-    Article article =
-        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Article article = new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
     Comment comment = new Comment("body", commenter.getId(), article.getId());
     assertThat(AuthorizationService.canWriteComment(stranger, article, comment), is(false));
   }

--- a/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
+++ b/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
@@ -1,0 +1,61 @@
+package io.spring.core.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.spring.core.article.Article;
+import io.spring.core.comment.Comment;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationServiceTest {
+
+  @Test
+  public void should_allow_author_to_write_article() {
+    User author = new User("author@email.com", "author", "password", "bio", "image");
+    Article article =
+        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    assertThat(AuthorizationService.canWriteArticle(author, article), is(true));
+  }
+
+  @Test
+  public void should_forbid_non_author_to_write_article() {
+    User author = new User("author@email.com", "author", "password", "bio", "image");
+    User other = new User("other@email.com", "other", "password", "bio", "image");
+    Article article =
+        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    assertThat(AuthorizationService.canWriteArticle(other, article), is(false));
+  }
+
+  @Test
+  public void should_allow_article_author_to_write_comment() {
+    User author = new User("author@email.com", "author", "password", "bio", "image");
+    User commenter = new User("commenter@email.com", "commenter", "password", "bio", "image");
+    Article article =
+        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Comment comment = new Comment("body", commenter.getId(), article.getId());
+    assertThat(AuthorizationService.canWriteComment(author, article, comment), is(true));
+  }
+
+  @Test
+  public void should_allow_comment_author_to_write_comment() {
+    User author = new User("author@email.com", "author", "password", "bio", "image");
+    User commenter = new User("commenter@email.com", "commenter", "password", "bio", "image");
+    Article article =
+        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Comment comment = new Comment("body", commenter.getId(), article.getId());
+    assertThat(AuthorizationService.canWriteComment(commenter, article, comment), is(true));
+  }
+
+  @Test
+  public void should_forbid_unrelated_user_to_write_comment() {
+    User author = new User("author@email.com", "author", "password", "bio", "image");
+    User commenter = new User("commenter@email.com", "commenter", "password", "bio", "image");
+    User stranger = new User("stranger@email.com", "stranger", "password", "bio", "image");
+    Article article =
+        new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+    Comment comment = new Comment("body", commenter.getId(), article.getId());
+    assertThat(AuthorizationService.canWriteComment(stranger, article, comment), is(false));
+  }
+}

--- a/src/test/java/io/spring/core/user/FollowRelationTest.java
+++ b/src/test/java/io/spring/core/user/FollowRelationTest.java
@@ -1,0 +1,41 @@
+package io.spring.core.user;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class FollowRelationTest {
+
+  @Test
+  public void should_set_user_id_and_target_id_on_construction() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+    assertThat(relation.getUserId(), is("userId"));
+    assertThat(relation.getTargetId(), is("targetId"));
+  }
+
+  @Test
+  public void should_update_fields_via_setters() {
+    FollowRelation relation = new FollowRelation();
+    relation.setUserId("userId");
+    relation.setTargetId("targetId");
+    assertThat(relation.getUserId(), is("userId"));
+    assertThat(relation.getTargetId(), is("targetId"));
+  }
+
+  @Test
+  public void should_be_equal_for_same_user_and_target() {
+    FollowRelation first = new FollowRelation("userId", "targetId");
+    FollowRelation second = new FollowRelation("userId", "targetId");
+    assertThat(first, is(second));
+    assertThat(first.hashCode(), is(second.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_fields_differ() {
+    FollowRelation first = new FollowRelation("userId", "targetId");
+    FollowRelation second = new FollowRelation("userId", "otherTarget");
+    assertThat(first, is(not(second)));
+  }
+}

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -51,6 +51,17 @@ public class UserTest {
   }
 
   @Test
+  public void should_keep_existing_values_when_update_args_are_null() {
+    User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
+    user.update(null, null, null, null, null);
+    assertThat(user.getEmail(), is("jake@jake.jake"));
+    assertThat(user.getUsername(), is("jake"));
+    assertThat(user.getPassword(), is("password"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
   public void should_update_only_the_provided_fields() {
     User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
     user.update("", "newname", "", "", "new image");

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.lang.reflect.Field;
 import org.junit.jupiter.api.Test;
 
 public class UserTest {
@@ -61,10 +62,12 @@ public class UserTest {
   }
 
   @Test
-  public void should_be_equal_when_ids_are_equal() {
-    User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
-    assertThat(user, is(user));
-    assertThat(user.hashCode(), is(user.hashCode()));
+  public void should_be_equal_for_distinct_instances_sharing_the_same_id() throws Exception {
+    User first = new User("jake@jake.jake", "jake", "password", "bio", "image");
+    User second = new User("other@email.com", "other", "otherpassword", "other bio", "other image");
+    setId(second, first.getId());
+    assertThat(first, is(second));
+    assertThat(first.hashCode(), is(second.hashCode()));
   }
 
   @Test
@@ -72,5 +75,11 @@ public class UserTest {
     User first = new User("a@a.com", "a", "p", "b", "i");
     User second = new User("b@b.com", "b", "p", "b", "i");
     assertThat(first, is(not(second)));
+  }
+
+  private static void setId(User user, String id) throws Exception {
+    Field field = User.class.getDeclaredField("id");
+    field.setAccessible(true);
+    field.set(user, id);
   }
 }

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -1,0 +1,76 @@
+package io.spring.core.user;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+  @Test
+  public void should_set_all_fields_and_generate_id_on_construction() {
+    User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
+    assertThat(user.getId(), is(notNullValue()));
+    assertThat(user.getEmail(), is("jake@jake.jake"));
+    assertThat(user.getUsername(), is("jake"));
+    assertThat(user.getPassword(), is("password"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_generate_unique_ids_for_different_users() {
+    User first = new User("a@a.com", "a", "p", "b", "i");
+    User second = new User("b@b.com", "b", "p", "b", "i");
+    assertThat(first.getId(), is(not(second.getId())));
+  }
+
+  @Test
+  public void should_update_all_fields_when_new_values_provided() {
+    User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
+    user.update("new@email.com", "newname", "newpassword", "new bio", "new image");
+    assertThat(user.getEmail(), is("new@email.com"));
+    assertThat(user.getUsername(), is("newname"));
+    assertThat(user.getPassword(), is("newpassword"));
+    assertThat(user.getBio(), is("new bio"));
+    assertThat(user.getImage(), is("new image"));
+  }
+
+  @Test
+  public void should_keep_existing_values_when_update_args_are_empty() {
+    User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
+    user.update("", "", "", "", "");
+    assertThat(user.getEmail(), is("jake@jake.jake"));
+    assertThat(user.getUsername(), is("jake"));
+    assertThat(user.getPassword(), is("password"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_update_only_the_provided_fields() {
+    User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
+    user.update("", "newname", "", "", "new image");
+    assertThat(user.getEmail(), is("jake@jake.jake"));
+    assertThat(user.getUsername(), is("newname"));
+    assertThat(user.getPassword(), is("password"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("new image"));
+  }
+
+  @Test
+  public void should_be_equal_when_ids_are_equal() {
+    User user = new User("jake@jake.jake", "jake", "password", "bio", "image");
+    assertThat(user, is(user));
+    assertThat(user.hashCode(), is(user.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_differ() {
+    User first = new User("a@a.com", "a", "p", "b", "i");
+    User second = new User("b@b.com", "b", "p", "b", "i");
+    assertThat(first, is(not(second)));
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -12,7 +12,6 @@ import com.netflix.graphql.dgs.exceptions.QueryException;
 import io.spring.application.CursorPager;
 import io.spring.application.CursorPager.Direction;
 import io.spring.application.data.ArticleData;
-import io.spring.core.user.User;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -54,7 +54,7 @@ class ArticleDatafetcherTest extends DgsGraphQLTestBase {
 
   @Test
   void should_error_when_feed_missing_first_and_last() {
-    setAnonymous();
+    setAuthenticatedUser(user);
 
     QueryException error =
         org.junit.jupiter.api.Assertions.assertThrows(

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,206 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ArticleDatafetcherTest extends DgsGraphQLTestBase {
+
+  private CursorPager<ArticleData> onePage() {
+    return new CursorPager<>(
+        Collections.singletonList(articleData("hello-world", user)), Direction.NEXT, false);
+  }
+
+  @Test
+  void should_query_feed() {
+    setAuthenticatedUser(user);
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ feed(first: 10) { edges { cursor node { slug title body } } pageInfo { hasNextPage"
+                + " hasPreviousPage } } }",
+            "data.feed.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), slugs);
+  }
+
+  @Test
+  void should_query_feed_backwards() {
+    setAuthenticatedUser(user);
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    Boolean hasPrevious =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ feed(last: 10) { edges { node { slug } } pageInfo { hasPreviousPage } } }",
+            "data.feed.pageInfo.hasPreviousPage");
+
+    assertFalse(hasPrevious);
+  }
+
+  @Test
+  void should_error_when_feed_missing_first_and_last() {
+    setAnonymous();
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ feed { edges { node { slug } } } }", "data.feed"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_query_articles_with_filters() {
+    setAnonymous();
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ articles(first: 5, withTag: \"java\", authoredBy: \"johnjacob\") { edges { node {"
+                + " slug title } } pageInfo { hasNextPage } } }",
+            "data.articles.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), slugs);
+  }
+
+  @Test
+  void should_query_articles_backwards() {
+    setAnonymous();
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ articles(last: 5) { edges { node { slug } } pageInfo { hasNextPage } } }",
+            "data.articles.pageInfo.hasNextPage");
+
+    assertFalse(hasNext);
+  }
+
+  @Test
+  void should_find_article_by_slug() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+
+    String title =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { slug title body description favorited favoritesCount"
+                + " tagList createdAt updatedAt } }",
+            "data.article.title");
+
+    assertEquals("title hello-world", title);
+  }
+
+  @Test
+  void should_error_when_article_not_found() {
+    setAnonymous();
+    when(articleQueryService.findBySlug(anyString(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ article(slug: \"missing\") { slug } }", "data.article"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_resolve_profile_articles_and_feed_and_favorites() {
+    setAuthenticatedUser(user);
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(eq(user.getUsername()))).thenReturn(Optional.of(user));
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    List<String> articleSlugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"johnjacob\") { profile { username articles(first: 3) { edges {"
+                + " node { slug } } } favorites(first: 3) { edges { node { slug } } } feed(first: 3)"
+                + " { edges { node { slug } } } } } }",
+            "data.profile.profile.articles.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), articleSlugs);
+  }
+
+  @Test
+  void should_resolve_profile_articles_backwards() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(eq(user.getUsername()))).thenReturn(Optional.of(user));
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    List<String> favoriteSlugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"johnjacob\") { profile { articles(last: 3) { edges { node { slug"
+                + " } } } favorites(last: 3) { edges { node { slug } } } feed(last: 3) { edges {"
+                + " node { slug } } } } } }",
+            "data.profile.profile.favorites.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), favoriteSlugs);
+  }
+
+  @Test
+  void should_error_when_profile_feed_missing_pagination() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(eq(user.getUsername()))).thenReturn(Optional.of(user));
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ profile(username: \"johnjacob\") { profile { feed { edges { node { slug } } }"
+                        + " } } }",
+                    "data.profile.profile.feed"));
+
+    assertTrue(error.getErrors().size() > 0);
+  }
+
+  @Test
+  void should_error_when_profile_feed_target_missing() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ profile(username: \"ghost\") { profile { feed(first: 3) { edges { node { slug"
+                        + " } } } } } }",
+                    "data.profile.profile.feed"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -200,9 +200,7 @@ class ArticleMutationTest extends DgsGraphQLTestBase {
             QueryException.class,
             () ->
                 dgsQueryExecutor.executeAndExtractJsonPath(
-                    "mutation { deleteArticle(slug: \""
-                        + article.getSlug()
-                        + "\") { success } }",
+                    "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }",
                     "data.deleteArticle"));
 
     assertFalse(error.getErrors().isEmpty());

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,210 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.TestHelper;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ArticleMutationTest extends DgsGraphQLTestBase {
+
+  private Article articleOf(User author) {
+    return new Article(
+        "How to Test", "desc", "body", Arrays.asList("java", "spring"), author.getId());
+  }
+
+  @Test
+  void should_create_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleCommandService.createArticle(any(), eq(user))).thenReturn(article);
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createArticle(input: {title: \"How to Test\", description: \"desc\", body:"
+                + " \"body\", tagList: [\"java\"]}) { article { slug title body } } }",
+            "data.createArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+  }
+
+  @Test
+  void should_create_article_without_taglist() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleCommandService.createArticle(any(), eq(user))).thenReturn(article);
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String title =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createArticle(input: {title: \"How to Test\", description: \"desc\", body:"
+                + " \"body\"}) { article { title } } }",
+            "data.createArticle.article.title");
+
+    assertEquals(articleData.getTitle(), title);
+  }
+
+  @Test
+  void should_reject_create_article_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { createArticle(input: {title: \"t\", description: \"d\", body: \"b\"})"
+                        + " { article { slug } } }",
+                    "data.createArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_update_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any())).thenReturn(article);
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { updateArticle(slug: \""
+                + article.getSlug()
+                + "\", changes: {title: \"new\"}) { article { slug } } }",
+            "data.updateArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+  }
+
+  @Test
+  void should_reject_update_article_when_not_found() {
+    setAuthenticatedUser(user);
+    when(articleRepository.findBySlug(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { updateArticle(slug: \"missing\", changes: {title: \"new\"}) {"
+                        + " article { slug } } }",
+                    "data.updateArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_update_article_when_not_author() {
+    setAuthenticatedUser(user);
+    User other = new User("other@test.com", "other", "123", "", "");
+    Article article = articleOf(other);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { updateArticle(slug: \""
+                        + article.getSlug()
+                        + "\", changes: {title: \"new\"}) { article { slug } } }",
+                    "data.updateArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_favorite_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { favoriteArticle(slug: \""
+                + article.getSlug()
+                + "\") { article { slug } } }",
+            "data.favoriteArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+    verify(articleFavoriteRepository).save(any(ArticleFavorite.class));
+  }
+
+  @Test
+  void should_unfavorite_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), user.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.of(favorite));
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { unfavoriteArticle(slug: \""
+                + article.getSlug()
+                + "\") { article { slug } } }",
+            "data.unfavoriteArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+    verify(articleFavoriteRepository).remove(eq(favorite));
+  }
+
+  @Test
+  void should_delete_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    Boolean success =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }",
+            "data.deleteArticle.success");
+
+    assertTrue(success);
+    verify(articleRepository).remove(eq(article));
+  }
+
+  @Test
+  void should_reject_delete_article_when_not_author() {
+    setAuthenticatedUser(user);
+    User other = new User("other@test.com", "other", "123", "", "");
+    Article article = articleOf(other);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteArticle(slug: \""
+                        + article.getSlug()
+                        + "\") { success } }",
+                    "data.deleteArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,77 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CommentDatafetcherTest extends DgsGraphQLTestBase {
+
+  private CursorPager<CommentData> onePage() {
+    return new CursorPager<>(
+        Collections.singletonList(commentData("comment-1", user)), Direction.NEXT, false);
+  }
+
+  @Test
+  void should_resolve_article_comments() {
+    setAuthenticatedUser(user);
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(any(), any(), any())).thenReturn(onePage());
+
+    List<String> ids =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { slug comments(first: 5) { edges { cursor node { id"
+                + " body createdAt updatedAt } } pageInfo { hasNextPage } } } }",
+            "data.article.comments.edges[*].node.id");
+
+    assertEquals(Collections.singletonList("comment-1"), ids);
+  }
+
+  @Test
+  void should_resolve_article_comments_backwards() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(any(), any(), any())).thenReturn(onePage());
+
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { comments(last: 5) { edges { node { id } } pageInfo {"
+                + " hasNextPage } } } }",
+            "data.article.comments.pageInfo.hasNextPage");
+
+    assertFalse(hasNext);
+  }
+
+  @Test
+  void should_error_when_article_comments_missing_pagination() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ article(slug: \"hello-world\") { comments { edges { node { id } } } } }",
+                    "data.article.comments"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,158 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.data.CommentData;
+import io.spring.core.article.Article;
+import io.spring.core.comment.Comment;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CommentMutationTest extends DgsGraphQLTestBase {
+
+  private Article articleOf(User author) {
+    return new Article("Title", "desc", "body", Arrays.asList("java"), author.getId());
+  }
+
+  @Test
+  void should_add_comment() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    CommentData commentData = commentData("comment-1", user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(user))).thenReturn(Optional.of(commentData));
+
+    String body =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { addComment(slug: \""
+                + article.getSlug()
+                + "\", body: \"nice article\") { comment { id body } } }",
+            "data.addComment.comment.body");
+
+    assertEquals(commentData.getBody(), body);
+    verify(commentRepository).save(any(Comment.class));
+  }
+
+  @Test
+  void should_reject_add_comment_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { addComment(slug: \"s\", body: \"b\") { comment { id } } }",
+                    "data.addComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_add_comment_when_article_not_found() {
+    setAuthenticatedUser(user);
+    when(articleRepository.findBySlug(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { addComment(slug: \"missing\", body: \"b\") { comment { id } } }",
+                    "data.addComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_delete_comment() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    Comment comment = new Comment("body", user.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    Boolean success =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \""
+                + comment.getId()
+                + "\") { success } }",
+            "data.deleteComment.success");
+
+    assertTrue(success);
+    verify(commentRepository).remove(eq(comment));
+  }
+
+  @Test
+  void should_reject_delete_comment_when_not_authorized() {
+    setAuthenticatedUser(user);
+    User other = new User("other@test.com", "other", "123", "", "");
+    Article article = articleOf(other);
+    Comment comment = new Comment("body", other.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteComment(slug: \""
+                        + article.getSlug()
+                        + "\", id: \""
+                        + comment.getId()
+                        + "\") { success } }",
+                    "data.deleteComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_delete_comment_when_comment_not_found() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(any(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteComment(slug: \""
+                        + article.getSlug()
+                        + "\", id: \"missing\") { success } }",
+                    "data.deleteComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_delete_comment_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteComment(slug: \"s\", id: \"c\") { success } }",
+                    "data.deleteComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
@@ -32,9 +32,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
- * Shared base for GraphQL (Netflix DGS) datafetcher/mutation tests. Boots the full Spring context so
- * the real GraphQL schema and wiring are exercised, while every collaborating service/repository is
- * replaced with a Mockito mock so behaviour can be controlled per test. All subclasses share the
+ * Shared base for GraphQL (Netflix DGS) datafetcher/mutation tests. Boots the full Spring context
+ * so the real GraphQL schema and wiring are exercised, while every collaborating service/repository
+ * is replaced with a Mockito mock so behaviour can be controlled per test. All subclasses share the
  * exact same context configuration so Spring caches and reuses a single application context.
  */
 @SpringBootTest

--- a/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
@@ -30,6 +30,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Shared base for GraphQL (Netflix DGS) datafetcher/mutation tests. Boots the full Spring context
@@ -38,6 +39,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  * exact same context configuration so Spring caches and reuses a single application context.
  */
 @SpringBootTest
+@ActiveProfiles("test")
 abstract class DgsGraphQLTestBase {
 
   @Autowired protected DgsQueryExecutor dgsQueryExecutor;

--- a/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
@@ -1,0 +1,112 @@
+package io.spring.graphql;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.TagsQueryService;
+import io.spring.application.UserQueryService;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.application.user.UserService;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Shared base for GraphQL (Netflix DGS) datafetcher/mutation tests. Boots the full Spring context so
+ * the real GraphQL schema and wiring are exercised, while every collaborating service/repository is
+ * replaced with a Mockito mock so behaviour can be controlled per test. All subclasses share the
+ * exact same context configuration so Spring caches and reuses a single application context.
+ */
+@SpringBootTest
+abstract class DgsGraphQLTestBase {
+
+  @Autowired protected DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean protected ArticleQueryService articleQueryService;
+  @MockBean protected CommentQueryService commentQueryService;
+  @MockBean protected ProfileQueryService profileQueryService;
+  @MockBean protected TagsQueryService tagsQueryService;
+  @MockBean protected UserQueryService userQueryService;
+  @MockBean protected UserRepository userRepository;
+  @MockBean protected ArticleRepository articleRepository;
+  @MockBean protected CommentRepository commentRepository;
+  @MockBean protected ArticleFavoriteRepository articleFavoriteRepository;
+  @MockBean protected ArticleCommandService articleCommandService;
+  @MockBean protected UserService userService;
+  @MockBean protected JwtService jwtService;
+  @MockBean protected PasswordEncoder passwordEncoder;
+
+  protected User user;
+
+  @BeforeEach
+  void setUpCurrentUser() {
+    user = new User("john@jacob.com", "johnjacob", "123", "bio", "avatar.png");
+    setAnonymous();
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  protected void setAuthenticatedUser(User currentUser) {
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(currentUser, null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  protected void setAnonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "anonymous-key",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+
+  protected ArticleData articleData(String seed, User author) {
+    DateTime now = new DateTime();
+    return new ArticleData(
+        seed + "-id",
+        seed,
+        "title " + seed,
+        "desc " + seed,
+        "body " + seed,
+        false,
+        0,
+        now,
+        now,
+        new ArrayList<>(Collections.singletonList("java")),
+        profileData(author));
+  }
+
+  protected CommentData commentData(String id, User author) {
+    DateTime now = new DateTime();
+    return new CommentData(id, "comment body " + id, "article-id", now, now, profileData(author));
+  }
+
+  protected ProfileData profileData(User author) {
+    return new ProfileData(
+        author.getId(), author.getUsername(), author.getBio(), author.getImage(), false);
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,62 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.data.UserData;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class MeDatafetcherTest extends DgsGraphQLTestBase {
+
+  private HttpHeaders authHeader() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token");
+    return headers;
+  }
+
+  @Test
+  void should_return_me_when_authenticated() {
+    setAuthenticatedUser(user);
+    UserData userData =
+        new UserData(user.getId(), user.getEmail(), user.getUsername(), user.getBio(), "img");
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.of(userData));
+
+    String token =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ me { email username token } }", "data.me.token", authHeader());
+
+    assertEquals("jwt-token", token);
+  }
+
+  @Test
+  void should_return_null_me_when_anonymous() {
+    setAnonymous();
+
+    Object me =
+        dgsQueryExecutor.executeAndExtractJsonPath("{ me { email } }", "data.me", authHeader());
+
+    assertNull(me);
+  }
+
+  @Test
+  void should_error_me_when_user_data_missing() {
+    setAuthenticatedUser(user);
+    when(userQueryService.findById(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ me { email } }", "data.me", authHeader()));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,109 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.UserData;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class ProfileDatafetcherTest extends DgsGraphQLTestBase {
+
+  @Test
+  void should_query_profile() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(eq("johnjacob"), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"johnjacob\") { profile { username bio image following } } }",
+            "data.profile.profile.username");
+
+    assertEquals("johnjacob", username);
+  }
+
+  @Test
+  void should_error_when_profile_not_found() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ profile(username: \"ghost\") { profile { username } } }",
+                    "data.profile.profile"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_resolve_article_author() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    String authorName =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { slug author { username following } } }",
+            "data.article.author.username");
+
+    assertEquals(user.getUsername(), authorName);
+  }
+
+  @Test
+  void should_resolve_comment_author() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    CommentData commentData = commentData("comment-1", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(any(), any(), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(commentData), Direction.NEXT, false));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    java.util.List<String> authorNames =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { comments(first: 5) { edges { node { id author {"
+                + " username } } } } } }",
+            "data.article.comments.edges[*].node.author.username");
+
+    assertEquals(Collections.singletonList(user.getUsername()), authorNames);
+  }
+
+  @Test
+  void should_resolve_user_profile_via_me() {
+    setAuthenticatedUser(user);
+    UserData userData =
+        new UserData(user.getId(), user.getEmail(), user.getUsername(), user.getBio(), "img");
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.of(userData));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token");
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ me { profile { username } } }", "data.me.profile.username", headers);
+
+    assertEquals(user.getUsername(), username);
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,134 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RelationMutationTest extends DgsGraphQLTestBase {
+
+  private final User target = new User("target@test.com", "target", "123", "bio", "img");
+
+  @Test
+  void should_follow_user() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername(eq(target.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(target)));
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { followUser(username: \"target\") { profile { username following } } }",
+            "data.followUser.profile.username");
+
+    assertEquals(target.getUsername(), username);
+    verify(userRepository).saveRelation(any(FollowRelation.class));
+  }
+
+  @Test
+  void should_reject_follow_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { followUser(username: \"target\") { profile { username } } }",
+                    "data.followUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_follow_when_target_missing() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { followUser(username: \"ghost\") { profile { username } } }",
+                    "data.followUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_unfollow_user() {
+    setAuthenticatedUser(user);
+    FollowRelation relation = new FollowRelation(user.getId(), target.getId());
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername(eq(target.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(target)));
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { unfollowUser(username: \"target\") { profile { username } } }",
+            "data.unfollowUser.profile.username");
+
+    assertEquals(target.getUsername(), username);
+    verify(userRepository).removeRelation(eq(relation));
+  }
+
+  @Test
+  void should_reject_unfollow_when_target_missing() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { unfollowUser(username: \"ghost\") { profile { username } } }",
+                    "data.unfollowUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_unfollow_when_relation_missing() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(any(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { unfollowUser(username: \"target\") { profile { username } } }",
+                    "data.unfollowUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_unfollow_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { unfollowUser(username: \"target\") { profile { username } } }",
+                    "data.unfollowUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -2,6 +2,7 @@ package io.spring.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.spring.core.user.User;
@@ -50,5 +51,14 @@ class SecurityUtilTest {
         .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
 
     assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+
+  @Test
+  void should_throw_when_no_authentication_present() {
+    SecurityContextHolder.clearContext();
+
+    // Documents current behaviour: with no authentication in the context the
+    // instanceof check is false for null and getPrincipal() is dereferenced.
+    assertThrows(NullPointerException.class, SecurityUtil::getCurrentUser);
   }
 }

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -57,8 +57,10 @@ class SecurityUtilTest {
   void should_throw_when_no_authentication_present() {
     SecurityContextHolder.clearContext();
 
-    // Documents current behaviour: with no authentication in the context the
-    // instanceof check is false for null and getPrincipal() is dereferenced.
+    // TODO: this NPE is a latent null-safety bug in SecurityUtil.getCurrentUser
+    // (it dereferences authentication without a null check). This test documents
+    // the current behaviour; if the production code is hardened to return
+    // Optional.empty() when authentication is null, update this to expect empty.
     assertThrows(NullPointerException.class, SecurityUtil::getCurrentUser);
   }
 }

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,54 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class SecurityUtilTest {
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void should_return_current_user_when_authenticated() {
+    User user = new User("test@example.com", "tester", "123", "", "");
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+
+    Optional<User> current = SecurityUtil.getCurrentUser();
+
+    assertTrue(current.isPresent());
+    assertEquals(user, current.get());
+  }
+
+  @Test
+  void should_return_empty_when_anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+
+  @Test
+  void should_return_empty_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -13,8 +13,7 @@ class TagDatafetcherTest extends DgsGraphQLTestBase {
   void should_return_all_tags() {
     when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
 
-    List<String> tags =
-        dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
 
     assertEquals(Arrays.asList("java", "spring"), tags);
   }

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,21 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TagDatafetcherTest extends DgsGraphQLTestBase {
+
+  @Test
+  void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
+
+    List<String> tags =
+        dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertEquals(Arrays.asList("java", "spring"), tags);
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,110 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+class UserMutationTest extends DgsGraphQLTestBase {
+
+  @Test
+  void should_create_user() {
+    when(userService.createUser(any(RegisterParam.class))).thenReturn(user);
+    when(jwtService.toToken(eq(user))).thenReturn("jwt-token");
+
+    String token =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createUser(input: {email: \"john@jacob.com\", username: \"johnjacob\","
+                + " password: \"123\"}) { ... on UserPayload { user { email username token } } } }",
+            "data.createUser.user.token");
+
+    assertEquals("jwt-token", token);
+  }
+
+  @Test
+  void should_return_error_when_create_user_invalid() {
+    when(userService.createUser(any(RegisterParam.class)))
+        .thenThrow(new ConstraintViolationException(Collections.emptySet()));
+
+    String message =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createUser(input: {email: \"bad\", username: \"u\", password: \"p\"}) { ..."
+                + " on Error { message } } }",
+            "data.createUser.message");
+
+    assertEquals("BAD_REQUEST", message);
+  }
+
+  @Test
+  void should_login() {
+    setAnonymous();
+    when(userRepository.findByEmail(eq(user.getEmail()))).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(eq("123"), eq(user.getPassword()))).thenReturn(true);
+    when(jwtService.toToken(eq(user))).thenReturn("jwt-token");
+
+    String token =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { login(password: \"123\", email: \"john@jacob.com\") { user { email token }"
+                + " } }",
+            "data.login.user.token");
+
+    assertEquals("jwt-token", token);
+  }
+
+  @Test
+  void should_reject_login_when_invalid() {
+    setAnonymous();
+    when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { login(password: \"wrong\", email: \"nobody@test.com\") { user {"
+                        + " email } } }",
+                    "data.login"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_update_user() {
+    setAuthenticatedUser(user);
+    when(jwtService.toToken(eq(user))).thenReturn("jwt-token");
+
+    String email =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { updateUser(changes: {email: \"new@jacob.com\", bio: \"new bio\"}) { user {"
+                + " email } } }",
+            "data.updateUser.user.email");
+
+    assertEquals(user.getEmail(), email);
+    verify(userService).updateUser(any(UpdateUserCommand.class));
+  }
+
+  @Test
+  void should_return_null_update_user_when_anonymous() {
+    setAnonymous();
+
+    User result =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { updateUser(changes: {email: \"new@jacob.com\"}) { user { email } } }",
+            "data.updateUser");
+
+    assertNull(result);
+  }
+}


### PR DESCRIPTION
## Summary
Adds JaCoCo coverage tooling and a large batch of new tests, raising coverage across previously-untested packages. Written across four parallel child sessions targeting non-overlapping packages, then merged into this base branch.

### Tooling (`build.gradle`)
- Add `id 'jacoco'` plugin (toolVersion `0.8.8`, JDK17-compatible).
- `test` is `finalizedBy jacocoTestReport`; `jacocoTestReport` `dependsOn test` and emits HTML + XML.
- On-demand `jacocoTestCoverageVerification` with a modest `minimum = 0.30` (deliberately not wired into `check` yet — coverage now clears it, so it can be gated in a follow-up).

### Tests added (all under `src/test/java/...`)
- **GraphQL layer** (`io.spring.graphql`, via DGS `DgsQueryExecutor` + `@SpringBootTest`): datafetchers/mutations for Article, Comment, Me, Profile, Relation, Tag, User + `SecurityUtil`. (PR #794)
- **Application write services + validators** (`application.article`, `application.user`, Mockito unit tests): `ArticleCommandService`, `UserService`, `UpdateUserCommand`, and the three `Duplicated*Validator`s (valid + duplicate cases). (PR #793)
- **Core domain** (`io.spring.core`, plain JUnit): `User`, `FollowRelation`, `Comment`, `ArticleFavorite`, `AuthorizationService`. (PR #791)
- **Security** (`api.security`): `JwtTokenFilter` (unit, mocked `JwtService`/`UserRepository`) and `WebSecurityConfig` (MockMvc public-vs-protected access rules). (PR #792)

### Result
`./gradlew clean test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` is green — **183 tests pass**. Aggregated coverage: **line 68.1%, instruction 59.1%** (report at `build/reports/jacoco/test/`). No `src/main` files were modified. New test files were run through google-java-format (spotless can't run under the machine's JDK17 without the `--add-exports jdk.compiler/...` workaround).

Notes:
- No GitHub Actions CI exists in this repo (checks are Snyk + Devin Review only).
- Child A flagged a pre-existing bug in `CommentDatafetcher.buildCommentResult` (uses `getCreatedAt()` where `getUpdatedAt()` is expected); left untouched as out of scope for this test-only work.


Link to Devin session: https://app.devin.ai/sessions/49354d446cf84291b7d00644c304420f
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/788?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->