### PR TITLE
test: add DGS GraphQL layer tests for datafetchers and mutations

### DIFF
--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -54,7 +54,7 @@ class ArticleDatafetcherTest extends DgsGraphQLTestBase {
 
   @Test
   void should_error_when_feed_missing_first_and_last() {
-    setAnonymous();
+    setAuthenticatedUser(user);
 
     QueryException error =
         org.junit.jupiter.api.Assertions.assertThrows(

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,206 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ArticleDatafetcherTest extends DgsGraphQLTestBase {
+
+  private CursorPager<ArticleData> onePage() {
+    return new CursorPager<>(
+        Collections.singletonList(articleData("hello-world", user)), Direction.NEXT, false);
+  }
+
+  @Test
+  void should_query_feed() {
+    setAuthenticatedUser(user);
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ feed(first: 10) { edges { cursor node { slug title body } } pageInfo { hasNextPage"
+                + " hasPreviousPage } } }",
+            "data.feed.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), slugs);
+  }
+
+  @Test
+  void should_query_feed_backwards() {
+    setAuthenticatedUser(user);
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    Boolean hasPrevious =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ feed(last: 10) { edges { node { slug } } pageInfo { hasPreviousPage } } }",
+            "data.feed.pageInfo.hasPreviousPage");
+
+    assertFalse(hasPrevious);
+  }
+
+  @Test
+  void should_error_when_feed_missing_first_and_last() {
+    setAnonymous();
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ feed { edges { node { slug } } } }", "data.feed"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_query_articles_with_filters() {
+    setAnonymous();
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ articles(first: 5, withTag: \"java\", authoredBy: \"johnjacob\") { edges { node {"
+                + " slug title } } pageInfo { hasNextPage } } }",
+            "data.articles.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), slugs);
+  }
+
+  @Test
+  void should_query_articles_backwards() {
+    setAnonymous();
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ articles(last: 5) { edges { node { slug } } pageInfo { hasNextPage } } }",
+            "data.articles.pageInfo.hasNextPage");
+
+    assertFalse(hasNext);
+  }
+
+  @Test
+  void should_find_article_by_slug() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+
+    String title =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { slug title body description favorited favoritesCount"
+                + " tagList createdAt updatedAt } }",
+            "data.article.title");
+
+    assertEquals("title hello-world", title);
+  }
+
+  @Test
+  void should_error_when_article_not_found() {
+    setAnonymous();
+    when(articleQueryService.findBySlug(anyString(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ article(slug: \"missing\") { slug } }", "data.article"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_resolve_profile_articles_and_feed_and_favorites() {
+    setAuthenticatedUser(user);
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(eq(user.getUsername()))).thenReturn(Optional.of(user));
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    List<String> articleSlugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"johnjacob\") { profile { username articles(first: 3) { edges {"
+                + " node { slug } } } favorites(first: 3) { edges { node { slug } } } feed(first: 3)"
+                + " { edges { node { slug } } } } } }",
+            "data.profile.profile.articles.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), articleSlugs);
+  }
+
+  @Test
+  void should_resolve_profile_articles_backwards() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(eq(user.getUsername()))).thenReturn(Optional.of(user));
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(onePage());
+    when(articleQueryService.findUserFeedWithCursor(any(), any())).thenReturn(onePage());
+
+    List<String> favoriteSlugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"johnjacob\") { profile { articles(last: 3) { edges { node { slug"
+                + " } } } favorites(last: 3) { edges { node { slug } } } feed(last: 3) { edges {"
+                + " node { slug } } } } } }",
+            "data.profile.profile.favorites.edges[*].node.slug");
+
+    assertEquals(Collections.singletonList("hello-world"), favoriteSlugs);
+  }
+
+  @Test
+  void should_error_when_profile_feed_missing_pagination() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(eq(user.getUsername()))).thenReturn(Optional.of(user));
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ profile(username: \"johnjacob\") { profile { feed { edges { node { slug } } }"
+                        + " } } }",
+                    "data.profile.profile.feed"));
+
+    assertTrue(error.getErrors().size() > 0);
+  }
+
+  @Test
+  void should_error_when_profile_feed_target_missing() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any()))
+        .thenReturn(Optional.of(profileData(user)));
+    when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ profile(username: \"ghost\") { profile { feed(first: 3) { edges { node { slug"
+                        + " } } } } } }",
+                    "data.profile.profile.feed"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,210 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.TestHelper;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ArticleMutationTest extends DgsGraphQLTestBase {
+
+  private Article articleOf(User author) {
+    return new Article(
+        "How to Test", "desc", "body", Arrays.asList("java", "spring"), author.getId());
+  }
+
+  @Test
+  void should_create_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleCommandService.createArticle(any(), eq(user))).thenReturn(article);
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createArticle(input: {title: \"How to Test\", description: \"desc\", body:"
+                + " \"body\", tagList: [\"java\"]}) { article { slug title body } } }",
+            "data.createArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+  }
+
+  @Test
+  void should_create_article_without_taglist() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleCommandService.createArticle(any(), eq(user))).thenReturn(article);
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String title =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createArticle(input: {title: \"How to Test\", description: \"desc\", body:"
+                + " \"body\"}) { article { title } } }",
+            "data.createArticle.article.title");
+
+    assertEquals(articleData.getTitle(), title);
+  }
+
+  @Test
+  void should_reject_create_article_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { createArticle(input: {title: \"t\", description: \"d\", body: \"b\"})"
+                        + " { article { slug } } }",
+                    "data.createArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_update_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any())).thenReturn(article);
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { updateArticle(slug: \""
+                + article.getSlug()
+                + "\", changes: {title: \"new\"}) { article { slug } } }",
+            "data.updateArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+  }
+
+  @Test
+  void should_reject_update_article_when_not_found() {
+    setAuthenticatedUser(user);
+    when(articleRepository.findBySlug(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { updateArticle(slug: \"missing\", changes: {title: \"new\"}) {"
+                        + " article { slug } } }",
+                    "data.updateArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_update_article_when_not_author() {
+    setAuthenticatedUser(user);
+    User other = new User("other@test.com", "other", "123", "", "");
+    Article article = articleOf(other);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { updateArticle(slug: \""
+                        + article.getSlug()
+                        + "\", changes: {title: \"new\"}) { article { slug } } }",
+                    "data.updateArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_favorite_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { favoriteArticle(slug: \""
+                + article.getSlug()
+                + "\") { article { slug } } }",
+            "data.favoriteArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+    verify(articleFavoriteRepository).save(any(ArticleFavorite.class));
+  }
+
+  @Test
+  void should_unfavorite_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    ArticleData articleData = TestHelper.getArticleDataFromArticleAndUser(article, user);
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), user.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.of(favorite));
+    when(articleQueryService.findById(any(), any())).thenReturn(Optional.of(articleData));
+
+    String slug =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { unfavoriteArticle(slug: \""
+                + article.getSlug()
+                + "\") { article { slug } } }",
+            "data.unfavoriteArticle.article.slug");
+
+    assertEquals(article.getSlug(), slug);
+    verify(articleFavoriteRepository).remove(eq(favorite));
+  }
+
+  @Test
+  void should_delete_article() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    Boolean success =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }",
+            "data.deleteArticle.success");
+
+    assertTrue(success);
+    verify(articleRepository).remove(eq(article));
+  }
+
+  @Test
+  void should_reject_delete_article_when_not_author() {
+    setAuthenticatedUser(user);
+    User other = new User("other@test.com", "other", "123", "", "");
+    Article article = articleOf(other);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteArticle(slug: \""
+                        + article.getSlug()
+                        + "\") { success } }",
+                    "data.deleteArticle"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,77 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CommentDatafetcherTest extends DgsGraphQLTestBase {
+
+  private CursorPager<CommentData> onePage() {
+    return new CursorPager<>(
+        Collections.singletonList(commentData("comment-1", user)), Direction.NEXT, false);
+  }
+
+  @Test
+  void should_resolve_article_comments() {
+    setAuthenticatedUser(user);
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(any(), any(), any())).thenReturn(onePage());
+
+    List<String> ids =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { slug comments(first: 5) { edges { cursor node { id"
+                + " body createdAt updatedAt } } pageInfo { hasNextPage } } } }",
+            "data.article.comments.edges[*].node.id");
+
+    assertEquals(Collections.singletonList("comment-1"), ids);
+  }
+
+  @Test
+  void should_resolve_article_comments_backwards() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(any(), any(), any())).thenReturn(onePage());
+
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { comments(last: 5) { edges { node { id } } pageInfo {"
+                + " hasNextPage } } } }",
+            "data.article.comments.pageInfo.hasNextPage");
+
+    assertFalse(hasNext);
+  }
+
+  @Test
+  void should_error_when_article_comments_missing_pagination() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ article(slug: \"hello-world\") { comments { edges { node { id } } } } }",
+                    "data.article.comments"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,158 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.data.CommentData;
+import io.spring.core.article.Article;
+import io.spring.core.comment.Comment;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CommentMutationTest extends DgsGraphQLTestBase {
+
+  private Article articleOf(User author) {
+    return new Article("Title", "desc", "body", Arrays.asList("java"), author.getId());
+  }
+
+  @Test
+  void should_add_comment() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    CommentData commentData = commentData("comment-1", user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(user))).thenReturn(Optional.of(commentData));
+
+    String body =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { addComment(slug: \""
+                + article.getSlug()
+                + "\", body: \"nice article\") { comment { id body } } }",
+            "data.addComment.comment.body");
+
+    assertEquals(commentData.getBody(), body);
+    verify(commentRepository).save(any(Comment.class));
+  }
+
+  @Test
+  void should_reject_add_comment_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { addComment(slug: \"s\", body: \"b\") { comment { id } } }",
+                    "data.addComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_add_comment_when_article_not_found() {
+    setAuthenticatedUser(user);
+    when(articleRepository.findBySlug(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { addComment(slug: \"missing\", body: \"b\") { comment { id } } }",
+                    "data.addComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_delete_comment() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    Comment comment = new Comment("body", user.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    Boolean success =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \""
+                + comment.getId()
+                + "\") { success } }",
+            "data.deleteComment.success");
+
+    assertTrue(success);
+    verify(commentRepository).remove(eq(comment));
+  }
+
+  @Test
+  void should_reject_delete_comment_when_not_authorized() {
+    setAuthenticatedUser(user);
+    User other = new User("other@test.com", "other", "123", "", "");
+    Article article = articleOf(other);
+    Comment comment = new Comment("body", other.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteComment(slug: \""
+                        + article.getSlug()
+                        + "\", id: \""
+                        + comment.getId()
+                        + "\") { success } }",
+                    "data.deleteComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_delete_comment_when_comment_not_found() {
+    setAuthenticatedUser(user);
+    Article article = articleOf(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(any(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteComment(slug: \""
+                        + article.getSlug()
+                        + "\", id: \"missing\") { success } }",
+                    "data.deleteComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_delete_comment_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { deleteComment(slug: \"s\", id: \"c\") { success } }",
+                    "data.deleteComment"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/DgsGraphQLTestBase.java
@@ -1,0 +1,112 @@
+package io.spring.graphql;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.TagsQueryService;
+import io.spring.application.UserQueryService;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.application.user.UserService;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Shared base for GraphQL (Netflix DGS) datafetcher/mutation tests. Boots the full Spring context so
+ * the real GraphQL schema and wiring are exercised, while every collaborating service/repository is
+ * replaced with a Mockito mock so behaviour can be controlled per test. All subclasses share the
+ * exact same context configuration so Spring caches and reuses a single application context.
+ */
+@SpringBootTest
+abstract class DgsGraphQLTestBase {
+
+  @Autowired protected DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean protected ArticleQueryService articleQueryService;
+  @MockBean protected CommentQueryService commentQueryService;
+  @MockBean protected ProfileQueryService profileQueryService;
+  @MockBean protected TagsQueryService tagsQueryService;
+  @MockBean protected UserQueryService userQueryService;
+  @MockBean protected UserRepository userRepository;
+  @MockBean protected ArticleRepository articleRepository;
+  @MockBean protected CommentRepository commentRepository;
+  @MockBean protected ArticleFavoriteRepository articleFavoriteRepository;
+  @MockBean protected ArticleCommandService articleCommandService;
+  @MockBean protected UserService userService;
+  @MockBean protected JwtService jwtService;
+  @MockBean protected PasswordEncoder passwordEncoder;
+
+  protected User user;
+
+  @BeforeEach
+  void setUpCurrentUser() {
+    user = new User("john@jacob.com", "johnjacob", "123", "bio", "avatar.png");
+    setAnonymous();
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  protected void setAuthenticatedUser(User currentUser) {
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(currentUser, null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  protected void setAnonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "anonymous-key",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+
+  protected ArticleData articleData(String seed, User author) {
+    DateTime now = new DateTime();
+    return new ArticleData(
+        seed + "-id",
+        seed,
+        "title " + seed,
+        "desc " + seed,
+        "body " + seed,
+        false,
+        0,
+        now,
+        now,
+        new ArrayList<>(Collections.singletonList("java")),
+        profileData(author));
+  }
+
+  protected CommentData commentData(String id, User author) {
+    DateTime now = new DateTime();
+    return new CommentData(id, "comment body " + id, "article-id", now, now, profileData(author));
+  }
+
+  protected ProfileData profileData(User author) {
+    return new ProfileData(
+        author.getId(), author.getUsername(), author.getBio(), author.getImage(), false);
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,62 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.data.UserData;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class MeDatafetcherTest extends DgsGraphQLTestBase {
+
+  private HttpHeaders authHeader() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token");
+    return headers;
+  }
+
+  @Test
+  void should_return_me_when_authenticated() {
+    setAuthenticatedUser(user);
+    UserData userData =
+        new UserData(user.getId(), user.getEmail(), user.getUsername(), user.getBio(), "img");
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.of(userData));
+
+    String token =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ me { email username token } }", "data.me.token", authHeader());
+
+    assertEquals("jwt-token", token);
+  }
+
+  @Test
+  void should_return_null_me_when_anonymous() {
+    setAnonymous();
+
+    Object me =
+        dgsQueryExecutor.executeAndExtractJsonPath("{ me { email } }", "data.me", authHeader());
+
+    assertNull(me);
+  }
+
+  @Test
+  void should_error_me_when_user_data_missing() {
+    setAuthenticatedUser(user);
+    when(userQueryService.findById(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ me { email } }", "data.me", authHeader()));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,109 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.UserData;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class ProfileDatafetcherTest extends DgsGraphQLTestBase {
+
+  @Test
+  void should_query_profile() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(eq("johnjacob"), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"johnjacob\") { profile { username bio image following } } }",
+            "data.profile.profile.username");
+
+    assertEquals("johnjacob", username);
+  }
+
+  @Test
+  void should_error_when_profile_not_found() {
+    setAnonymous();
+    when(profileQueryService.findByUsername(any(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "{ profile(username: \"ghost\") { profile { username } } }",
+                    "data.profile.profile"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_resolve_article_author() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    String authorName =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { slug author { username following } } }",
+            "data.article.author.username");
+
+    assertEquals(user.getUsername(), authorName);
+  }
+
+  @Test
+  void should_resolve_comment_author() {
+    setAnonymous();
+    ArticleData articleData = articleData("hello-world", user);
+    CommentData commentData = commentData("comment-1", user);
+    when(articleQueryService.findBySlug(eq("hello-world"), any()))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(any(), any(), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(commentData), Direction.NEXT, false));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    java.util.List<String> authorNames =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ article(slug: \"hello-world\") { comments(first: 5) { edges { node { id author {"
+                + " username } } } } } }",
+            "data.article.comments.edges[*].node.author.username");
+
+    assertEquals(Collections.singletonList(user.getUsername()), authorNames);
+  }
+
+  @Test
+  void should_resolve_user_profile_via_me() {
+    setAuthenticatedUser(user);
+    UserData userData =
+        new UserData(user.getId(), user.getEmail(), user.getUsername(), user.getBio(), "img");
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.of(userData));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(user)));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token");
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ me { profile { username } } }", "data.me.profile.username", headers);
+
+    assertEquals(user.getUsername(), username);
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,134 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RelationMutationTest extends DgsGraphQLTestBase {
+
+  private final User target = new User("target@test.com", "target", "123", "bio", "img");
+
+  @Test
+  void should_follow_user() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername(eq(target.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(target)));
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { followUser(username: \"target\") { profile { username following } } }",
+            "data.followUser.profile.username");
+
+    assertEquals(target.getUsername(), username);
+    verify(userRepository).saveRelation(any(FollowRelation.class));
+  }
+
+  @Test
+  void should_reject_follow_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { followUser(username: \"target\") { profile { username } } }",
+                    "data.followUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_follow_when_target_missing() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { followUser(username: \"ghost\") { profile { username } } }",
+                    "data.followUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_unfollow_user() {
+    setAuthenticatedUser(user);
+    FollowRelation relation = new FollowRelation(user.getId(), target.getId());
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername(eq(target.getUsername()), any()))
+        .thenReturn(Optional.of(profileData(target)));
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { unfollowUser(username: \"target\") { profile { username } } }",
+            "data.unfollowUser.profile.username");
+
+    assertEquals(target.getUsername(), username);
+    verify(userRepository).removeRelation(eq(relation));
+  }
+
+  @Test
+  void should_reject_unfollow_when_target_missing() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { unfollowUser(username: \"ghost\") { profile { username } } }",
+                    "data.unfollowUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_unfollow_when_relation_missing() {
+    setAuthenticatedUser(user);
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(any(), any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { unfollowUser(username: \"target\") { profile { username } } }",
+                    "data.unfollowUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_reject_unfollow_when_not_authenticated() {
+    setAnonymous();
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { unfollowUser(username: \"target\") { profile { username } } }",
+                    "data.unfollowUser"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -2,6 +2,7 @@ package io.spring.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.spring.core.user.User;
@@ -50,5 +51,14 @@ class SecurityUtilTest {
         .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
 
     assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+
+  @Test
+  void should_throw_when_no_authentication_present() {
+    SecurityContextHolder.clearContext();
+
+    // Documents current behaviour: with no authentication in the context the
+    // instanceof check is false for null and getPrincipal() is dereferenced.
+    assertThrows(NullPointerException.class, SecurityUtil::getCurrentUser);
   }
 }

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -57,8 +57,10 @@ class SecurityUtilTest {
   void should_throw_when_no_authentication_present() {
     SecurityContextHolder.clearContext();
 
-    // Documents current behaviour: with no authentication in the context the
-    // instanceof check is false for null and getPrincipal() is dereferenced.
+    // TODO: this NPE is a latent null-safety bug in SecurityUtil.getCurrentUser
+    // (it dereferences authentication without a null check). This test documents
+    // the current behaviour; if the production code is hardened to return
+    // Optional.empty() when authentication is null, update this to expect empty.
     assertThrows(NullPointerException.class, SecurityUtil::getCurrentUser);
   }
 }

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,54 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class SecurityUtilTest {
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void should_return_current_user_when_authenticated() {
+    User user = new User("test@example.com", "tester", "123", "", "");
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+
+    Optional<User> current = SecurityUtil.getCurrentUser();
+
+    assertTrue(current.isPresent());
+    assertEquals(user, current.get());
+  }
+
+  @Test
+  void should_return_empty_when_anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+
+  @Test
+  void should_return_empty_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,21 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TagDatafetcherTest extends DgsGraphQLTestBase {
+
+  @Test
+  void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
+
+    List<String> tags =
+        dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertEquals(Arrays.asList("java", "spring"), tags);
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,110 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.exceptions.QueryException;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+class UserMutationTest extends DgsGraphQLTestBase {
+
+  @Test
+  void should_create_user() {
+    when(userService.createUser(any(RegisterParam.class))).thenReturn(user);
+    when(jwtService.toToken(eq(user))).thenReturn("jwt-token");
+
+    String token =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createUser(input: {email: \"john@jacob.com\", username: \"johnjacob\","
+                + " password: \"123\"}) { ... on UserPayload { user { email username token } } } }",
+            "data.createUser.user.token");
+
+    assertEquals("jwt-token", token);
+  }
+
+  @Test
+  void should_return_error_when_create_user_invalid() {
+    when(userService.createUser(any(RegisterParam.class)))
+        .thenThrow(new ConstraintViolationException(Collections.emptySet()));
+
+    String message =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createUser(input: {email: \"bad\", username: \"u\", password: \"p\"}) { ..."
+                + " on Error { message } } }",
+            "data.createUser.message");
+
+    assertEquals("BAD_REQUEST", message);
+  }
+
+  @Test
+  void should_login() {
+    setAnonymous();
+    when(userRepository.findByEmail(eq(user.getEmail()))).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(eq("123"), eq(user.getPassword()))).thenReturn(true);
+    when(jwtService.toToken(eq(user))).thenReturn("jwt-token");
+
+    String token =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { login(password: \"123\", email: \"john@jacob.com\") { user { email token }"
+                + " } }",
+            "data.login.user.token");
+
+    assertEquals("jwt-token", token);
+  }
+
+  @Test
+  void should_reject_login_when_invalid() {
+    setAnonymous();
+    when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+
+    QueryException error =
+        assertThrows(
+            QueryException.class,
+            () ->
+                dgsQueryExecutor.executeAndExtractJsonPath(
+                    "mutation { login(password: \"wrong\", email: \"nobody@test.com\") { user {"
+                        + " email } } }",
+                    "data.login"));
+
+    assertFalse(error.getErrors().isEmpty());
+  }
+
+  @Test
+  void should_update_user() {
+    setAuthenticatedUser(user);
+    when(jwtService.toToken(eq(user))).thenReturn("jwt-token");
+
+    String email =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { updateUser(changes: {email: \"new@jacob.com\", bio: \"new bio\"}) { user {"
+                + " email } } }",
+            "data.updateUser.user.email");
+
+    assertEquals(user.getEmail(), email);
+    verify(userService).updateUser(any(UpdateUserCommand.class));
+  }
+
+  @Test
+  void should_return_null_update_user_when_anonymous() {
+    setAnonymous();
+
+    User result =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { updateUser(changes: {email: \"new@jacob.com\"}) { user { email } } }",
+            "data.updateUser");
+
+    assertNull(result);
+  }
+}


### PR DESCRIPTION
## Summary
Adds test coverage for the previously-untested `io.spring.graphql` package (DGS datafetchers/mutations + `SecurityUtil`). No main source changes.

The datafetchers/mutations read the authenticated principal from the Spring `SecurityContext` (via `SecurityUtil.getCurrentUser()`), so tests boot the full context and execute real GraphQL against the schema with `DgsQueryExecutor`, while every collaborating service/repository is a `@MockBean`.

Shared setup lives in `DgsGraphQLTestBase`:
- `@SpringBootTest` + `@Autowired DgsQueryExecutor`; all query services / repositories / `JwtService` / `PasswordEncoder` mocked.
- `setAuthenticatedUser(user)` / `setAnonymous()` push a principal into `SecurityContextHolder` (cleared after each test). An `AnonymousAuthenticationToken` is used for the unauthenticated case because `getCurrentUser()` dereferences `authentication` directly.
- fixture helpers `articleData(...)`, `commentData(...)`, `profileData(...)`.

All subclasses share the identical context config, so Spring caches and reuses one application context.

Tests exercise happy paths, pagination (forward/backward), nested field resolution (`article.author`, `article.comments`, `comment.author`, `profile.articles/favorites/feed`, `me.profile`), and error paths surfaced as GraphQL errors, e.g.:

```java
// error paths assert the executor surfaces GraphQL errors
QueryException e = assertThrows(QueryException.class,
    () -> dgsQueryExecutor.executeAndExtractJsonPath(
        "mutation { createArticle(input: {...}) { article { slug } } }",
        "data.createArticle"));   // AuthenticationException when anonymous
assertFalse(e.getErrors().isEmpty());
```

`MeDatafetcher` uses `@RequestHeader("Authorization")`, so those tests pass `HttpHeaders` with `Token jwt-token` into `executeAndExtractJsonPath`.

`SecurityUtilTest` is a plain unit test manipulating `SecurityContextHolder` (authenticated / anonymous / null-principal).

New test files under `src/test/java/io/spring/graphql/`:
- `DgsGraphQLTestBase`, `SecurityUtilTest`
- `ArticleDatafetcherTest`, `ArticleMutationTest`
- `CommentDatafetcherTest`, `CommentMutationTest`
- `MeDatafetcherTest`, `ProfileDatafetcherTest`, `RelationMutationTest`, `TagDatafetcherTest`, `UserMutationTest`

## Verification
`./gradlew test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` is green (Spotless excluded per repo note: google-java-format crashes on JDK17; test files are written to be format-compliant).

JaCoCo line coverage for targeted classes: ArticleMutation/CommentMutation/MeDatafetcher/ProfileDatafetcher/RelationMutation/TagDatafetcher/UserMutation 100%, CommentDatafetcher 96%, ArticleDatafetcher 92%, SecurityUtil 86%.


Link to Devin session: https://app.devin.ai/sessions/fef8babb824a4b8780a9be44646bdb29
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/794?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->