### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,30 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private final Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar);
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar);
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar);
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar);
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,32 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private final Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  }
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar());
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar());
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }


### PR DESCRIPTION
## Summary
Weekly SonarQube sweep. Fixes the 5 highest-priority open issues (ranked by severity → type → effort → recency). All 4 open `CRITICAL` issues plus the single `MAJOR`-severity `BUG` were selected. Changes are minimal and behavior-preserving; `./gradlew test` passes.

## Issues fixed

| # | Key | Severity / Type | Rule | Location | Fix |
|---|-----|-----------------|------|----------|-----|
| 1 | `AZ1u3HCaEnUkF3fpjVtj` | CRITICAL / CODE_SMELL | `java:S1452` | `ArticleApi.article` (L36) | Wildcard return type → concrete type |
| 2 | `AZ1u3HCaEnUkF3fpjVtk` | CRITICAL / CODE_SMELL | `java:S1452` | `ArticleApi.updateArticle` (L45) | Wildcard return type → concrete type |
| 3 | `AZ1u3HBkEnUkF3fpjVtQ` | CRITICAL / CODE_SMELL | `java:S1452` | `CommentsApi.createComment` (L41) | Wildcard return type → concrete type |
| 4 | `AZ1u3HBdEnUkF3fpjVtN` | CRITICAL / CODE_SMELL | `java:S1948` | `InvalidRequestException` (L7) | Non-serializable field → `transient` |
| 5 | `AZ1u3HAmEnUkF3fpjVtC` | MAJOR / BUG | `java:S2885` | `DateTimeHandler` (L18) | Shared non-thread-safe `static` Calendar → fresh per-call Calendar |

## Details

**S1452 — Generic wildcard types should not be used in return types.** REST handlers returned `ResponseEntity<?>` while always producing a `Map<String, Object>` body. Narrowed the declared type; no runtime change.
```diff
- public ResponseEntity<?> article(...) {                 // ArticleApi
+ public ResponseEntity<Map<String, Object>> article(...) {
- public ResponseEntity<?> updateArticle(...) {           // ArticleApi
+ public ResponseEntity<Map<String, Object>> updateArticle(...) {
- public ResponseEntity<?> createComment(...) {           // CommentsApi
+ public ResponseEntity<Map<String, Object>> createComment(...) {
```

**S1948 — Serializable fields must be transient or serializable.** `InvalidRequestException extends RuntimeException` (serializable) but held a non-serializable `org.springframework.validation.Errors`. Marked `transient`.
```diff
- private final Errors errors;
+ private final transient Errors errors;
```

**S2885 — Non-thread-safe fields should not be static (BUG).** `java.util.Calendar` is not thread-safe. The field was a shared `static` instance in a MyBatis `TypeHandler`. Because MyBatis instantiates `TypeHandler`s as singletons, simply demoting it to an instance field would still share one mutable `Calendar` across all threads — so instead each JDBC call now gets its own `Calendar`, which both resolves S2885 and removes the underlying concurrency hazard (per Devin Review feedback).
```diff
- private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
- ... uses UTC_CALENDAR
+ private static Calendar utcCalendar() {
+   return Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+ }
+ ... uses utcCalendar()
```

## Verification
- `./gradlew test` — BUILD SUCCESSFUL (run on JDK 11 per README; `spotless`/google-java-format is incompatible with JDK 17).
- All changed lines are `spotless`-clean.

## Note
`./gradlew spotlessCheck` reports one **pre-existing** formatting violation in `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java` that exists on `master` and is unrelated to this sweep. Left untouched to keep this PR focused on the 5 SonarQube fixes.


Link to Devin session: https://app.devin.ai/sessions/d7243bffd6b24af4be0234bda45c1342
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/799?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->