### PR TITLE
Fix post-upgrade API compile errors: jjwt 0.12.x, DGS 9.x, Spring 6

### DIFF
--- a/src/main/java/io/spring/api/exception/CustomizeExceptionHandler.java
+++ b/src/main/java/io/spring/api/exception/CustomizeExceptionHandler.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -63,7 +63,7 @@ public class CustomizeExceptionHandler extends ResponseEntityExceptionHandler {
   protected ResponseEntity<Object> handleMethodArgumentNotValid(
       MethodArgumentNotValidException e,
       HttpHeaders headers,
-      HttpStatus status,
+      HttpStatusCode status,
       WebRequest request) {
     List<FieldErrorResource> errorResources =
         e.getBindingResult().getFieldErrors().stream()

--- a/src/main/java/io/spring/graphql/ArticleDatafetcher.java
+++ b/src/main/java/io/spring/graphql/ArticleDatafetcher.java
@@ -6,8 +6,6 @@ import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import com.netflix.graphql.dgs.DgsQuery;
 import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
-import graphql.relay.DefaultConnectionCursor;
-import graphql.relay.DefaultPageInfo;
 import graphql.schema.DataFetchingEnvironment;
 import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ArticleQueryService;
@@ -26,6 +24,7 @@ import io.spring.graphql.DgsConstants.QUERY;
 import io.spring.graphql.types.Article;
 import io.spring.graphql.types.ArticleEdge;
 import io.spring.graphql.types.ArticlesConnection;
+import io.spring.graphql.types.PageInfo;
 import io.spring.graphql.types.Profile;
 import java.util.HashMap;
 import java.util.stream.Collectors;
@@ -64,7 +63,7 @@ public class ArticleDatafetcher {
               current,
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV));
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -114,7 +113,7 @@ public class ArticleDatafetcher {
               target,
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV));
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -167,7 +166,7 @@ public class ArticleDatafetcher {
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV),
               current);
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
 
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
@@ -221,7 +220,7 @@ public class ArticleDatafetcher {
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV),
               current);
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -276,7 +275,7 @@ public class ArticleDatafetcher {
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV),
               current);
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -356,16 +355,14 @@ public class ArticleDatafetcher {
         .build();
   }
 
-  private DefaultPageInfo buildArticlePageInfo(CursorPager<ArticleData> articles) {
-    return new DefaultPageInfo(
-        articles.getStartCursor() == null
-            ? null
-            : new DefaultConnectionCursor(articles.getStartCursor().toString()),
-        articles.getEndCursor() == null
-            ? null
-            : new DefaultConnectionCursor(articles.getEndCursor().toString()),
-        articles.hasPrevious(),
-        articles.hasNext());
+  private PageInfo buildArticlePageInfo(CursorPager<ArticleData> articles) {
+    return PageInfo.newBuilder()
+        .startCursor(
+            articles.getStartCursor() == null ? null : articles.getStartCursor().toString())
+        .endCursor(articles.getEndCursor() == null ? null : articles.getEndCursor().toString())
+        .hasPreviousPage(articles.hasPrevious())
+        .hasNextPage(articles.hasNext())
+        .build();
   }
 
   private Article buildArticleResult(ArticleData articleData) {

--- a/src/main/java/io/spring/graphql/CommentDatafetcher.java
+++ b/src/main/java/io/spring/graphql/CommentDatafetcher.java
@@ -5,8 +5,6 @@ import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
-import graphql.relay.DefaultConnectionCursor;
-import graphql.relay.DefaultPageInfo;
 import io.spring.application.CommentQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -21,6 +19,7 @@ import io.spring.graphql.types.Article;
 import io.spring.graphql.types.Comment;
 import io.spring.graphql.types.CommentEdge;
 import io.spring.graphql.types.CommentsConnection;
+import io.spring.graphql.types.PageInfo;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -78,7 +77,7 @@ public class CommentDatafetcher {
               current,
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV));
     }
-    graphql.relay.PageInfo pageInfo = buildCommentPageInfo(comments);
+    PageInfo pageInfo = buildCommentPageInfo(comments);
     CommentsConnection result =
         CommentsConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -99,16 +98,14 @@ public class CommentDatafetcher {
         .build();
   }
 
