### PR TITLE
test: unit tests for application command/write services and validators

### DIFF
--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,87 @@
+package io.spring.application.article;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleCommandServiceTest {
+
+  @Mock private ArticleRepository articleRepository;
+
+  @InjectMocks private ArticleCommandService articleCommandService;
+
+  private User creator;
+
+  @BeforeEach
+  public void setUp() {
+    creator = new User("author@example.com", "author", "123", "", "");
+  }
+
+  @Test
+  public void should_create_article_from_param_and_save_it() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("a new title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(param, creator);
+
+    assertEquals("a new title", article.getTitle());
+    assertEquals("desc", article.getDescription());
+    assertEquals("body", article.getBody());
+    assertEquals("a-new-title", article.getSlug());
+    assertEquals(creator.getId(), article.getUserId());
+    assertEquals(2, article.getTags().size());
+
+    ArgumentCaptor<Article> captor = ArgumentCaptor.forClass(Article.class);
+    verify(articleRepository, times(1)).save(captor.capture());
+    assertSame(article, captor.getValue());
+  }
+
+  @Test
+  public void should_update_article_fields_and_save_it() {
+    Article article =
+        new Article("old title", "old desc", "old body", Arrays.asList("java"), creator.getId());
+    UpdateArticleParam param = new UpdateArticleParam("new title", "new body", "new desc");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertSame(article, updated);
+    assertEquals("new title", updated.getTitle());
+    assertEquals("new desc", updated.getDescription());
+    assertEquals("new body", updated.getBody());
+    assertEquals("new-title", updated.getSlug());
+    verify(articleRepository, times(1)).save(article);
+  }
+
+  @Test
+  public void should_keep_original_fields_when_update_param_is_empty() {
+    Article article =
+        new Article("old title", "old desc", "old body", Arrays.asList("java"), creator.getId());
+    UpdateArticleParam param = new UpdateArticleParam("", "", "");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertEquals("old title", updated.getTitle());
+    assertEquals("old desc", updated.getDescription());
+    assertEquals("old body", updated.getBody());
+    verify(articleRepository, times(1)).save(article);
+  }
+}

--- a/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
+++ b/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
@@ -1,0 +1,44 @@
+package io.spring.application.article;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedArticleValidatorTest {
+
+  @Mock private ArticleQueryService articleQueryService;
+
+  @InjectMocks private DuplicatedArticleValidator validator;
+
+  @Test
+  public void should_be_valid_when_no_article_with_same_slug_exists() {
+    String title = "a brand new title";
+    when(articleQueryService.findBySlug(eq(Article.toSlug(title)), isNull()))
+        .thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid(title, null));
+  }
+
+  @Test
+  public void should_be_invalid_when_article_with_same_slug_exists() {
+    String title = "an existing title";
+    when(articleQueryService.findBySlug(eq(Article.toSlug(title)), isNull()))
+        .thenReturn(Optional.of(mock(ArticleData.class)));
+
+    assertFalse(validator.isValid(title, null));
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
@@ -1,0 +1,43 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedEmailValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedEmailValidator validator;
+
+  @Test
+  public void should_be_valid_when_email_is_not_used() {
+    when(userRepository.findByEmail("free@example.com")).thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid("free@example.com", null));
+  }
+
+  @Test
+  public void should_be_invalid_when_email_is_already_used() {
+    User existing = new User("used@example.com", "someone", "123", "", "");
+    when(userRepository.findByEmail("used@example.com")).thenReturn(Optional.of(existing));
+
+    assertFalse(validator.isValid("used@example.com", null));
+  }
+
+  @Test
+  public void should_be_valid_when_email_is_null_or_empty() {
+    assertTrue(validator.isValid(null, null));
+    assertTrue(validator.isValid("", null));
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
@@ -1,0 +1,43 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedUsernameValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedUsernameValidator validator;
+
+  @Test
+  public void should_be_valid_when_username_is_not_used() {
+    when(userRepository.findByUsername("freename")).thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid("freename", null));
+  }
+
+  @Test
+  public void should_be_invalid_when_username_is_already_used() {
+    User existing = new User("someone@example.com", "usedname", "123", "", "");
+    when(userRepository.findByUsername("usedname")).thenReturn(Optional.of(existing));
+
+    assertFalse(validator.isValid("usedname", null));
+  }
+
+  @Test
+  public void should_be_valid_when_username_is_null_or_empty() {
+    assertTrue(validator.isValid(null, null));
+    assertTrue(validator.isValid("", null));
+  }
+}

