### PR TITLE
Rewrite WebSecurityConfig for Spring Security 6

### DIFF
--- a/src/main/java/io/spring/api/security/WebSecurityConfig.java
+++ b/src/main/java/io/spring/api/security/WebSecurityConfig.java
@@ -6,12 +6,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -20,7 +21,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+public class WebSecurityConfig {
 
   @Bean
   public JwtTokenFilter jwtTokenFilter() {
@@ -32,36 +33,34 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     return new BCryptPasswordEncoder();
   }
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-    http.csrf()
-        .disable()
-        .cors()
-        .and()
-        .exceptionHandling()
-        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
-        .and()
-        .sessionManagement()
-        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        .and()
-        .authorizeRequests()
-        .antMatchers(HttpMethod.OPTIONS)
-        .permitAll()
-        .antMatchers("/graphiql")
-        .permitAll()
-        .antMatchers("/graphql")
-        .permitAll()
-        .antMatchers(HttpMethod.GET, "/articles/feed")
-        .authenticated()
-        .antMatchers(HttpMethod.POST, "/users", "/users/login")
-        .permitAll()
-        .antMatchers(HttpMethod.GET, "/articles/**", "/profiles/**", "/tags")
-        .permitAll()
-        .anyRequest()
-        .authenticated();
+    http.csrf(csrf -> csrf.disable())
+        .cors(Customizer.withDefaults())
+        .exceptionHandling(
+            eh -> eh.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.OPTIONS)
+                    .permitAll()
+                    .requestMatchers("/graphiql")
+                    .permitAll()
+                    .requestMatchers("/graphql")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/articles/feed")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.POST, "/users", "/users/login")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/articles/**", "/profiles/**", "/tags")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated());
 
     http.addFilterBefore(jwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
   }
 
   @Bean


### PR DESCRIPTION
## Summary
Spring Security 6 removed `WebSecurityConfigurerAdapter` and the `authorizeRequests()`/`antMatchers()` fluent API. This rewrites `WebSecurityConfig` to the component-based, lambda-DSL style while preserving the exact existing behavior.

Key changes:
- Drop `extends WebSecurityConfigurerAdapter`; keep `@Configuration` + `@EnableWebSecurity`.
- Replace the `configure(HttpSecurity)` override with a `@Bean SecurityFilterChain filterChain(HttpSecurity http)` returning `http.build()`.
- Convert `.and()` chaining to lambda DSL: `csrf(csrf -> csrf.disable())`, `cors(Customizer.withDefaults())`, `exceptionHandling(...)`, `sessionManagement(sm -> ...STATELESS)`.
- `authorizeRequests()`/`antMatchers()` → `authorizeHttpRequests(...)`/`requestMatchers(...)`, preserving matcher order and semantics:
  - `OPTIONS` permitAll → `/graphiql`, `/graphql` permitAll → `GET /articles/feed` authenticated → `POST /users`, `/users/login` permitAll → `GET /articles/**`, `/profiles/**`, `/tags` permitAll → `anyRequest().authenticated()`.
- JWT filter still registered before `UsernamePasswordAuthenticationFilter`.

`jwtTokenFilter()`, `passwordEncoder()` (BCrypt), and `corsConfigurationSource()` beans are unchanged; CORS continues to use the existing `corsConfigurationSource()`.

## Scope
Only `src/main/java/io/spring/api/security/WebSecurityConfig.java` is touched. `javax`→`jakarta` and jjwt changes are handled by sibling sessions, so a full `./gradlew build` won't pass until those merge. Targets base branch `devin/spring-boot-3-migration`.

Link to Devin session: https://app.devin.ai/sessions/2ed7770234e54377875c44841a9b9071
Requested by: @kylie-chang
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/824?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->