### PR TITLE
build: add JaCoCo coverage tooling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -58,6 +59,49 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+def jacocoExcludes = [
+    'io/spring/graphql/types/**',
+    'io/spring/graphql/DgsConstants**',
+    'io/spring/graphql/generated/**'
+]
+
+jacoco {
+    toolVersion = '0.8.11'
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                minimum = 0.60
+            }
+        }
+    }
+}
+
+afterEvaluate {
+    tasks.withType(JacocoReport).configureEach {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: jacocoExcludes)
+        }))
+    }
+    tasks.withType(JacocoCoverageVerification).configureEach {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: jacocoExcludes)
+        }))
+    }
 }
 
 tasks.named('clean') {


### PR DESCRIPTION
## Summary
Adds JaCoCo coverage tooling to establish a baseline for the coverage-improvement effort. This is the **foundation** PR; test-writing workstreams land separately.

Changes to `build.gradle`:
- Add `id 'jacoco'` to the `plugins` block (`toolVersion = '0.8.11'`).
- `test` is `finalizedBy jacocoTestReport`; `jacocoTestReport` `dependsOn test` and emits XML + HTML.
- Exclude DGS-generated code from coverage — `io/spring/graphql/types/**`, `io/spring/graphql/DgsConstants*`, and `io/spring/graphql/generated/**` — applied via an `afterEvaluate` block that rewrites `classDirectories` for all `JacocoReport`/`JacocoCoverageVerification` tasks. The datafetchers/mutations under `io.spring.graphql` remain covered; only generated types/constants are dropped.
- Add a `jacocoTestCoverageVerification` task with a modest 0.60 LINE threshold. It is **not** wired into the build (build does not fail on coverage yet).

Report lands at `build/reports/jacoco/test/html/index.html` (+ `jacocoTestReport.xml`).

## Baseline coverage (generated code excluded)
Verified via `./gradlew test jacocoTestReport`:

| Counter | Covered/Total | % |
|---|---|---|
| LINE | 738/1377 | 53.6% |
| INSTRUCTION | 3477/7435 | 46.8% |
| BRANCH | 146/650 | 22.5% |
| METHOD | 347/504 | 68.8% |
| CLASS | 86/96 | 89.6% |

Note: this repo's Spotless/google-java-format step fails under JDK17, so the report was generated with `-x spotlessJava -x spotlessJavaCheck` per the repo's environment notes. `build.gradle` is not a Spotless target so no formatting change was needed.


Link to Devin session: https://app.devin.ai/sessions/8b3d7e1f3d174b37a5df0f65be549c02
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/797?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->