### PR TITLE
test: cover JwtTokenFilter and WebSecurityConfig

### DIFF
--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -1,6 +1,5 @@
 package io.spring.api.security;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -39,13 +38,14 @@ public class JwtTokenFilterTest {
   private MockHttpServletRequest request;
   private MockHttpServletResponse response;
   private MockFilterChain chain;
+  private AutoCloseable closeable;
 
   private User user;
   private final String token = "valid.jwt.token";
 
   @BeforeEach
   public void setUp() {
-    MockitoAnnotations.openMocks(this);
+    closeable = MockitoAnnotations.openMocks(this);
     filter = new JwtTokenFilter();
     ReflectionTestUtils.setField(filter, "jwtService", jwtService);
     ReflectionTestUtils.setField(filter, "userRepository", userRepository);
@@ -59,8 +59,9 @@ public class JwtTokenFilterTest {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws Exception {
     SecurityContextHolder.clearContext();
+    closeable.close();
   }
 
   private void doFilter() {

--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -119,7 +119,7 @@ public class JwtTokenFilterTest {
     doFilter();
 
     assertNull(currentAuthentication());
-    verify(userRepository, never()).findById(eq(user.getId()));
+    verifyNoInteractions(userRepository);
     assertNotNull(chain.getRequest());
   }
 

--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -1,0 +1,176 @@
+package io.spring.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class JwtTokenFilterTest {
+
+  @Mock private JwtService jwtService;
+  @Mock private UserRepository userRepository;
+
+  private JwtTokenFilter filter;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+  private MockFilterChain chain;
+
+  private User user;
+  private final String token = "valid.jwt.token";
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    filter = new JwtTokenFilter();
+    ReflectionTestUtils.setField(filter, "jwtService", jwtService);
+    ReflectionTestUtils.setField(filter, "userRepository", userRepository);
+
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+    chain = new MockFilterChain();
+
+    user = new User("email@example.com", "username", "123", "", "");
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void doFilter() {
+    ReflectionTestUtils.invokeMethod(filter, "doFilterInternal", request, response, chain);
+  }
+
+  private Authentication currentAuthentication() {
+    return SecurityContextHolder.getContext().getAuthentication();
+  }
+
+  @Test
+  public void should_populate_security_context_with_valid_token() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    doFilter();
+
+    Authentication authentication = currentAuthentication();
+    assertNotNull(authentication);
+    assertSame(user, authentication.getPrincipal());
+    assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+    assertTrue(authentication.getAuthorities().isEmpty());
+    assertTrue(authentication.getDetails() instanceof WebAuthenticationDetails);
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_header_missing() {
+    doFilter();
+
+    assertNull(currentAuthentication());
+    verifyNoInteractions(jwtService);
+    verifyNoInteractions(userRepository);
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_header_has_no_token_part() {
+    request.addHeader("Authorization", "Token");
+
+    doFilter();
+
+    assertNull(currentAuthentication());
+    verifyNoInteractions(jwtService);
+    verifyNoInteractions(userRepository);
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_token_is_invalid() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.empty());
+
+    doFilter();
+
+    assertNull(currentAuthentication());
+    verify(userRepository, never()).findById(eq(user.getId()));
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_authenticate_when_user_not_found() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.empty());
+
+    doFilter();
+
+    assertNull(currentAuthentication());
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_not_overwrite_existing_authentication() {
+    Authentication existing =
+        new UsernamePasswordAuthenticationToken("existing-principal", null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(existing);
+
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+
+    doFilter();
+
+    assertSame(existing, currentAuthentication());
+    verify(userRepository, never()).findById(eq(user.getId()));
+    assertNotNull(chain.getRequest());
+  }
+
+  @Test
+  public void should_extract_token_by_position_regardless_of_scheme() {
+    request.addHeader("Authorization", "Bearer " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    doFilter();
+
+    Authentication authentication = currentAuthentication();
+    assertNotNull(authentication);
+    assertSame(user, authentication.getPrincipal());
+  }
+
+  @Test
+  public void should_always_continue_filter_chain() {
+    request.addHeader("Authorization", "Token " + token);
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.empty());
+
+    doFilter();
+
+    assertSame(request, chain.getRequest());
+    assertSame(response, chain.getResponse());
+  }
+}

--- a/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
+++ b/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
@@ -1,0 +1,89 @@
+package io.spring.api.security;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class WebSecurityConfigTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private JwtService jwtService;
+
+  @MockBean private UserRepository userRepository;
+
+  private User user;
+  private final String token = "valid.jwt.token";
+
+  @BeforeEach
+  public void setUp() {
+    RestAssuredMockMvc.mockMvc(mvc);
+    user = new User("secconfig@example.com", "secconfig", "123", "", "");
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+  }
+
+  @Test
+  public void public_get_tags_is_accessible_without_authentication() {
+    given().contentType("application/json").when().get("/tags").then().statusCode(200);
+  }
+
+  @Test
+  public void public_get_articles_is_accessible_without_authentication() {
+    given().contentType("application/json").when().get("/articles").then().statusCode(200);
+  }
+
+  @Test
+  public void public_post_login_passes_security_layer() {
+    given()
+        .contentType("application/json")
+        .body("{\"user\":{\"email\":\"nobody@example.com\",\"password\":\"whatever\"}}")
+        .when()
+        .post("/users/login")
+        .then()
+        .statusCode(422);
+  }
+
+  @Test
+  public void options_requests_are_permitted() {
+    given().when().options("/articles/feed").then().statusCode(200);
+  }
+
+  @Test
+  public void protected_feed_requires_authentication() {
+    given().contentType("application/json").when().get("/articles/feed").then().statusCode(401);
+  }
+
+  @Test
+  public void protected_current_user_requires_authentication() {
+    given().contentType("application/json").when().get("/user").then().statusCode(401);
+  }
+
+  @Test
+  public void protected_feed_is_accessible_with_valid_token() {
+    given()
+        .header("Authorization", "Token " + token)
+        .contentType("application/json")
+        .when()
+        .get("/articles/feed")
+        .then()
+        .statusCode(200);
+  }
+}

--- a/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
+++ b/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
@@ -52,6 +52,8 @@ public class WebSecurityConfigTest {
 
   @Test
   public void public_post_login_passes_security_layer() {
+    // Endpoint is public, so the request reaches the controller and fails on unknown
+    // credentials (422) rather than being rejected by the security layer (401/403).
     given()
         .contentType("application/json")
         .body("{\"user\":{\"email\":\"nobody@example.com\",\"password\":\"whatever\"}}")


### PR DESCRIPTION
## Summary
Adds tests for the two security components under `io.spring.api.security`, taking both to 100% line coverage (JaCoCo). No main source changes.

**`JwtTokenFilterTest`** — unit test of the filter in isolation. Constructs `JwtTokenFilter` and injects mocked `JwtService` + `UserRepository` via `ReflectionTestUtils` (fields are `@Autowired` private), then drives `doFilterInternal` with `MockHttpServletRequest/Response` + `MockFilterChain`. Cases:
- valid `Authorization: Token <jwt>` → `SecurityContext` gets a `UsernamePasswordAuthenticationToken` whose principal is the loaded `User`, empty authorities, `WebAuthenticationDetails` set
- missing header / header with no token part (`"Token"`) → no auth, `jwtService`/`userRepository` untouched
- invalid token (`getSubFromToken` empty) / user not found (`findById` empty) → no auth
- pre-existing authentication is not overwritten
- token is extracted positionally, so a non-`Token` scheme (`Bearer <jwt>`) still authenticates — documents actual behavior
- filter chain always continues

**`WebSecurityConfigTest`** — `@SpringBootTest` + `@AutoConfigureMockMvc` (`@ActiveProfiles("test")`, in-memory SQLite) hitting representative endpoints via REST Assured MockMvc, with `JwtService`/`UserRepository` mocked to mint a valid identity:
- public: `GET /tags` 200, `GET /articles` 200, `OPTIONS /articles/feed` 200, `POST /users/login` reaches the controller (422, not 401)
- protected: `GET /articles/feed` and `GET /user` → 401 without a token; `GET /articles/feed` → 200 with a valid token


Link to Devin session: https://app.devin.ai/sessions/885c2ead51f040cc93ccdedfd1f183b8
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/792?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->