-  private DefaultPageInfo buildCommentPageInfo(CursorPager<CommentData> comments) {
-    return new DefaultPageInfo(
-        comments.getStartCursor() == null
-            ? null
-            : new DefaultConnectionCursor(comments.getStartCursor().toString()),
-        comments.getEndCursor() == null
-            ? null
-            : new DefaultConnectionCursor(comments.getEndCursor().toString()),
-        comments.hasPrevious(),
-        comments.hasNext());
+  private PageInfo buildCommentPageInfo(CursorPager<CommentData> comments) {
+    return PageInfo.newBuilder()
+        .startCursor(
+            comments.getStartCursor() == null ? null : comments.getStartCursor().toString())
+        .endCursor(comments.getEndCursor() == null ? null : comments.getEndCursor().toString())
+        .hasPreviousPage(comments.hasPrevious())
+        .hasNextPage(comments.hasNext())
+        .build();
   }
 
   private Comment buildCommentResult(CommentData comment) {

--- a/src/main/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandler.java
+++ b/src/main/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandler.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -28,7 +29,7 @@ public class GraphQLCustomizeExceptionHandler implements DataFetcherExceptionHan
       new DefaultDataFetcherExceptionHandler();
 
   @Override
-  public DataFetcherExceptionHandlerResult onException(
+  public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(
       DataFetcherExceptionHandlerParameters handlerParameters) {
     if (handlerParameters.getException() instanceof InvalidAuthenticationException) {
       GraphQLError graphqlError =
@@ -37,7 +38,8 @@ public class GraphQLCustomizeExceptionHandler implements DataFetcherExceptionHan
               .message(handlerParameters.getException().getMessage())
               .path(handlerParameters.getPath())
               .build();
-      return DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build();
+      return CompletableFuture.completedFuture(
+          DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build());
     } else if (handlerParameters.getException() instanceof ConstraintViolationException) {
       List<FieldErrorResource> errors = new ArrayList<>();
       for (ConstraintViolation<?> violation :
@@ -61,9 +63,10 @@ public class GraphQLCustomizeExceptionHandler implements DataFetcherExceptionHan
               .path(handlerParameters.getPath())
               .extensions(errorsToMap(errors))
               .build();
-      return DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build();
+      return CompletableFuture.completedFuture(
+          DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build());
     } else {
-      return defaultHandler.onException(handlerParameters);
+      return defaultHandler.handleException(handlerParameters);
     }
   }
 

--- a/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
+++ b/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
@@ -3,7 +3,6 @@ package io.spring.infrastructure.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import java.util.Date;
@@ -17,22 +16,20 @@ import org.springframework.stereotype.Component;
 @Component
 public class DefaultJwtService implements JwtService {
   private final SecretKey signingKey;
-  private final SignatureAlgorithm signatureAlgorithm;
   private int sessionTime;
 
   @Autowired
   public DefaultJwtService(
       @Value("${jwt.secret}") String secret, @Value("${jwt.sessionTime}") int sessionTime) {
     this.sessionTime = sessionTime;
-    signatureAlgorithm = SignatureAlgorithm.HS512;
-    this.signingKey = new SecretKeySpec(secret.getBytes(), signatureAlgorithm.getJcaName());
+    this.signingKey = new SecretKeySpec(secret.getBytes(), "HmacSHA512");
   }
 
   @Override
   public String toToken(User user) {
     return Jwts.builder()
-        .setSubject(user.getId())
-        .setExpiration(expireTimeFromNow())
+        .subject(user.getId())
+        .expiration(expireTimeFromNow())
         .signWith(signingKey)
         .compact();
   }
@@ -40,9 +37,8 @@ public class DefaultJwtService implements JwtService {
   @Override
   public Optional<String> getSubFromToken(String token) {
     try {
-      Jws<Claims> claimsJws =
-          Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token);
-      return Optional.ofNullable(claimsJws.getBody().getSubject());
+      Jws<Claims> claimsJws = Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token);
+      return Optional.ofNullable(claimsJws.getPayload().getSubject());
     } catch (Exception e) {
       return Optional.empty();
     }

--- a/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
+++ b/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
@@ -3,12 +3,12 @@ package io.spring.infrastructure.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import java.util.Date;
 import java.util.Optional;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -22,7 +22,7 @@ public class DefaultJwtService implements JwtService {
   public DefaultJwtService(
       @Value("${jwt.secret}") String secret, @Value("${jwt.sessionTime}") int sessionTime) {
     this.sessionTime = sessionTime;
-    this.signingKey = new SecretKeySpec(secret.getBytes(), "HmacSHA512");
+    this.signingKey = Keys.hmacShaKeyFor(secret.getBytes());
   }
 
   @Override


### PR DESCRIPTION
## Summary
Child D of the Spring Boot 3 / Java 17 migration. Fixes source compilation breakages caused by the dependency bumps (base branch `devin/spring-boot-3-migration`), **excluding** the `javax.*`→`jakarta.*` namespace swap (Session B) and the Spring Security 6 rewrite of `WebSecurityConfig` (Session C).

### 1. jjwt 0.11.2 → 0.12.6 (`DefaultJwtService`)
Builder/parser API overhaul:
```
setSubject(id)          -> subject(id)
setExpiration(date)     -> expiration(date)
Jwts.parserBuilder()
    .setSigningKey(k)   -> Jwts.parser().verifyWith(k)
    .parseClaimsJws(t)  ->     .parseSignedClaims(t)
claimsJws.getBody()     -> claimsJws.getPayload()
```
Dropped the deprecated `SignatureAlgorithm` field. The signing key is now derived with `Keys.hmacShaKeyFor(secret.getBytes())` and `signWith(key)` infers the algorithm.

Why not `new SecretKeySpec(secret, "HmacSHA512")`: jjwt 0.12.6's `signWith(key)` throws `UnsupportedKeyException` when a key declared `HmacSHA512` is shorter than 512 bits — which is the case for the 480-bit test secret (`DefaultJwtServiceTest`), so the token round-trip test failed. `Keys.hmacShaKeyFor` selects the strongest standard HMAC the key length supports (HS384 for the 480-bit test secret, HS512 for the 688-bit production secret in `application.properties`), matching what the pre-PR `signWith(key)` inferred. Note: `Keys.hmacShaKeyFor` rejects secrets < 256 bits with `WeakKeyException` at bean construction — no impact for this repo's configured secrets.

### 2. DGS 4.9.21 → 9.2.2 / codegen 5.0.6 → 8.6.0 (graphql-java 22)
- `GraphQLCustomizeExceptionHandler`: graphql-java 22 removed `DataFetcherExceptionHandler.onException`; only `handleException` returning `CompletableFuture<DataFetcherExceptionHandlerResult>` remains. Overrode `handleException`, wrapped returns in `CompletableFuture.completedFuture(...)`, and delegate to `defaultHandler.handleException(...)`.
- `ArticleDatafetcher` / `CommentDatafetcher`: codegen 8.6.0 now types connection `pageInfo` as the generated `io.spring.graphql.types.PageInfo` instead of `graphql.relay.PageInfo`. Replaced the `DefaultPageInfo`/`DefaultConnectionCursor` construction with the generated builder:
```
PageInfo.newBuilder()
    .startCursor(...).endCursor(...)
    .hasPreviousPage(...).hasNextPage(...)
    .build();
```

### 3. Spring 6 (`CustomizeExceptionHandler`)
`ResponseEntityExceptionHandler.handleMethodArgumentNotValid` now takes `HttpStatusCode` instead of `HttpStatus`; updated the override signature and import.

### MyBatis 3.0.x & rest-assured 5.5.2
No code changes required — mappers and tests compile unchanged against the new versions.

## Verification
- `./gradlew generateJava` — succeeds.
- `./gradlew compileJava compileTestJava` — with the sibling changes applied locally (temporary `javax`→`jakarta` swap + `WebSecurityConfig` stub, not committed), both compile cleanly. On this branch alone the only remaining errors are the unmerged `javax`→`jakarta` (Session B) and `WebSecurityConfig`/`JwtTokenFilter` Spring Security 6 (Session C) changes — not in scope here.
- `DefaultJwtServiceTest` (3/3) passes under jjwt 0.12.6.

## Notes
- Left all `javax.*` imports untouched (including the correctly-`javax` `javax.crypto` in `DefaultJwtService`).
- joda-time not migrated (not required for compilation).


Link to Devin session: https://app.devin.ai/sessions/37f74a866a704f59a09555342f5572b2
Requested by: @kylie-chang
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/825?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->