### PR TITLE
Add first unit tests for the GraphQL layer (io.spring.graphql)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -56,8 +57,31 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.0
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/RealworldApplicationTests.java
+++ b/src/test/java/io/spring/RealworldApplicationTests.java
@@ -1,9 +1,15 @@
 package io.spring;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public class RealworldApplicationTests {
 
   @Test

--- a/src/test/java/io/spring/api/TestWithCurrentUser.java
+++ b/src/test/java/io/spring/api/TestWithCurrentUser.java
@@ -10,8 +10,11 @@ import io.spring.core.user.UserRepository;
 import io.spring.infrastructure.mybatis.readservice.UserReadService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 abstract class TestWithCurrentUser {
   @MockBean protected UserRepository userRepository;
 

--- a/src/test/java/io/spring/api/UsersApiTest.java
+++ b/src/test/java/io/spring/api/UsersApiTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,6 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
   BCryptPasswordEncoder.class,
   JacksonCustomizations.class
 })
+@ResourceLock(value = "MOCKMVC", mode = ResourceAccessMode.READ_WRITE)
 public class UsersApiTest {
   @Autowired private MockMvc mvc;
 

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,218 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.ArticlesConnection;
+import io.spring.graphql.types.Profile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleDatafetcherTest extends GraphQLTestBase {
+
+  @Mock private ArticleQueryService articleQueryService;
+  @Mock private UserRepository userRepository;
+
+  private ArticleDatafetcher articleDatafetcher;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    articleDatafetcher = new ArticleDatafetcher(articleQueryService, userRepository);
+    user = newUser();
+  }
+
+  private CursorPager<ArticleData> onePage() {
+    return new CursorPager<>(
+        Collections.singletonList(articleData("a1", "a-slug", "johnjacob")),
+        Direction.NEXT,
+        false);
+  }
+
+  @Test
+  void should_get_feed_forward_with_first() {
+    setCurrentUser(user);
+    when(articleQueryService.findUserFeedWithCursor(
+            any(User.class), any(CursorPageParameter.class)))
+        .thenReturn(onePage());
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(10, null, null, null, null);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+    assertThat(result.getData().getEdges().get(0).getNode().getSlug()).isEqualTo("a-slug");
+  }
+
+  @Test
+  void should_get_feed_backward_with_last() {
+    setCurrentUser(user);
+    when(articleQueryService.findUserFeedWithCursor(any(), any(CursorPageParameter.class)))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.PREV, false));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(null, null, 10, "123", null);
+
+    assertThat(result.getData().getEdges()).isEmpty();
+  }
+
+  @Test
+  void should_throw_when_neither_first_nor_last_provided() {
+    assertThatThrownBy(() -> articleDatafetcher.getFeed(null, null, null, null, null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void should_get_user_feed_by_profile() {
+    DataFetchingEnvironment dfe = mockEnv();
+    when(dfe.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
+    when(articleQueryService.findUserFeedWithCursor(any(), any(CursorPageParameter.class)))
+        .thenReturn(onePage());
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userFeed(5, null, null, null, dgs(dfe));
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_throw_when_user_feed_target_missing() {
+    DataFetchingEnvironment dfe = mockEnv();
+    when(dfe.getSource()).thenReturn(Profile.newBuilder().username("ghost").build());
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> articleDatafetcher.userFeed(5, null, null, null, dgs(dfe)))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_get_user_favorites_forward_and_backward() {
+    setCurrentUser(user);
+    DataFetchingEnvironment dfe = mockEnv();
+    when(dfe.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            any(), any(), any(), any(CursorPageParameter.class), any()))
+        .thenReturn(onePage());
+
+    DataFetcherResult<ArticlesConnection> forward =
+        articleDatafetcher.userFavorites(5, null, null, null, dgs(dfe));
+    DataFetcherResult<ArticlesConnection> backward =
+        articleDatafetcher.userFavorites(null, null, 5, "123", dgs(dfe));
+
+    assertThat(forward.getData().getEdges()).hasSize(1);
+    assertThat(backward.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_get_user_articles() {
+    setCurrentUser(user);
+    DataFetchingEnvironment dfe = mockEnv();
+    when(dfe.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            any(), any(), any(), any(CursorPageParameter.class), any()))
+        .thenReturn(onePage());
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userArticles(5, null, null, null, dgs(dfe));
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_get_articles_with_filters() {
+    setCurrentUser(user);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            any(), any(), any(), any(CursorPageParameter.class), any()))
+        .thenReturn(onePage());
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getArticles(5, null, null, null, "authored", "favorited", "tag", null);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_get_article_from_local_context() {
+    setCurrentUser(user);
+    DataFetchingEnvironment dfe = mockEnv();
+    io.spring.core.article.Article coreArticle =
+        new io.spring.core.article.Article("title", "desc", "body", Arrays.asList("t"), user.getId());
+    when(dfe.getLocalContext()).thenReturn(coreArticle);
+    when(articleQueryService.findById(eq(coreArticle.getId()), any()))
+        .thenReturn(Optional.of(articleData(coreArticle.getId(), "the-slug", "johnjacob")));
+
+    DataFetcherResult<Article> result = articleDatafetcher.getArticle(dfe);
+
+    assertThat(result.getData().getSlug()).isEqualTo("the-slug");
+  }
+
+  @Test
+  void should_throw_when_article_by_local_context_missing() {
+    setCurrentUser(user);
+    DataFetchingEnvironment dfe = mockEnv();
+    io.spring.core.article.Article coreArticle =
+        new io.spring.core.article.Article("title", "desc", "body", Arrays.asList("t"), user.getId());
+    when(dfe.getLocalContext()).thenReturn(coreArticle);
+    when(articleQueryService.findById(eq(coreArticle.getId()), any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> articleDatafetcher.getArticle(dfe))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_get_comment_article() {
+    setCurrentUser(user);
+    DataFetchingEnvironment dfe = mockEnv();
+    CommentData comment = commentData("c1", "article-42", "johnjacob");
+    when(dfe.getLocalContext()).thenReturn(comment);
+    when(articleQueryService.findById(eq("article-42"), any()))
+        .thenReturn(Optional.of(articleData("article-42", "art-slug", "johnjacob")));
+
+    DataFetcherResult<Article> result = articleDatafetcher.getCommentArticle(dfe);
+
+    assertThat(result.getData().getSlug()).isEqualTo("art-slug");
+  }
+
+  @Test
+  void should_find_article_by_slug() {
+    setCurrentUser(user);
+    when(articleQueryService.findBySlug(eq("art-slug"), any()))
+        .thenReturn(Optional.of(articleData("a1", "art-slug", "johnjacob")));
+
+    DataFetcherResult<Article> result = articleDatafetcher.findArticleBySlug("art-slug");
+
+    assertThat(result.getData().getSlug()).isEqualTo("art-slug");
+    assertThat(result.getData().getTitle()).isEqualTo("a title");
+  }
+
+  @Test
+  void should_throw_when_find_article_by_slug_missing() {
+    setCurrentUser(user);
+    when(articleQueryService.findBySlug(eq("missing"), any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> articleDatafetcher.findArticleBySlug("missing"))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,202 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ArticlePayload;
+import io.spring.graphql.types.CreateArticleInput;
+import io.spring.graphql.types.DeletionStatus;
+import io.spring.graphql.types.UpdateArticleInput;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleMutationTest extends GraphQLTestBase {
+
+  @Mock private ArticleCommandService articleCommandService;
+  @Mock private ArticleFavoriteRepository articleFavoriteRepository;
+  @Mock private ArticleRepository articleRepository;
+
+  private ArticleMutation articleMutation;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    articleMutation =
+        new ArticleMutation(articleCommandService, articleFavoriteRepository, articleRepository);
+    user = newUser();
+  }
+
+  private Article ownedArticle() {
+    return new Article("title", "desc", "body", Arrays.asList("t"), user.getId());
+  }
+
+  @Test
+  void should_create_article() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleCommandService.createArticle(any(), eq(user))).thenReturn(article);
+
+    DataFetcherResult<ArticlePayload> result =
+        articleMutation.createArticle(
+            CreateArticleInput.newBuilder()
+                .title("title")
+                .description("desc")
+                .body("body")
+                .tagList(Arrays.asList("t"))
+                .build());
+
+    assertThat(result.getLocalContext()).isSameAs(article);
+  }
+
+  @Test
+  void should_create_article_with_null_tag_list() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleCommandService.createArticle(any(), eq(user))).thenReturn(article);
+
+    DataFetcherResult<ArticlePayload> result =
+        articleMutation.createArticle(
+            CreateArticleInput.newBuilder().title("title").description("desc").body("body").build());
+
+    assertThat(result.getLocalContext()).isSameAs(article);
+  }
+
+  @Test
+  void should_throw_when_create_article_unauthenticated() {
+    setAnonymous();
+    assertThatThrownBy(
+            () ->
+                articleMutation.createArticle(
+                    CreateArticleInput.newBuilder().title("t").description("d").body("b").build()))
+        .isInstanceOf(AuthenticationException.class);
+  }
+
+  @Test
+  void should_update_article() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any())).thenReturn(article);
+
+    DataFetcherResult<ArticlePayload> result =
+        articleMutation.updateArticle(
+            "slug", UpdateArticleInput.newBuilder().title("new").body("b").description("d").build());
+
+    assertThat(result.getLocalContext()).isSameAs(article);
+  }
+
+  @Test
+  void should_throw_when_update_article_missing() {
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                articleMutation.updateArticle(
+                    "slug", UpdateArticleInput.newBuilder().build()))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_throw_when_update_article_not_author() {
+    setCurrentUser(user);
+    Article othersArticle = new Article("t", "d", "b", Arrays.asList("x"), "another-user");
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(othersArticle));
+
+    assertThatThrownBy(
+            () ->
+                articleMutation.updateArticle(
+                    "slug", UpdateArticleInput.newBuilder().build()))
+        .isInstanceOf(NoAuthorizationException.class);
+  }
+
+  @Test
+  void should_favorite_article() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+
+    articleMutation.favoriteArticle("slug");
+
+    verify(articleFavoriteRepository).save(any(ArticleFavorite.class));
+  }
+
+  @Test
+  void should_throw_when_favorite_article_missing() {
+    setCurrentUser(user);
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> articleMutation.favoriteArticle("slug"))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_unfavorite_article_when_favorite_present() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), user.getId());
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.of(favorite));
+
+    articleMutation.unfavoriteArticle("slug");
+
+    verify(articleFavoriteRepository).remove(favorite);
+  }
+
+  @Test
+  void should_not_remove_when_unfavorite_without_existing_favorite() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.empty());
+
+    articleMutation.unfavoriteArticle("slug");
+
+    verify(articleFavoriteRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_delete_article() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+
+    DeletionStatus status = articleMutation.deleteArticle("slug");
+
+    assertThat(status.getSuccess()).isTrue();
+    verify(articleRepository).remove(article);
+  }
+
+  @Test
+  void should_throw_when_delete_article_not_author() {
+    setCurrentUser(user);
+    Article othersArticle = new Article("t", "d", "b", Arrays.asList("x"), "another-user");
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(othersArticle));
+
+    assertThatThrownBy(() -> articleMutation.deleteArticle("slug"))
+        .isInstanceOf(NoAuthorizationException.class);
+    verify(articleRepository, never()).remove(any());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,105 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.CommentsConnection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentDatafetcherTest extends GraphQLTestBase {
+
+  @Mock private CommentQueryService commentQueryService;
+
+  private CommentDatafetcher commentDatafetcher;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    commentDatafetcher = new CommentDatafetcher(commentQueryService);
+    user = newUser();
+  }
+
+  @Test
+  void should_get_comment_from_local_context() {
+    DataFetchingEnvironment dfe = mockEnv();
+    when(dfe.getLocalContext()).thenReturn(commentData("c1", "art1", "johnjacob"));
+
+    DataFetcherResult<Comment> result = commentDatafetcher.getComment(dgs(dfe));
+
+    assertThat(result.getData().getId()).isEqualTo("c1");
+    assertThat(result.getData().getBody()).isEqualTo("a comment body");
+  }
+
+  @Test
+  void should_get_article_comments_forward() {
+    setCurrentUser(user);
+    DataFetchingEnvironment dfe = mockEnv();
+    Article article = Article.newBuilder().slug("art-slug").build();
+    Map<String, ArticleData> localContext = new HashMap<>();
+    localContext.put("art-slug", articleData("art1", "art-slug", "johnjacob"));
+    when(dfe.getSource()).thenReturn(article);
+    when(dfe.getLocalContext()).thenReturn(localContext);
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq("art1"), any(), any(CursorPageParameter.class)))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(commentData("c1", "art1", "johnjacob")),
+                Direction.NEXT,
+                false));
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(10, null, null, null, dgs(dfe));
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+    assertThat(result.getData().getEdges().get(0).getNode().getId()).isEqualTo("c1");
+  }
+
+  @Test
+  void should_get_article_comments_backward() {
+    setCurrentUser(user);
+    DataFetchingEnvironment dfe = mockEnv();
+    Article article = Article.newBuilder().slug("art-slug").build();
+    Map<String, ArticleData> localContext = new HashMap<>();
+    localContext.put("art-slug", articleData("art1", "art-slug", "johnjacob"));
+    when(dfe.getSource()).thenReturn(article);
+    when(dfe.getLocalContext()).thenReturn(localContext);
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq("art1"), any(), any(CursorPageParameter.class)))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.PREV, false));
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(null, null, 10, "123", dgs(dfe));
+
+    assertThat(result.getData().getEdges()).isEmpty();
+  }
+
+  @Test
+  void should_throw_when_neither_first_nor_last_provided() {
+    DataFetchingEnvironment dfe = mockEnv();
+    assertThatThrownBy(
+            () -> commentDatafetcher.articleComments(null, null, null, null, dgs(dfe)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,148 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.CommentQueryService;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.CommentPayload;
+import io.spring.graphql.types.DeletionStatus;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentMutationTest extends GraphQLTestBase {
+
+  @Mock private ArticleRepository articleRepository;
+  @Mock private CommentRepository commentRepository;
+  @Mock private CommentQueryService commentQueryService;
+
+  private CommentMutation commentMutation;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    commentMutation = new CommentMutation(articleRepository, commentRepository, commentQueryService);
+    user = newUser();
+  }
+
+  private Article ownedArticle() {
+    return new Article("title", "desc", "body", Arrays.asList("t"), user.getId());
+  }
+
+  @Test
+  void should_create_comment() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(user)))
+        .thenReturn(Optional.of(commentData("c1", article.getId(), "johnjacob")));
+
+    DataFetcherResult<CommentPayload> result = commentMutation.createComment("slug", "hi");
+
+    assertThat(((io.spring.application.data.CommentData) result.getLocalContext()).getId())
+        .isEqualTo("c1");
+    verify(commentRepository).save(any(Comment.class));
+  }
+
+  @Test
+  void should_throw_when_create_comment_unauthenticated() {
+    setAnonymous();
+    assertThatThrownBy(() -> commentMutation.createComment("slug", "hi"))
+        .isInstanceOf(AuthenticationException.class);
+  }
+
+  @Test
+  void should_throw_when_create_comment_article_missing() {
+    setCurrentUser(user);
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> commentMutation.createComment("slug", "hi"))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_throw_when_created_comment_not_found_afterwards() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(user))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> commentMutation.createComment("slug", "hi"))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_remove_comment() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    Comment comment = new Comment("body", user.getId(), article.getId());
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    DeletionStatus status = commentMutation.removeComment("slug", comment.getId());
+
+    assertThat(status.getSuccess()).isTrue();
+    verify(commentRepository).remove(comment);
+  }
+
+  @Test
+  void should_throw_when_remove_comment_unauthenticated() {
+    setAnonymous();
+    assertThatThrownBy(() -> commentMutation.removeComment("slug", "c1"))
+        .isInstanceOf(AuthenticationException.class);
+  }
+
+  @Test
+  void should_throw_when_remove_comment_article_missing() {
+    setCurrentUser(user);
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> commentMutation.removeComment("slug", "c1"))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_throw_when_remove_comment_missing() {
+    setCurrentUser(user);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq("c1"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> commentMutation.removeComment("slug", "c1"))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_throw_when_remove_comment_not_authorized() {
+    setCurrentUser(user);
+    Article article = new Article("title", "desc", "body", Arrays.asList("t"), "another-user");
+    Comment comment = new Comment("body", "someone-else", article.getId());
+    when(articleRepository.findBySlug(eq("slug"))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    assertThatThrownBy(() -> commentMutation.removeComment("slug", comment.getId()))
+        .isInstanceOf(NoAuthorizationException.class);
+    verify(commentRepository, never()).remove(any());
+  }
+}

--- a/src/test/java/io/spring/graphql/GraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphQLTestBase.java
@@ -1,0 +1,81 @@
+package io.spring.graphql;
+
+import static org.mockito.Mockito.mock;
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Collections;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Shared fixtures and Spring-Security context helpers for the pure-Mockito GraphQL layer tests.
+ * These tests never touch the database or a DGS context, so they are parallel-safe.
+ */
+abstract class GraphQLTestBase {
+
+  protected User newUser() {
+    return new User("john@jacob.com", "johnjacob", "123", "bio", "avatar.png");
+  }
+
+  protected void setCurrentUser(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  /** Mimics Spring Security's anonymous authentication when there is no logged-in user. */
+  protected void setAnonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymous", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  /** DGS wraps a plain {@link DataFetchingEnvironment}; mock the inner one and stub it. */
+  protected DataFetchingEnvironment mockEnv() {
+    return mock(DataFetchingEnvironment.class);
+  }
+
+  protected DgsDataFetchingEnvironment dgs(DataFetchingEnvironment dfe) {
+    return new DgsDataFetchingEnvironment(dfe);
+  }
+
+  protected ProfileData profileData(String username) {
+    return new ProfileData("profile-id", username, "some bio", "image.png", false);
+  }
+
+  protected ArticleData articleData(String id, String slug, String authorUsername) {
+    return new ArticleData(
+        id,
+        slug,
+        "a title",
+        "a description",
+        "a body",
+        false,
+        0,
+        new DateTime(),
+        new DateTime(),
+        Arrays.asList("java", "spring"),
+        profileData(authorUsername));
+  }
+
+  protected CommentData commentData(String id, String articleId, String authorUsername) {
+    return new CommentData(
+        id, "a comment body", articleId, new DateTime(), new DateTime(), profileData(authorUsername));
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,96 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class MeDatafetcherTest extends GraphQLTestBase {
+
+  @Mock private UserQueryService userQueryService;
+  @Mock private JwtService jwtService;
+
+  private MeDatafetcher meDatafetcher;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    meDatafetcher = new MeDatafetcher(userQueryService, jwtService);
+    user = newUser();
+  }
+
+  @Test
+  void should_get_me_when_authenticated() {
+    setCurrentUser(user);
+    when(userQueryService.findById(eq(user.getId())))
+        .thenReturn(
+            Optional.of(new UserData(user.getId(), "john@jacob.com", "johnjacob", "", "avatar")));
+
+    DataFetcherResult<io.spring.graphql.types.User> result =
+        meDatafetcher.getMe("Token jwt-abc", mockEnv());
+
+    assertThat(result.getData().getUsername()).isEqualTo("johnjacob");
+    assertThat(result.getData().getEmail()).isEqualTo("john@jacob.com");
+    assertThat(result.getData().getToken()).isEqualTo("jwt-abc");
+  }
+
+  @Test
+  void should_return_null_when_anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymous", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    assertThat(meDatafetcher.getMe("Token jwt-abc", mockEnv())).isNull();
+  }
+
+  @Test
+  void should_return_null_when_principal_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertThat(meDatafetcher.getMe("Token jwt-abc", mockEnv())).isNull();
+  }
+
+  @Test
+  void should_throw_when_user_not_found() {
+    setCurrentUser(user);
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> meDatafetcher.getMe("Token jwt-abc", mockEnv()))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_get_user_payload_user_from_local_context() {
+    DataFetchingEnvironment dfe = mockEnv();
+    when(dfe.getLocalContext()).thenReturn(user);
+    when(jwtService.toToken(any(User.class))).thenReturn("generated-token");
+
+    DataFetcherResult<io.spring.graphql.types.User> result =
+        meDatafetcher.getUserPayloadUser(dfe);
+
+    assertThat(result.getData().getUsername()).isEqualTo("johnjacob");
+    assertThat(result.getData().getToken()).isEqualTo("generated-token");
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,109 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.Profile;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileDatafetcherTest extends GraphQLTestBase {
+
+  @Mock private ProfileQueryService profileQueryService;
+
+  private ProfileDatafetcher profileDatafetcher;
+
+  @BeforeEach
+  void setUp() {
+    profileDatafetcher = new ProfileDatafetcher(profileQueryService);
+    setAnonymous();
+  }
+
+  @Test
+  void should_get_user_profile_from_local_context() {
+    DataFetchingEnvironment dfe = mockEnv();
+    User user = newUser();
+    when(dfe.getLocalContext()).thenReturn(user);
+    when(profileQueryService.findByUsername(eq("johnjacob"), any()))
+        .thenReturn(Optional.of(profileData("johnjacob")));
+
+    Profile profile = profileDatafetcher.getUserProfile(dfe);
+
+    assertThat(profile.getUsername()).isEqualTo("johnjacob");
+    assertThat(profile.getBio()).isEqualTo("some bio");
+  }
+
+  @Test
+  void should_throw_when_profile_missing() {
+    DataFetchingEnvironment dfe = mockEnv();
+    User user = newUser();
+    when(dfe.getLocalContext()).thenReturn(user);
+    when(profileQueryService.findByUsername(eq("johnjacob"), any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> profileDatafetcher.getUserProfile(dfe))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_get_article_author() {
+    DataFetchingEnvironment dfe = mockEnv();
+    Article article = Article.newBuilder().slug("art-slug").build();
+    Map<String, ArticleData> map = new HashMap<>();
+    map.put("art-slug", articleData("a1", "art-slug", "authorname"));
+    when(dfe.getSource()).thenReturn(article);
+    when(dfe.getLocalContext()).thenReturn(map);
+    when(profileQueryService.findByUsername(eq("authorname"), any()))
+        .thenReturn(Optional.of(profileData("authorname")));
+
+    Profile profile = profileDatafetcher.getAuthor(dfe);
+
+    assertThat(profile.getUsername()).isEqualTo("authorname");
+  }
+
+  @Test
+  void should_get_comment_author() {
+    DataFetchingEnvironment dfe = mockEnv();
+    Comment comment = Comment.newBuilder().id("c1").build();
+    Map<String, CommentData> map = new HashMap<>();
+    map.put("c1", commentData("c1", "art1", "commenter"));
+    when(dfe.getSource()).thenReturn(comment);
+    when(dfe.getLocalContext()).thenReturn(map);
+    when(profileQueryService.findByUsername(eq("commenter"), any()))
+        .thenReturn(Optional.of(profileData("commenter")));
+
+    Profile profile = profileDatafetcher.getCommentAuthor(dfe);
+
+    assertThat(profile.getUsername()).isEqualTo("commenter");
+  }
+
+  @Test
+  void should_query_profile_by_argument() {
+    DataFetchingEnvironment dfe = mockEnv();
+    when(dfe.getArgument("username")).thenReturn("johnjacob");
+    when(profileQueryService.findByUsername(eq("johnjacob"), any()))
+        .thenReturn(Optional.of(profileData("johnjacob")));
+
+    ProfilePayload payload = profileDatafetcher.queryProfile("johnjacob", dfe);
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo("johnjacob");
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,115 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RelationMutationTest extends GraphQLTestBase {
+
+  @Mock private UserRepository userRepository;
+  @Mock private ProfileQueryService profileQueryService;
+
+  private RelationMutation relationMutation;
+  private User user;
+  private User target;
+
+  @BeforeEach
+  void setUp() {
+    relationMutation = new RelationMutation(userRepository, profileQueryService);
+    user = newUser();
+    target = new User("target@test.com", "target", "123", "", "");
+  }
+
+  @Test
+  void should_follow_user() {
+    setCurrentUser(user);
+    when(userRepository.findByUsername(eq("target"))).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername(eq("target"), any()))
+        .thenReturn(Optional.of(profileData("target")));
+
+    ProfilePayload payload = relationMutation.follow("target");
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo("target");
+    verify(userRepository).saveRelation(any(FollowRelation.class));
+  }
+
+  @Test
+  void should_throw_when_follow_unauthenticated() {
+    setAnonymous();
+    assertThatThrownBy(() -> relationMutation.follow("target"))
+        .isInstanceOf(AuthenticationException.class);
+  }
+
+  @Test
+  void should_throw_when_follow_target_missing() {
+    setCurrentUser(user);
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> relationMutation.follow("ghost"))
+        .isInstanceOf(ResourceNotFoundException.class);
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  void should_unfollow_user() {
+    setCurrentUser(user);
+    FollowRelation relation = new FollowRelation(user.getId(), target.getId());
+    when(userRepository.findByUsername(eq("target"))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername(eq("target"), any()))
+        .thenReturn(Optional.of(profileData("target")));
+
+    ProfilePayload payload = relationMutation.unfollow("target");
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo("target");
+    verify(userRepository).removeRelation(relation);
+  }
+
+  @Test
+  void should_throw_when_unfollow_unauthenticated() {
+    setAnonymous();
+    assertThatThrownBy(() -> relationMutation.unfollow("target"))
+        .isInstanceOf(AuthenticationException.class);
+  }
+
+  @Test
+  void should_throw_when_unfollow_target_missing() {
+    setCurrentUser(user);
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> relationMutation.unfollow("ghost"))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void should_throw_when_unfollow_relation_missing() {
+    setCurrentUser(user);
+    when(userRepository.findByUsername(eq("target"))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> relationMutation.unfollow("target"))
+        .isInstanceOf(ResourceNotFoundException.class);
+    verify(userRepository, never()).removeRelation(any());
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,52 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class SecurityUtilTest {
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void should_return_current_user_when_authenticated() {
+    User user = new User("email@test.com", "user", "123", "", "");
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+
+    Optional<User> current = SecurityUtil.getCurrentUser();
+
+    assertThat(current).isPresent();
+    assertThat(current.get()).isSameAs(user);
+  }
+
+  @Test
+  void should_return_empty_when_anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymous", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  void should_return_empty_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,43 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TagDatafetcherTest {
+
+  @Mock private TagsQueryService tagsQueryService;
+
+  private TagDatafetcher tagDatafetcher;
+
+  @BeforeEach
+  void setUp() {
+    tagDatafetcher = new TagDatafetcher(tagsQueryService);
+  }
+
+  @Test
+  void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
+
+    List<String> tags = tagDatafetcher.getTags();
+
+    assertThat(tags).containsExactly("java", "spring");
+  }
+
+  @Test
+  void should_return_empty_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    assertThat(tagDatafetcher.getTags()).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,142 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.application.user.UserService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.CreateUserInput;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.UpdateUserInput;
+import io.spring.graphql.types.UserPayload;
+import io.spring.graphql.types.UserResult;
+import java.util.Collections;
+import java.util.Optional;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserMutationTest extends GraphQLTestBase {
+
+  @Mock private UserRepository userRepository;
+  @Mock private PasswordEncoder encryptService;
+  @Mock private UserService userService;
+
+  private UserMutation userMutation;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    userMutation = new UserMutation(userRepository, encryptService, userService);
+    user = newUser();
+  }
+
+  @Test
+  void should_create_user() {
+    when(userService.createUser(any())).thenReturn(user);
+
+    DataFetcherResult<UserResult> result =
+        userMutation.createUser(
+            CreateUserInput.newBuilder()
+                .email("john@jacob.com")
+                .username("johnjacob")
+                .password("123")
+                .build());
+
+    assertThat(result.getData()).isInstanceOf(UserPayload.class);
+    assertThat(result.getLocalContext()).isSameAs(user);
+  }
+
+  @Test
+  void should_return_error_data_when_create_user_invalid() {
+    when(userService.createUser(any()))
+        .thenThrow(new ConstraintViolationException("invalid", Collections.emptySet()));
+
+    DataFetcherResult<UserResult> result =
+        userMutation.createUser(
+            CreateUserInput.newBuilder().email("bad").username("u").password("p").build());
+
+    assertThat(result.getData()).isInstanceOf(Error.class);
+    assertThat(((Error) result.getData()).getMessage()).isEqualTo("BAD_REQUEST");
+  }
+
+  @Test
+  void should_login_with_valid_credentials() {
+    when(userRepository.findByEmail(eq("john@jacob.com"))).thenReturn(Optional.of(user));
+    when(encryptService.matches(eq("123"), eq(user.getPassword()))).thenReturn(true);
+
+    DataFetcherResult<UserPayload> result = userMutation.login("123", "john@jacob.com");
+
+    assertThat(result.getLocalContext()).isSameAs(user);
+  }
+
+  @Test
+  void should_throw_when_login_email_unknown() {
+    when(userRepository.findByEmail(eq("nobody@test.com"))).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> userMutation.login("123", "nobody@test.com"))
+        .isInstanceOf(InvalidAuthenticationException.class);
+  }
+
+  @Test
+  void should_throw_when_login_password_wrong() {
+    when(userRepository.findByEmail(eq("john@jacob.com"))).thenReturn(Optional.of(user));
+    when(encryptService.matches(eq("wrong"), eq(user.getPassword()))).thenReturn(false);
+
+    assertThatThrownBy(() -> userMutation.login("wrong", "john@jacob.com"))
+        .isInstanceOf(InvalidAuthenticationException.class);
+  }
+
+  @Test
+  void should_update_user() {
+    setCurrentUser(user);
+
+    DataFetcherResult<UserPayload> result =
+        userMutation.updateUser(
+            UpdateUserInput.newBuilder()
+                .email("new@test.com")
+                .username("newname")
+                .bio("bio")
+                .password("pw")
+                .image("img")
+                .build());
+
+    assertThat(result.getLocalContext()).isSameAs(user);
+    verify(userService).updateUser(any(UpdateUserCommand.class));
+  }
+
+  @Test
+  void should_return_null_when_update_user_anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymous", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    assertThat(userMutation.updateUser(UpdateUserInput.newBuilder().build())).isNull();
+  }
+
+  @Test
+  void should_return_null_when_update_user_principal_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertThat(userMutation.updateUser(UpdateUserInput.newBuilder().build())).isNull();
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/AuthenticationExceptionTest.java
+++ b/src/test/java/io/spring/graphql/exception/AuthenticationExceptionTest.java
@@ -1,0 +1,15 @@
+package io.spring.graphql.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthenticationExceptionTest {
+
+  @Test
+  void should_be_a_runtime_exception() {
+    AuthenticationException exception = new AuthenticationException();
+
+    assertThat(exception).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -1,0 +1,96 @@
+package io.spring.graphql.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.types.errors.ErrorType;
+import com.netflix.graphql.types.errors.TypedGraphQLError;
+import graphql.GraphQLError;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ResultPath;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.graphql.types.Error;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotBlank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GraphQLCustomizeExceptionHandlerTest {
+
+  private GraphQLCustomizeExceptionHandler handler;
+  private Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    handler = new GraphQLCustomizeExceptionHandler();
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  private DataFetcherExceptionHandlerParameters paramsWith(Throwable t) {
+    DataFetcherExceptionHandlerParameters params =
+        mock(DataFetcherExceptionHandlerParameters.class);
+    when(params.getException()).thenReturn(t);
+    when(params.getPath()).thenReturn(ResultPath.rootPath());
+    return params;
+  }
+
+  private Set<ConstraintViolation<Bean>> violations() {
+    Set<ConstraintViolation<Bean>> violations = validator.validate(new Bean());
+    assertThat(violations).isNotEmpty();
+    return violations;
+  }
+
+  private static class Bean {
+    @NotBlank(message = "can't be empty")
+    private String email = "";
+  }
+
+  @Test
+  void should_map_invalid_authentication_to_unauthenticated() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(paramsWith(new InvalidAuthenticationException()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error).isInstanceOf(TypedGraphQLError.class);
+    assertThat(error.getMessage()).isEqualTo("invalid email or password");
+    assertThat(error.toSpecification().toString()).contains(ErrorType.UNAUTHENTICATED.name());
+  }
+
+  @Test
+  void should_map_constraint_violation_to_bad_request() {
+    ConstraintViolationException cve = new ConstraintViolationException(violations());
+
+    DataFetcherExceptionHandlerResult result = handler.onException(paramsWith(cve));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getExtensions()).isNotEmpty();
+  }
+
+  @Test
+  void should_delegate_other_exceptions_to_default_handler() {
+    DataFetcherExceptionHandlerParameters params = mock(DataFetcherExceptionHandlerParameters.class);
+    when(params.getException()).thenReturn(new RuntimeException("boom"));
+    when(params.getPath()).thenReturn(ResultPath.rootPath());
+
+    DataFetcherExceptionHandlerResult result = handler.onException(params);
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_build_errors_as_data() {
+    ConstraintViolationException cve = new ConstraintViolationException(violations());
+
+    Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(cve);
+
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).isNotEmpty();
+  }
+}

--- a/src/test/java/io/spring/infrastructure/DbTestBase.java
+++ b/src/test/java/io/spring/infrastructure/DbTestBase.java
@@ -1,5 +1,9 @@
 package io.spring.infrastructure;
 
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
@@ -8,4 +12,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @MybatisTest
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "DB", mode = ResourceAccessMode.READ_WRITE)
 public abstract class DbTestBase {}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
Adds the **first** unit tests for the `io.spring.graphql` package (previously zero tests — the single largest coverage gap). All tests are pure Mockito, DB-free and DGS-context-free, so they run under the JUnit5 parallel config with no SQLite contention.

**Coverage (JaCoCo instruction, excluding generated `io.spring.graphql.types`):**

| package | before | after |
|---|---|---|
| `io.spring.graphql` | 4.73% | **91.59%** |
| `io.spring.graphql.exception` | 3.04% | **96.58%** |
| combined | 4.50% | **92.26%** |

**73 tests** added across 12 new test files under `src/test/java/io/spring/graphql/`. Full suite is green via `./gradlew clean test jacocoTestReport -x spotlessJava -x spotlessJavaCheck`.

> Stacked on #785 (`devin/1783646746-jacoco-parallel-tests`, adds JaCoCo + safe JUnit5 parallel execution), which should merge first. This branch is based on it; the diff against `master` will shrink once #785 lands.

## Approach
- Each datafetcher/mutation is instantiated directly with its collaborators mocked (`ArticleQueryService`, `CommentQueryService`, `ProfileQueryService`, `*Repository`, `UserService`, `JwtService`, `PasswordEncoder`, etc.).
- `SecurityUtil` reads the current user from `SecurityContextHolder`; a shared `GraphQLTestBase` sets the auth context per test and clears it in `@AfterEach`:
  ```java
  setCurrentUser(user);   // UsernamePasswordAuthenticationToken(user, ...)
  setAnonymous();         // AnonymousAuthenticationToken -> getCurrentUser() empty
  ```
  Note: `SecurityUtil.getCurrentUser()` NPEs when the context is completely empty, so the "unauthenticated" paths install an `AnonymousAuthenticationToken` (what Spring Security does in production) rather than leaving the context null.
- DGS's `DgsDataFetchingEnvironment` is `final`; instead of mocking it, tests mock the plain `DataFetchingEnvironment` and wrap it: `new DgsDataFetchingEnvironment(mock)`, since DGS delegates `getSource()/getLocalContext()/getArgument()` to the wrapped env.

## What's covered
- **ArticleDatafetcher**: feed / user feed / favorites / articles (forward + backward cursor pagination), article-by-slug, article-by-local-context, comment→article, and `ResourceNotFoundException` / `IllegalArgumentException` paths.
- **ArticleMutation / CommentMutation / RelationMutation / UserMutation**: create/update/delete/favorite/unfavorite/follow/unfollow/login, plus `AuthenticationException`, `NoAuthorizationException`, `ResourceNotFoundException`, `InvalidAuthenticationException` and constraint-violation branches.
- **CommentDatafetcher / MeDatafetcher / ProfileDatafetcher / TagDatafetcher**: happy paths, anonymous/null-principal returns, and not-found paths.
- **SecurityUtil**: authenticated / anonymous / null-principal.
- **exception package**: `GraphQLCustomizeExceptionHandler` (UNAUTHENTICATED mapping, constraint-violation → bad request, default-handler delegation, `getErrorsAsData`) and `AuthenticationException`.

## Pre-existing production observations (not fixed here — this PR is test-only)
- **`CommentDatafetcher.buildCommentResult` (bug):** `updatedAt` is populated from `comment.getCreatedAt()` instead of `comment.getUpdatedAt()`. Genuine bug; flagged rather than fixed to keep this PR scoped to tests. Fixing it needs a one-line production change plus a fixture with distinct timestamps.
- **`ProfileDatafetcher.queryProfile`:** ignores its `@InputArgument("username")` parameter and reads `dataFetchingEnvironment.getArgument("username")` instead, making the parameter redundant. Behavior preserved; cleanup left for a separate change.

## Constraints honored
- Only ADDs test files under `src/test/java/io/spring/graphql/`. No production code changed. `build.gradle`, `junit-platform.properties`, `DbTestBase`, `RealworldApplicationTests`, `TestWithCurrentUser` untouched.
- No `spotlessApply` (broken under JDK17); imports kept alphabetically ordered manually.
- No existing tests modified; no `RestAssuredMockMvc` / DB / DGS-context usage.

Link to Devin session: https://app.devin.ai/sessions/add4ed297359402c93781b9bf9dd69bf
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/790?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->