### PR TITLE
Build tooling: bump Gradle, Spring Boot 3, Java 17 and dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id 'org.springframework.boot' version '2.6.3'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.springframework.boot' version '3.3.13'
+    id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
-    id "com.netflix.dgs.codegen" version "5.0.6"
-    id "com.diffplug.spotless" version "6.2.1"
+    id "com.netflix.dgs.codegen" version "8.6.0"
+    id "com.diffplug.spotless" version "6.25.0"
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {
@@ -35,25 +35,25 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
-    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:9.2.2'
     implementation 'org.flywaydb:flyway-core'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
-                'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6',
+                'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'joda-time:joda-time:2.10.13'
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'io.rest-assured:rest-assured:4.5.1'
-    testImplementation 'io.rest-assured:json-path:4.5.1'
-    testImplementation 'io.rest-assured:xml-path:4.5.1'
-    testImplementation 'io.rest-assured:spring-mock-mvc:4.5.1'
+    testImplementation 'io.rest-assured:rest-assured:5.5.2'
+    testImplementation 'io.rest-assured:json-path:5.5.2'
+    testImplementation 'io.rest-assured:xml-path:5.5.2'
+    testImplementation 'io.rest-assured:spring-mock-mvc:5.5.2'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 }
 
 tasks.named('test') {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
Build-tooling half of the Spring Boot 2.6.3 → 3.x / Java 11 → 17 migration. Touches **only** `build.gradle` and `gradle/wrapper/gradle-wrapper.properties` — no `.java` sources. A full `compileJava`/`build` is expected to still fail at this stage because the source tree remains on `javax.*` / Spring Security 5 APIs (handled by other sessions); the goal here is that the build DSL parses and all new dependency versions resolve.

### Version matrix applied
- Java `sourceCompatibility`/`targetCompatibility`: `11` → `17`
- `org.springframework.boot` plugin: `2.6.3` → `3.3.13`
- `io.spring.dependency-management`: `1.0.11.RELEASE` → `1.1.7`
- `com.netflix.dgs.codegen` plugin: `5.0.6` → `8.6.0`
- `com.diffplug.spotless` plugin: `6.2.1` → `6.25.0`
- `mybatis-spring-boot-starter` + `-starter-test`: `2.2.2` → `3.0.4`
- `graphql-dgs-spring-boot-starter`: `4.9.21` → `9.2.2`
- `jjwt-api`/`-impl`/`-jackson`: `0.11.2` → `0.12.6`
- `org.xerial:sqlite-jdbc`: `3.36.0.3` → `3.49.1.0`
- `io.rest-assured` (rest-assured/json-path/xml-path/spring-mock-mvc): `4.5.1` → `5.5.2`
- Gradle wrapper: `gradle-7.4-bin.zip` → `gradle-8.7-bin.zip`
- Unchanged as required: `joda-time`, `flyway-core`

The `generateJava` DGS codegen task config and the `spotless` block are left intact (only the plugin version bumped).

### Verification
- `./gradlew --version` → Gradle **8.7** active on JVM 17.0.13
- `./gradlew tasks` → BUILD SUCCESSFUL; `generateJava` and `spotless*` tasks still recognized (DSL parses)
- `./gradlew dependencies --configuration compileClasspath` and `--configuration testCompileClasspath` → BUILD SUCCESSFUL; all declared versions resolve from Maven Central (DGS aligns transitively to `10.0.4` via its platform BOM; rest-assured-common aligns to `5.4.0` — no version-not-found errors)

### Assumptions / deviations
- No DGS codegen task config change was needed — the `8.6.0` plugin still registers `generateJava` with the existing `schemaPaths`/`packageName` config.
- Did not attempt `compileJava`/`build` (expected to fail on `javax.*`/Spring Security 5 source, out of scope).


Link to Devin session: https://app.devin.ai/sessions/ab5d8f1641074a089d5db2207320818c
Requested by: @kylie-chang
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/822?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->