### PR TITLE
Add command-service tests for ArticleCommandService and UserService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -56,8 +57,31 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.0
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/RealworldApplicationTests.java
+++ b/src/test/java/io/spring/RealworldApplicationTests.java
@@ -1,9 +1,15 @@
 package io.spring;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public class RealworldApplicationTests {
 
   @Test

--- a/src/test/java/io/spring/api/TestWithCurrentUser.java
+++ b/src/test/java/io/spring/api/TestWithCurrentUser.java
@@ -10,8 +10,11 @@ import io.spring.core.user.UserRepository;
 import io.spring.infrastructure.mybatis.readservice.UserReadService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 abstract class TestWithCurrentUser {
   @MockBean protected UserRepository userRepository;
 

--- a/src/test/java/io/spring/api/UsersApiTest.java
+++ b/src/test/java/io/spring/api/UsersApiTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,6 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
   BCryptPasswordEncoder.class,
   JacksonCustomizations.class
 })
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 public class UsersApiTest {
   @Autowired private MockMvc mvc;
 

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,114 @@
+package io.spring.application.article;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisArticleRepository;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@Import({
+  ArticleCommandService.class,
+  ArticleQueryService.class,
+  MyBatisArticleRepository.class,
+  MyBatisUserRepository.class,
+  ValidationAutoConfiguration.class
+})
+public class ArticleCommandServiceTest extends DbTestBase {
+  @Autowired private ArticleCommandService articleCommandService;
+
+  @Autowired private ArticleRepository articleRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("author@example.com", "author", "123", "", "");
+    userRepository.save(user);
+  }
+
+  @Test
+  public void should_create_article_and_persist_it() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("a new article")
+            .description("a description")
+            .body("article body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    Article created = articleCommandService.createArticle(param, user);
+
+    Assertions.assertNotNull(created.getId());
+    Assertions.assertEquals("a-new-article", created.getSlug());
+    Assertions.assertEquals(user.getId(), created.getUserId());
+
+    Optional<Article> fetched = articleRepository.findById(created.getId());
+    Assertions.assertTrue(fetched.isPresent());
+    Article saved = fetched.get();
+    Assertions.assertEquals("a new article", saved.getTitle());
+    Assertions.assertEquals("a description", saved.getDescription());
+    Assertions.assertEquals("article body", saved.getBody());
+    Assertions.assertEquals(2, saved.getTags().size());
+  }
+
+  @Test
+  public void should_reject_article_with_duplicated_title() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("duplicated title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java"))
+            .build();
+    articleCommandService.createArticle(param, user);
+
+    NewArticleParam duplicated =
+        NewArticleParam.builder()
+            .title("duplicated title")
+            .description("another desc")
+            .body("another body")
+            .tagList(Arrays.asList("spring"))
+            .build();
+
+    Assertions.assertThrows(
+        ConstraintViolationException.class,
+        () -> articleCommandService.createArticle(duplicated, user));
+  }
+
+  @Test
+  public void should_update_article_and_persist_changes() {
+    Article article =
+        new Article(
+            "origin title", "origin desc", "origin body", Arrays.asList("java"), user.getId());
+    articleRepository.save(article);
+
+    UpdateArticleParam updateParam =
+        new UpdateArticleParam("updated title", "updated body", "updated desc");
+    Article updated = articleCommandService.updateArticle(article, updateParam);
+
+    Assertions.assertEquals("updated title", updated.getTitle());
+    Assertions.assertEquals("updated-title", updated.getSlug());
+
+    Optional<Article> fetched = articleRepository.findById(article.getId());
+    Assertions.assertTrue(fetched.isPresent());
+    Article saved = fetched.get();
+    Assertions.assertEquals("updated title", saved.getTitle());
+    Assertions.assertEquals("updated desc", saved.getDescription());
+    Assertions.assertEquals("updated body", saved.getBody());
+    Assertions.assertEquals("updated-title", saved.getSlug());
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,125 @@
+package io.spring.application.user;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+@Import({
+  UserService.class,
+  MyBatisUserRepository.class,
+  BCryptPasswordEncoder.class,
+  ValidationAutoConfiguration.class
+})
+@TestPropertySource(
+    properties = "image.default=https://static.productionready.io/images/smiley-cyrus.jpg")
+public class UserServiceTest extends DbTestBase {
+  @Autowired private UserService userService;
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @Test
+  public void should_create_user_and_encode_password() {
+    RegisterParam param = new RegisterParam("new@example.com", "newuser", "plain-password");
+
+    User created = userService.createUser(param);
+
+    Assertions.assertNotNull(created.getId());
+    Assertions.assertEquals("new@example.com", created.getEmail());
+    Assertions.assertEquals("newuser", created.getUsername());
+    Assertions.assertEquals(
+        "https://static.productionready.io/images/smiley-cyrus.jpg", created.getImage());
+    Assertions.assertNotEquals("plain-password", created.getPassword());
+    Assertions.assertTrue(passwordEncoder.matches("plain-password", created.getPassword()));
+
+    Optional<User> fetched = userRepository.findById(created.getId());
+    Assertions.assertTrue(fetched.isPresent());
+    User saved = fetched.get();
+    Assertions.assertEquals("new@example.com", saved.getEmail());
+    Assertions.assertEquals("newuser", saved.getUsername());
+    Assertions.assertTrue(passwordEncoder.matches("plain-password", saved.getPassword()));
+  }
+
+  @Test
+  public void should_update_user_and_persist_changes() {
+    User user = new User("origin@example.com", "originuser", "123", "", "");
+    userRepository.save(user);
+
+    UpdateUserParam param =
+        UpdateUserParam.builder()
+            .email("updated@example.com")
+            .username("updateduser")
+            .bio("updated bio")
+            .build();
+
+    userService.updateUser(new UpdateUserCommand(user, param));
+
+    Optional<User> fetched = userRepository.findById(user.getId());
+    Assertions.assertTrue(fetched.isPresent());
+    User saved = fetched.get();
+    Assertions.assertEquals("updated@example.com", saved.getEmail());
+    Assertions.assertEquals("updateduser", saved.getUsername());
+    Assertions.assertEquals("updated bio", saved.getBio());
+  }
+
+  @Test
+  public void should_allow_update_user_with_own_unchanged_email_and_username() {
+    User user = new User("self@example.com", "selfuser", "123", "", "");
+    userRepository.save(user);
+
+    UpdateUserParam param =
+        UpdateUserParam.builder()
+            .email("self@example.com")
+            .username("selfuser")
+            .bio("new bio")
+            .build();
+
+    userService.updateUser(new UpdateUserCommand(user, param));
+
+    Optional<User> fetched = userRepository.findById(user.getId());
+    Assertions.assertTrue(fetched.isPresent());
+    Assertions.assertEquals("new bio", fetched.get().getBio());
+  }
+
+  @Test
+  public void should_reject_update_when_email_used_by_another_user() {
+    User target = new User("target@example.com", "targetuser", "123", "", "");
+    userRepository.save(target);
+    User other = new User("other@example.com", "otheruser", "123", "", "");
+    userRepository.save(other);
+
+    UpdateUserParam param =
+        UpdateUserParam.builder().email("other@example.com").username("targetuser").build();
+
+    Assertions.assertThrows(
+        ConstraintViolationException.class,
+        () -> userService.updateUser(new UpdateUserCommand(target, param)));
+  }
+
+  @Test
+  public void should_reject_update_when_username_used_by_another_user() {
+    User target = new User("target2@example.com", "targetuser2", "123", "", "");
+    userRepository.save(target);
+    User other = new User("other2@example.com", "otheruser2", "123", "", "");
+    userRepository.save(other);
+
+    UpdateUserParam param =
+        UpdateUserParam.builder().email("target2@example.com").username("otheruser2").build();
+
+    Assertions.assertThrows(
+        ConstraintViolationException.class,
+        () -> userService.updateUser(new UpdateUserCommand(target, param)));
+  }
+}

--- a/src/test/java/io/spring/infrastructure/DbTestBase.java
+++ b/src/test/java/io/spring/infrastructure/DbTestBase.java
@@ -1,5 +1,9 @@
 package io.spring.infrastructure;
 
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
@@ -8,4 +12,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @MybatisTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public abstract class DbTestBase {}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
Adds direct, DB-backed tests for the write/command-side services under `io.spring.application`, which previously had **no service-level tests** (existing `io.spring.application` tests only cover the read `*QueryService` classes). Both new classes extend `io.spring.infrastructure.DbTestBase` so they inherit `@Execution(SAME_THREAD)` + `@ResourceLock("DB")` and run serially with the other DB tests — no new parallel annotations added.

Stacked on #785 (`devin/1783646746-jacoco-parallel-tests`, which adds JaCoCo + parallel config + the `DbTestBase` lock); **#785 must merge first**. Only new test files are added — no production code, `build.gradle`, `junit-platform.properties`, `DbTestBase`, or existing tests were touched.

New tests (8 total):
- `ArticleCommandServiceTest` (3): `createArticle` persists + slug/tags fetched back via repo; `updateArticle` persists changes; duplicate title rejected with `ConstraintViolationException` (drives the `@Validated` method-validation path).
- `UserServiceTest` (5): `createUser` persists with BCrypt-encoded password (`passwordEncoder.matches(...)`) and default image; `updateUser` happy path; `updateUser` allowed when re-using the user's own email/username; and the package-private `UpdateUserValidator` rejecting an email/username already owned by a **different** user (two cases → `ConstraintViolationException`).

Wiring follows `ArticleQueryServiceTest`: `@Import` the service under test + the MyBatis repositories, `@Autowired` the repos. To exercise the `@Validated` service methods (and thereby the constraint validators, which `@Autowired` their repositories), each test also `@Import`s `ValidationAutoConfiguration.class` (same approach as `CurrentUserApiTest`). `UserServiceTest` supplies `PasswordEncoder` via `@Import(BCryptPasswordEncoder.class)` (as in `UsersApiTest`) and `image.default` via `@TestPropertySource`.

## Coverage note
The two touched services were **already at 100% instruction & branch coverage** (indirectly, through the API-/GraphQL-layer tests such as `ArticlesApiTest`, `CurrentUserApiTest`), so the JaCoCo numbers are unchanged: `ArticleCommandService` 40/40 instr, `UserService` 57/57 instr, `UpdateUserValidator` 78/78 — before and after. The value here is **direct command-service-level coverage** in the `io.spring.application` package (not reliant on the web/GraphQL layer), matching the read-side `*QueryServiceTest` pattern. No missing favorites/follow command-service coverage was found — those flows are exercised only through repositories, already covered by the `MyBatis*RepositoryTest` classes, so none were duplicated.

## Verification
`./gradlew clean test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` run repeatedly — **green every time**, no DB-locking/flakiness under the parallel config. Full suite: 76 tests, 0 failures, 0 errors (8 new).


Link to Devin session: https://app.devin.ai/sessions/d8c867dd84104871a79cf839f24d17ec
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/789?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->