--- a/src/test/java/io/spring/application/user/UpdateUserCommandTest.java
+++ b/src/test/java/io/spring/application/user/UpdateUserCommandTest.java
@@ -1,0 +1,86 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateUserCommandTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private UpdateUserValidator validator;
+
+  private User targetUser;
+
+  @BeforeEach
+  public void setUp() {
+    targetUser = new User("target@example.com", "target", "123", "", "");
+  }
+
+  private UpdateUserCommand command(String email, String username) {
+    UpdateUserParam param = UpdateUserParam.builder().email(email).username(username).build();
+    return new UpdateUserCommand(targetUser, param);
+  }
+
+  @Test
+  public void should_expose_target_user_and_param() {
+    UpdateUserParam param = UpdateUserParam.builder().email("a@example.com").build();
+    UpdateUserCommand cmd = new UpdateUserCommand(targetUser, param);
+
+    assertSame(targetUser, cmd.getTargetUser());
+    assertSame(param, cmd.getParam());
+  }
+
+  @Test
+  public void should_be_valid_when_email_and_username_are_unused() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+    when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+
+    assertTrue(validator.isValid(command("new@example.com", "newname"), context));
+  }
+
+  @Test
+  public void should_be_valid_when_email_and_username_belong_to_target_user() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+    when(userRepository.findByEmail("target@example.com")).thenReturn(Optional.of(targetUser));
+    when(userRepository.findByUsername("target")).thenReturn(Optional.of(targetUser));
+
+    assertTrue(validator.isValid(command("target@example.com", "target"), context));
+  }
+
+  @Test
+  public void should_be_invalid_when_email_belongs_to_another_user() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+    User other = new User("other@example.com", "other", "123", "", "");
+    when(userRepository.findByEmail("other@example.com")).thenReturn(Optional.of(other));
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+
+    assertFalse(validator.isValid(command("other@example.com", "newname"), context));
+  }
+
+  @Test
+  public void should_be_invalid_when_username_belongs_to_another_user() {
+    ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+    User other = new User("other@example.com", "other", "123", "", "");
+    when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("other")).thenReturn(Optional.of(other));
+
+    assertFalse(validator.isValid(command("new@example.com", "other"), context));
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,90 @@
+package io.spring.application.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+  private static final String DEFAULT_IMAGE = "https://example.com/default.jpg";
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private UserService userService;
+
+  @BeforeEach
+  public void setUp() {
+    userService = new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder);
+  }
+
+  @Test
+  public void should_create_user_with_encoded_password_and_default_image() {
+    RegisterParam param = new RegisterParam("new@example.com", "newuser", "plain-password");
+    when(passwordEncoder.encode("plain-password")).thenReturn("encoded-password");
+
+    User user = userService.createUser(param);
+
+    assertEquals("new@example.com", user.getEmail());
+    assertEquals("newuser", user.getUsername());
+    assertEquals("encoded-password", user.getPassword());
+    assertEquals("", user.getBio());
+    assertEquals(DEFAULT_IMAGE, user.getImage());
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    verify(passwordEncoder, times(1)).encode(eq("plain-password"));
+    verify(userRepository, times(1)).save(captor.capture());
+    assertSame(user, captor.getValue());
+  }
+
+  @Test
+  public void should_update_target_user_fields_and_save_it() {
+    User target = new User("old@example.com", "olduser", "password", "old bio", "old image");
+    UpdateUserParam param =
+        UpdateUserParam.builder()
+            .email("new@example.com")
+            .username("newuser")
+            .bio("new bio")
+            .image("new image")
+            .build();
+    UpdateUserCommand command = new UpdateUserCommand(target, param);
+
+    userService.updateUser(command);
+
+    assertEquals("new@example.com", target.getEmail());
+    assertEquals("newuser", target.getUsername());
+    assertEquals("new bio", target.getBio());
+    assertEquals("new image", target.getImage());
+    verify(userRepository, times(1)).save(target);
+  }
+
+  @Test
+  public void should_keep_original_fields_when_update_param_is_empty() {
+    User target = new User("old@example.com", "olduser", "password", "old bio", "old image");
+    UpdateUserParam param = UpdateUserParam.builder().build();
+    UpdateUserCommand command = new UpdateUserCommand(target, param);
+
+    userService.updateUser(command);
+
+    assertEquals("old@example.com", target.getEmail());
+    assertEquals("olduser", target.getUsername());
+    assertEquals("old bio", target.getBio());
+    assertEquals("old image", target.getImage());
+    verify(userRepository, times(1)).save(target);
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -59,6 +59,7 @@ public class UserServiceTest {
         UpdateUserParam.builder()
             .email("new@example.com")
             .username("newuser")
+            .password("new-password")
             .bio("new bio")
             .image("new image")
             .build();
@@ -68,6 +69,7 @@ public class UserServiceTest {
 
     assertEquals("new@example.com", target.getEmail());
     assertEquals("newuser", target.getUsername());
+    assertEquals("new-password", target.getPassword());
     assertEquals("new bio", target.getBio());
     assertEquals("new image", target.getImage());
     verify(userRepository, times(1)).save(target);

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -85,6 +85,7 @@ public class UserServiceTest {
 
     assertEquals("old@example.com", target.getEmail());
     assertEquals("olduser", target.getUsername());
+    assertEquals("password", target.getPassword());
     assertEquals("old bio", target.getBio());
     assertEquals("old image", target.getImage());
     verify(userRepository, times(1)).save(target);


### PR DESCRIPTION
## Summary
Adds pure Mockito unit tests (no Spring context / DB) for the write-side application services and their constraint validators, to raise JaCoCo coverage of `io.spring.application.article` and `io.spring.application.user`. No main source files were modified.

Covered:
- **`ArticleCommandService`** — `createArticle` maps `NewArticleParam` + creator into an `Article` (title/desc/body/slug/userId/tags) and saves it; `updateArticle` applies non-empty fields (and leaves fields untouched when the param is empty) then saves.
- **`UserService`** — `createUser` encodes the password via a mocked `PasswordEncoder` and applies the default image; `updateUser` mutates the target user from `UpdateUserCommand` and saves (plus the empty-param no-op case).
- **`UpdateUserCommand` / `UpdateUserValidator`** — getters, plus both valid cases (email/username unused, or belonging to the target user itself) and both duplicate cases (email or username owned by another user → invalid), driven by mocking `UserRepository.findByEmail/findByUsername`.
- **`DuplicatedArticleValidator`** — valid vs. duplicate via mocked `ArticleQueryService.findBySlug` returning empty vs. present.
- **`DuplicatedEmailValidator` / `DuplicatedUsernameValidator`** — valid, duplicate (mocked `UserRepository`), and the null/empty short-circuit.

All tests use `@ExtendWith(MockitoExtension.class)` with `@Mock`/`@InjectMocks` and are google-java-format compliant.

Verification: `./gradlew test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` is fully green.

Link to Devin session: https://app.devin.ai/sessions/f820b433db174326b547576d91eaeecd
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/793?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->