### PR TITLE
test: add JaCoCo coverage and high-impact unit/integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -56,8 +57,44 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+// Generated GraphQL (DGS codegen) sources should not count towards coverage.
+def coverageExcludes = [
+        'io/spring/graphql/DgsConstants**',
+        'io/spring/graphql/types/**',
+        'io/spring/graphql/client/**',
+]
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn test
+    reports {
+        html.required = true
+        xml.required = true
+    }
+    classDirectories.setFrom(files(sourceSets.main.output.classesDirs.collect {
+        fileTree(dir: it, exclude: coverageExcludes)
+    }))
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    classDirectories.setFrom(files(sourceSets.main.output.classesDirs.collect {
+        fileTree(dir: it, exclude: coverageExcludes)
+    }))
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.0
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -1,0 +1,61 @@
+package io.spring.api;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.application.TagsQueryService;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TagsApi.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class TagsApiTest {
+  @Autowired private MockMvc mvc;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private JwtService jwtService;
+
+  @BeforeEach
+  public void setUp() {
+    RestAssuredMockMvc.mockMvc(mvc);
+  }
+
+  @Test
+  public void should_return_all_tags_under_tags_root() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring", "graphql"));
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .then()
+        .statusCode(200)
+        .body("tags", hasSize(3))
+        .body("tags[0]", equalTo("java"))
+        .body("tags[1]", equalTo("spring"))
+        .body("tags[2]", equalTo("graphql"));
+
+    verify(tagsQueryService).allTags();
+  }
+
+  @Test
+  public void should_return_empty_tags_array_when_no_tags_exist() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    RestAssuredMockMvc.when().get("/tags").then().statusCode(200).body("tags", empty());
+  }
+}

--- a/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
@@ -1,0 +1,145 @@
+package io.spring.api.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.UserRepository;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validator;
+import javax.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebMvcTest(CustomizeExceptionHandlerTest.TestController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({CustomizeExceptionHandler.class, CustomizeExceptionHandlerTest.TestController.class})
+public class CustomizeExceptionHandlerTest {
+  @Autowired private MockMvc mvc;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private JwtService jwtService;
+
+  @Test
+  public void should_return_422_with_field_errors_for_invalid_request() throws Exception {
+    mvc.perform(get("/exception-test/invalid-request"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.errors.title[0]").value("can't be empty"));
+  }
+
+  @Test
+  public void should_return_422_with_message_for_invalid_authentication() throws Exception {
+    mvc.perform(get("/exception-test/invalid-authentication"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.message").value("invalid email or password"));
+  }
+
+  @Test
+  public void should_return_422_for_request_body_validation_errors() throws Exception {
+    mvc.perform(
+            post("/exception-test/method-argument")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"request\":{\"name\":\"\"}}"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.errors.name[0]").value("can't be empty"));
+  }
+
+  @Test
+  public void should_return_422_for_constraint_violations() throws Exception {
+    mvc.perform(get("/exception-test/constraint-violation"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.errors.name[0]").value("can't be empty"));
+  }
+
+  @Test
+  public void should_return_404_for_resource_not_found() throws Exception {
+    mvc.perform(get("/exception-test/not-found"))
+        .andExpect(status().isNotFound())
+        .andExpect(
+            result ->
+                assertThat(result.getResolvedException())
+                    .isInstanceOf(ResourceNotFoundException.class));
+  }
+
+  @RestController
+  @RequestMapping("/exception-test")
+  public static class TestController {
+    private final Validator validator;
+
+    public TestController(Validator validator) {
+      this.validator = validator;
+    }
+
+    @GetMapping("/invalid-request")
+    public void invalidRequest() {
+      BeanPropertyBindingResult errors = new BeanPropertyBindingResult(new Object(), "article");
+      errors.addError(
+          new FieldError(
+              "article", "title", null, false, new String[] {"NotBlank"}, null, "can't be empty"));
+      throw new InvalidRequestException(errors);
+    }
+
+    @GetMapping("/invalid-authentication")
+    public void invalidAuthentication() {
+      throw new InvalidAuthenticationException();
+    }
+
+    @PostMapping("/method-argument")
+    public void methodArgument(@Valid @RequestBody ValidationRequest request) {}
+
+    @GetMapping("/constraint-violation")
+    public void constraintViolation() {
+      Set<ConstraintViolation<ValidationRequest>> violations =
+          validator.validate(new ValidationRequest(""));
+      throw new ConstraintViolationException(violations);
+    }
+
+    @GetMapping("/not-found")
+    public void notFound() {
+      throw new ResourceNotFoundException();
+    }
+  }
+
+  @JsonRootName("request")
+  public static class ValidationRequest {
+    @NotBlank(message = "can't be empty")
+    private String name;
+
+    public ValidationRequest() {}
+
+    public ValidationRequest(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+}

--- a/src/test/java/io/spring/api/exception/ErrorResourceSerializerTest.java
+++ b/src/test/java/io/spring/api/exception/ErrorResourceSerializerTest.java
@@ -1,0 +1,54 @@
+package io.spring.api.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class ErrorResourceSerializerTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void should_group_multiple_messages_by_field() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Arrays.asList(
+                new FieldErrorResource("user", "email", "Email", "must be a valid email"),
+                new FieldErrorResource("user", "email", "Unique", "has already been taken"),
+                new FieldErrorResource("user", "username", "NotBlank", "can't be empty")));
+
+    JsonNode actual = objectMapper.readTree(objectMapper.writeValueAsString(errorResource));
+    JsonNode expected =
+        objectMapper.readTree(
+            "{\"errors\":{\"email\":[\"must be a valid email\",\"has already been taken\"],"
+                + "\"username\":[\"can't be empty\"]}}");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void should_serialize_only_field_names_and_messages() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Collections.singletonList(
+                new FieldErrorResource("article-command", "title", "NotBlank", "can't be empty")));
+
+    JsonNode actual = objectMapper.readTree(objectMapper.writeValueAsString(errorResource));
+
+    assertThat(actual.path("errors").path("title").get(0).asText()).isEqualTo("can't be empty");
+    assertThat(actual.toString()).doesNotContain("article-command", "NotBlank");
+  }
+
+  @Test
+  public void should_serialize_empty_errors_object_when_there_are_no_field_errors()
+      throws Exception {
+    ErrorResource errorResource = new ErrorResource(Collections.emptyList());
+
+    JsonNode actual = objectMapper.readTree(objectMapper.writeValueAsString(errorResource));
+
+    assertThat(actual).isEqualTo(objectMapper.readTree("{\"errors\":{}}"));
+  }
+}

--- a/src/test/java/io/spring/application/UserQueryServiceTest.java
+++ b/src/test/java/io/spring/application/UserQueryServiceTest.java
@@ -1,0 +1,49 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.application.data.UserData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import({UserQueryService.class, MyBatisUserRepository.class})
+public class UserQueryServiceTest extends DbTestBase {
+  @Autowired private UserQueryService userQueryService;
+
+  @Autowired private UserRepository userRepository;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("aisensiy@gmail.com", "aisensiy", "123", "bio", "image");
+    userRepository.save(user);
+  }
+
+  @Test
+  public void should_find_user_by_id_with_full_projection() {
+    Optional<UserData> optional = userQueryService.findById(user.getId());
+
+    assertThat(optional).isPresent();
+    UserData userData = optional.get();
+    assertThat(userData.getId()).isEqualTo(user.getId());
+    assertThat(userData.getEmail()).isEqualTo("aisensiy@gmail.com");
+    assertThat(userData.getUsername()).isEqualTo("aisensiy");
+    assertThat(userData.getBio()).isEqualTo("bio");
+    assertThat(userData.getImage()).isEqualTo("image");
+  }
+
+  @Test
+  public void should_return_empty_when_user_not_found() {
+    Optional<UserData> optional = userQueryService.findById("not-existing-id");
+
+    assertThat(optional).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,143 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleCommandServiceTest {
+
+  @Mock private ArticleRepository articleRepository;
+
+  @InjectMocks private ArticleCommandService articleCommandService;
+
+  private User creator;
+
+  @BeforeEach
+  public void setUp() {
+    creator = new User("creator@example.com", "creator", "123", "", "");
+  }
+
+  @Test
+  public void should_create_article_from_new_article_param() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("How to learn Spring Boot")
+            .description("a description")
+            .body("the body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(param, creator);
+
+    assertThat(article.getTitle()).isEqualTo("How to learn Spring Boot");
+    assertThat(article.getDescription()).isEqualTo("a description");
+    assertThat(article.getBody()).isEqualTo("the body");
+    assertThat(article.getUserId()).isEqualTo(creator.getId());
+    verify(articleRepository).save(article);
+  }
+
+  @Test
+  public void should_generate_slug_from_title_on_create() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("A New Title")
+            .description("desc")
+            .body("body")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Article article = articleCommandService.createArticle(param, creator);
+
+    assertThat(article.getSlug()).isEqualTo("a-new-title");
+  }
+
+  @Test
+  public void should_map_tag_list_to_tags_and_deduplicate() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("tags")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(param, creator);
+
+    List<String> tagNames =
+        article.getTags().stream()
+            .map(t -> t.getName())
+            .collect(java.util.stream.Collectors.toList());
+    assertThat(tagNames).containsExactlyInAnyOrder("java", "spring");
+  }
+
+  @Test
+  public void should_handle_empty_tag_list_on_create() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("no tags")
+            .description("desc")
+            .body("body")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Article article = articleCommandService.createArticle(param, creator);
+
+    assertThat(article.getTags()).isEmpty();
+    verify(articleRepository).save(article);
+  }
+
+  @Test
+  public void should_update_title_description_and_body() {
+    Article article =
+        new Article("old title", "old desc", "old body", Collections.emptyList(), creator.getId());
+    UpdateArticleParam param = new UpdateArticleParam("new title", "new body", "new desc");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertThat(updated.getTitle()).isEqualTo("new title");
+    assertThat(updated.getDescription()).isEqualTo("new desc");
+    assertThat(updated.getBody()).isEqualTo("new body");
+    verify(articleRepository).save(article);
+  }
+
+  @Test
+  public void should_regenerate_slug_when_title_updated() {
+    Article article =
+        new Article("old title", "old desc", "old body", Collections.emptyList(), creator.getId());
+    assertThat(article.getSlug()).isEqualTo("old-title");
+    UpdateArticleParam param = new UpdateArticleParam("Brand New Title", "", "");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertThat(updated.getSlug()).isEqualTo("brand-new-title");
+  }
+
+  @Test
+  public void should_not_change_fields_when_update_params_are_empty() {
+    Article article =
+        new Article("old title", "old desc", "old body", Collections.emptyList(), creator.getId());
+    UpdateArticleParam param = new UpdateArticleParam("", "", "");
+
+    Article updated = articleCommandService.updateArticle(article, param);
+
+    assertThat(updated.getTitle()).isEqualTo("old title");
+    assertThat(updated.getDescription()).isEqualTo("old desc");
+    assertThat(updated.getBody()).isEqualTo("old body");
+    assertThat(updated.getSlug()).isEqualTo("old-title");
+    verify(articleRepository, times(1)).save(article);
+  }
+}

--- a/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
+++ b/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
@@ -1,0 +1,50 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedArticleValidatorTest {
+
+  @Mock private ArticleQueryService articleQueryService;
+
+  @InjectMocks private DuplicatedArticleValidator validator;
+
+  @Test
+  public void should_be_valid_when_no_article_with_slug_exists() {
+    String title = "A Fresh Title";
+    when(articleQueryService.findBySlug(eq(Article.toSlug(title)), isNull()))
+        .thenReturn(Optional.empty());
+
+    assertThat(validator.isValid(title, null)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_article_with_slug_exists() {
+    String title = "Existing Title";
+    when(articleQueryService.findBySlug(eq(Article.toSlug(title)), isNull()))
+        .thenReturn(Optional.of(mock(ArticleData.class)));
+
+    assertThat(validator.isValid(title, null)).isFalse();
+  }
+
+  @Test
+  public void should_look_up_by_slugified_title() {
+    when(articleQueryService.findBySlug(eq("hello-world"), isNull())).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("Hello World", null)).isTrue();
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
@@ -1,0 +1,46 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedEmailValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedEmailValidator validator;
+
+  @Test
+  public void should_be_valid_when_email_not_taken() {
+    when(userRepository.findByEmail("free@example.com")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("free@example.com", null)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_email_already_exists() {
+    User existing = new User("taken@example.com", "user", "pass", "", "");
+    when(userRepository.findByEmail("taken@example.com")).thenReturn(Optional.of(existing));
+
+    assertThat(validator.isValid("taken@example.com", null)).isFalse();
+  }
+
+  @Test
+  public void should_be_valid_when_value_is_null() {
+    assertThat(validator.isValid(null, null)).isTrue();
+  }
+
+  @Test
+  public void should_be_valid_when_value_is_empty() {
+    assertThat(validator.isValid("", null)).isTrue();
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
@@ -1,0 +1,46 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedUsernameValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedUsernameValidator validator;
+
+  @Test
+  public void should_be_valid_when_username_not_taken() {
+    when(userRepository.findByUsername("free")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("free", null)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_username_already_exists() {
+    User existing = new User("user@example.com", "taken", "pass", "", "");
+    when(userRepository.findByUsername("taken")).thenReturn(Optional.of(existing));
+
+    assertThat(validator.isValid("taken", null)).isFalse();
+  }
+
+  @Test
+  public void should_be_valid_when_value_is_null() {
+    assertThat(validator.isValid(null, null)).isTrue();
+  }
+
+  @Test
+  public void should_be_valid_when_value_is_empty() {
+    assertThat(validator.isValid("", null)).isTrue();
+  }
+}

--- a/src/test/java/io/spring/application/user/UpdateUserValidatorTest.java
+++ b/src/test/java/io/spring/application/user/UpdateUserValidatorTest.java
@@ -1,0 +1,107 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateUserValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private ConstraintValidatorContext context;
+
+  private UpdateUserValidator validator;
+
+  private User targetUser;
+
+  @BeforeEach
+  void setUp() {
+    validator = new UpdateUserValidator();
+    ReflectionTestUtils.setField(validator, "userRepository", userRepository);
+    targetUser = new User("target@example.com", "target", "pass", "", "");
+  }
+
+  private UpdateUserCommand commandWith(String email, String username) {
+    UpdateUserParam param = UpdateUserParam.builder().email(email).username(username).build();
+    return new UpdateUserCommand(targetUser, param);
+  }
+
+  private void stubViolationBuilder() {
+    ConstraintViolationBuilder builder = mock(ConstraintViolationBuilder.class);
+    NodeBuilderCustomizableContext node = mock(NodeBuilderCustomizableContext.class);
+    lenient().when(context.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
+    lenient().when(builder.addPropertyNode(anyString())).thenReturn(node);
+    lenient().when(node.addConstraintViolation()).thenReturn(context);
+  }
+
+  @Test
+  void valid_when_email_and_username_are_free() {
+    when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid(commandWith("new@example.com", "newname"), context)).isTrue();
+    verify(context, never()).disableDefaultConstraintViolation();
+  }
+
+  @Test
+  void valid_when_email_and_username_belong_to_target_user_itself() {
+    when(userRepository.findByEmail("target@example.com")).thenReturn(Optional.of(targetUser));
+    when(userRepository.findByUsername("target")).thenReturn(Optional.of(targetUser));
+
+    assertThat(validator.isValid(commandWith("target@example.com", "target"), context)).isTrue();
+  }
+
+  @Test
+  void invalid_when_email_taken_by_another_user() {
+    User other = new User("other@example.com", "other", "pass", "", "");
+    when(userRepository.findByEmail("other@example.com")).thenReturn(Optional.of(other));
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+    stubViolationBuilder();
+
+    assertThat(validator.isValid(commandWith("other@example.com", "newname"), context)).isFalse();
+    verify(context).disableDefaultConstraintViolation();
+    verify(context).buildConstraintViolationWithTemplate("email already exist");
+  }
+
+  @Test
+  void invalid_when_username_taken_by_another_user() {
+    User other = new User("other@example.com", "other", "pass", "", "");
+    when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("other")).thenReturn(Optional.of(other));
+    stubViolationBuilder();
+
+    assertThat(validator.isValid(commandWith("new@example.com", "other"), context)).isFalse();
+    verify(context).disableDefaultConstraintViolation();
+    verify(context).buildConstraintViolationWithTemplate("username already exist");
+  }
+
+  @Test
+  void invalid_when_both_email_and_username_taken_by_another_user() {
+    User other = new User("other@example.com", "other", "pass", "", "");
+    when(userRepository.findByEmail("other@example.com")).thenReturn(Optional.of(other));
+    when(userRepository.findByUsername("other")).thenReturn(Optional.of(other));
+    stubViolationBuilder();
+
+    assertThat(validator.isValid(commandWith("other@example.com", "other"), context)).isFalse();
+    verify(context).buildConstraintViolationWithTemplate("email already exist");
+    verify(context).buildConstraintViolationWithTemplate("username already exist");
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,119 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private static final String DEFAULT_IMAGE =
+      "https://static.productionready.io/images/smiley-cyrus.jpg";
+
+  private UserService userService;
+
+  @BeforeEach
+  public void setUp() {
+    userService = new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder);
+  }
+
+  @Test
+  public void should_create_user_from_register_param() {
+    RegisterParam param = new RegisterParam("new@example.com", "newuser", "plain-password");
+    when(passwordEncoder.encode("plain-password")).thenReturn("encoded-password");
+
+    User user = userService.createUser(param);
+
+    assertThat(user.getEmail()).isEqualTo("new@example.com");
+    assertThat(user.getUsername()).isEqualTo("newuser");
+    assertThat(user.getBio()).isEqualTo("");
+    verify(userRepository).save(user);
+  }
+
+  @Test
+  public void should_encode_password_and_use_default_image_on_register() {
+    RegisterParam param = new RegisterParam("new@example.com", "newuser", "plain-password");
+    when(passwordEncoder.encode("plain-password")).thenReturn("encoded-password");
+
+    User user = userService.createUser(param);
+
+    assertThat(user.getPassword()).isEqualTo("encoded-password");
+    assertThat(user.getImage()).isEqualTo(DEFAULT_IMAGE);
+    verify(passwordEncoder).encode("plain-password");
+  }
+
+  @Test
+  public void should_persist_created_user() {
+    RegisterParam param = new RegisterParam("new@example.com", "newuser", "plain-password");
+    when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+
+    userService.createUser(param);
+
+    verify(userRepository).save(captor.capture());
+    assertThat(captor.getValue().getEmail()).isEqualTo("new@example.com");
+  }
+
+  @Test
+  public void should_update_all_provided_fields() {
+    User target = new User("old@example.com", "olduser", "pass", "old bio", "old-image");
+    UpdateUserParam param =
+        UpdateUserParam.builder()
+            .email("new@example.com")
+            .username("newuser")
+            .password("newpass")
+            .bio("new bio")
+            .image("new-image")
+            .build();
+
+    userService.updateUser(new UpdateUserCommand(target, param));
+
+    assertThat(target.getEmail()).isEqualTo("new@example.com");
+    assertThat(target.getUsername()).isEqualTo("newuser");
+    assertThat(target.getPassword()).isEqualTo("newpass");
+    assertThat(target.getBio()).isEqualTo("new bio");
+    assertThat(target.getImage()).isEqualTo("new-image");
+    verify(userRepository).save(target);
+  }
+
+  @Test
+  public void should_only_update_non_empty_fields() {
+    User target = new User("old@example.com", "olduser", "pass", "old bio", "old-image");
+    UpdateUserParam param = UpdateUserParam.builder().email("new@example.com").build();
+
+    userService.updateUser(new UpdateUserCommand(target, param));
+
+    assertThat(target.getEmail()).isEqualTo("new@example.com");
+    assertThat(target.getUsername()).isEqualTo("olduser");
+    assertThat(target.getPassword()).isEqualTo("pass");
+    assertThat(target.getBio()).isEqualTo("old bio");
+    assertThat(target.getImage()).isEqualTo("old-image");
+    verify(userRepository).save(target);
+  }
+
+  @Test
+  public void should_not_encode_password_on_update() {
+    User target = new User("old@example.com", "olduser", "pass", "old bio", "old-image");
+    UpdateUserParam param = UpdateUserParam.builder().bio("just bio").build();
+
+    userService.updateUser(new UpdateUserCommand(target, param));
+
+    verify(passwordEncoder, never()).encode(anyString());
+  }
+}

--- a/src/test/java/io/spring/core/article/ArticleBehaviorTest.java
+++ b/src/test/java/io/spring/core/article/ArticleBehaviorTest.java
@@ -1,0 +1,134 @@
+package io.spring.core.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+public class ArticleBehaviorTest {
+
+  @Test
+  public void should_generate_id_and_default_timestamps_on_construction() {
+    Article article = new Article("a title", "desc", "body", Arrays.asList("java"), "userId");
+    assertThat(article.getId()).isNotNull().isNotEmpty();
+    assertThat(article.getCreatedAt()).isNotNull();
+    assertThat(article.getUpdatedAt()).isEqualTo(article.getCreatedAt());
+    assertThat(article.getUserId()).isEqualTo("userId");
+  }
+
+  @Test
+  public void should_map_tag_list_to_tags() {
+    Article article =
+        new Article("a title", "desc", "body", Arrays.asList("java", "spring"), "userId");
+    List<String> names = article.getTags().stream().map(Tag::getName).collect(Collectors.toList());
+    assertThat(names).containsExactlyInAnyOrder("java", "spring");
+  }
+
+  @Test
+  public void should_deduplicate_tags() {
+    Article article =
+        new Article("a title", "desc", "body", Arrays.asList("java", "java"), "userId");
+    assertThat(article.getTags()).hasSize(1);
+    assertThat(article.getTags().get(0).getName()).isEqualTo("java");
+  }
+
+  @Test
+  public void should_have_empty_tags_when_tag_list_empty() {
+    Article article = new Article("a title", "desc", "body", Collections.emptyList(), "userId");
+    assertThat(article.getTags()).isEmpty();
+  }
+
+  @Test
+  public void should_regenerate_slug_when_title_updated() {
+    Article article = new Article("old title", "desc", "body", Collections.emptyList(), "userId");
+    article.update("brand new title", "", "");
+    assertThat(article.getTitle()).isEqualTo("brand new title");
+    assertThat(article.getSlug()).isEqualTo("brand-new-title");
+  }
+
+  @Test
+  public void should_not_change_title_or_slug_when_update_title_empty() {
+    Article article = new Article("old title", "desc", "body", Collections.emptyList(), "userId");
+    String originalSlug = article.getSlug();
+    article.update("", "new desc", "new body");
+    assertThat(article.getTitle()).isEqualTo("old title");
+    assertThat(article.getSlug()).isEqualTo(originalSlug);
+    assertThat(article.getDescription()).isEqualTo("new desc");
+    assertThat(article.getBody()).isEqualTo("new body");
+  }
+
+  @Test
+  public void should_not_change_fields_when_all_update_values_empty() {
+    Article article =
+        new Article("old title", "old desc", "old body", Collections.emptyList(), "userId");
+    article.update("", "", "");
+    assertThat(article.getTitle()).isEqualTo("old title");
+    assertThat(article.getDescription()).isEqualTo("old desc");
+    assertThat(article.getBody()).isEqualTo("old body");
+  }
+
+  @Test
+  public void should_advance_updated_at_when_a_field_is_updated() {
+    DateTime createdAt = new DateTime().minusDays(1);
+    Article article =
+        new Article("title", "desc", "body", Collections.emptyList(), "userId", createdAt);
+    assertThat(article.getUpdatedAt()).isEqualTo(createdAt);
+    article.update("new title", "", "");
+    assertThat(article.getUpdatedAt()).isGreaterThan(createdAt);
+  }
+
+  @Test
+  public void should_not_advance_updated_at_when_update_values_all_empty() {
+    DateTime createdAt = new DateTime().minusDays(1);
+    Article article =
+        new Article("title", "desc", "body", Collections.emptyList(), "userId", createdAt);
+    article.update("", "", "");
+    assertThat(article.getUpdatedAt()).isEqualTo(createdAt);
+  }
+
+  @Test
+  public void should_update_description_and_body_independently() {
+    Article article =
+        new Article("title", "old desc", "old body", Collections.emptyList(), "userId");
+    article.update("", "new desc", "");
+    assertThat(article.getDescription()).isEqualTo("new desc");
+    assertThat(article.getBody()).isEqualTo("old body");
+  }
+
+  @Test
+  public void should_be_equal_when_ids_match() {
+    Article article = new Article("title", "desc", "body", Collections.emptyList(), "userId");
+    Article same =
+        new Article("other", "otherDesc", "otherBody", Collections.emptyList(), "otherUser");
+    setId(same, article.getId());
+    assertThat(article).isEqualTo(same);
+    assertThat(article.hashCode()).isEqualTo(same.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_differ() {
+    Article first = new Article("title", "desc", "body", Collections.emptyList(), "userId");
+    Article second = new Article("title", "desc", "body", Collections.emptyList(), "userId");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  public void should_generate_slug_via_static_helper() {
+    assertThat(Article.toSlug("A New   Title")).isEqualTo("a-new-title");
+    assertThat(Article.toSlug("what?the.hell,w")).isEqualTo("what-the-hell-w");
+  }
+
+  private void setId(Article article, String id) {
+    try {
+      java.lang.reflect.Field field = Article.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(article, id);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/spring/core/article/TagTest.java
+++ b/src/test/java/io/spring/core/article/TagTest.java
@@ -1,0 +1,52 @@
+package io.spring.core.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class TagTest {
+
+  @Test
+  public void should_generate_id_on_construction() {
+    Tag tag = new Tag("java");
+    assertThat(tag.getId()).isNotNull();
+    assertThat(tag.getId()).isNotEmpty();
+  }
+
+  @Test
+  public void should_set_name_on_construction() {
+    Tag tag = new Tag("java");
+    assertThat(tag.getName()).isEqualTo("java");
+  }
+
+  @Test
+  public void should_generate_distinct_ids_for_different_instances() {
+    Tag first = new Tag("java");
+    Tag second = new Tag("java");
+    assertThat(first.getId()).isNotEqualTo(second.getId());
+  }
+
+  @Test
+  public void should_be_equal_when_names_match_regardless_of_id() {
+    Tag first = new Tag("java");
+    Tag second = new Tag("java");
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_names_differ() {
+    Tag first = new Tag("java");
+    Tag second = new Tag("kotlin");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  public void should_allow_setting_fields_via_setters() {
+    Tag tag = new Tag();
+    tag.setId("id");
+    tag.setName("scala");
+    assertThat(tag.getId()).isEqualTo("id");
+    assertThat(tag.getName()).isEqualTo("scala");
+  }
+}

--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -1,0 +1,67 @@
+package io.spring.core.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+
+  @Test
+  public void should_generate_id_on_construction() {
+    Comment comment = new Comment("body", "userId", "articleId");
+    assertThat(comment.getId()).isNotNull();
+    assertThat(comment.getId()).isNotEmpty();
+  }
+
+  @Test
+  public void should_set_all_fields_on_construction() {
+    Comment comment = new Comment("body", "userId", "articleId");
+    assertThat(comment.getBody()).isEqualTo("body");
+    assertThat(comment.getUserId()).isEqualTo("userId");
+    assertThat(comment.getArticleId()).isEqualTo("articleId");
+  }
+
+  @Test
+  public void should_set_created_at_on_construction() {
+    DateTime before = new DateTime();
+    Comment comment = new Comment("body", "userId", "articleId");
+    DateTime after = new DateTime();
+    assertThat(comment.getCreatedAt()).isNotNull();
+    assertThat(comment.getCreatedAt().isBefore(before.minusSeconds(1))).isFalse();
+    assertThat(comment.getCreatedAt().isAfter(after.plusSeconds(1))).isFalse();
+  }
+
+  @Test
+  public void should_generate_distinct_ids_for_different_comments() {
+    Comment first = new Comment("body", "userId", "articleId");
+    Comment second = new Comment("body", "userId", "articleId");
+    assertThat(first.getId()).isNotEqualTo(second.getId());
+  }
+
+  @Test
+  public void should_be_equal_when_ids_match() {
+    Comment comment = new Comment("body", "userId", "articleId");
+    Comment same = new Comment("other", "otherUser", "otherArticle");
+    setId(same, comment.getId());
+    assertThat(comment).isEqualTo(same);
+    assertThat(comment.hashCode()).isEqualTo(same.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_differ() {
+    Comment first = new Comment("body", "userId", "articleId");
+    Comment second = new Comment("body", "userId", "articleId");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  private void setId(Comment comment, String id) {
+    try {
+      java.lang.reflect.Field field = Comment.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(comment, id);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
+++ b/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
@@ -1,0 +1,44 @@
+package io.spring.core.favorite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ArticleFavoriteTest {
+
+  @Test
+  public void should_set_article_and_user_ids_on_construction() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+    assertThat(favorite.getArticleId()).isEqualTo("articleId");
+    assertThat(favorite.getUserId()).isEqualTo("userId");
+  }
+
+  @Test
+  public void should_be_equal_when_both_ids_match() {
+    ArticleFavorite first = new ArticleFavorite("articleId", "userId");
+    ArticleFavorite second = new ArticleFavorite("articleId", "userId");
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_article_id_differs() {
+    ArticleFavorite first = new ArticleFavorite("articleId", "userId");
+    ArticleFavorite second = new ArticleFavorite("otherArticle", "userId");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  public void should_not_be_equal_when_user_id_differs() {
+    ArticleFavorite first = new ArticleFavorite("articleId", "userId");
+    ArticleFavorite second = new ArticleFavorite("articleId", "otherUser");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  public void should_allow_null_ids() {
+    ArticleFavorite favorite = new ArticleFavorite(null, null);
+    assertThat(favorite.getArticleId()).isNull();
+    assertThat(favorite.getUserId()).isNull();
+  }
+}

--- a/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
+++ b/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
@@ -1,0 +1,73 @@
+package io.spring.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.spring.core.article.Article;
+import io.spring.core.comment.Comment;
+import io.spring.core.user.User;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class AuthorizationServiceTest {
+
+  private User newUser() {
+    return new User("user@example.com", "user", "123", "", "");
+  }
+
+  @Test
+  void should_allow_author_to_write_article() {
+    User author = newUser();
+    Article article =
+        new Article("title", "desc", "body", Collections.singletonList("java"), author.getId());
+
+    assertTrue(AuthorizationService.canWriteArticle(author, article));
+  }
+
+  @Test
+  void should_not_allow_non_author_to_write_article() {
+    User author = newUser();
+    User other = newUser();
+    Article article =
+        new Article("title", "desc", "body", Collections.singletonList("java"), author.getId());
+
+    assertFalse(AuthorizationService.canWriteArticle(other, article));
+  }
+
+  @Test
+  void article_author_can_write_comment_even_if_not_comment_author() {
+    User articleAuthor = newUser();
+    User commentAuthor = newUser();
+    Article article =
+        new Article(
+            "title", "desc", "body", Collections.singletonList("java"), articleAuthor.getId());
+    Comment comment = new Comment("comment body", commentAuthor.getId(), article.getId());
+
+    assertTrue(AuthorizationService.canWriteComment(articleAuthor, article, comment));
+  }
+
+  @Test
+  void comment_author_can_write_comment_even_if_not_article_author() {
+    User articleAuthor = newUser();
+    User commentAuthor = newUser();
+    Article article =
+        new Article(
+            "title", "desc", "body", Collections.singletonList("java"), articleAuthor.getId());
+    Comment comment = new Comment("comment body", commentAuthor.getId(), article.getId());
+
+    assertTrue(AuthorizationService.canWriteComment(commentAuthor, article, comment));
+  }
+
+  @Test
+  void unrelated_user_cannot_write_comment() {
+    User articleAuthor = newUser();
+    User commentAuthor = newUser();
+    User stranger = newUser();
+    Article article =
+        new Article(
+            "title", "desc", "body", Collections.singletonList("java"), articleAuthor.getId());
+    Comment comment = new Comment("comment body", commentAuthor.getId(), article.getId());
+
+    assertFalse(AuthorizationService.canWriteComment(stranger, article, comment));
+  }
+}

--- a/src/test/java/io/spring/core/user/FollowRelationTest.java
+++ b/src/test/java/io/spring/core/user/FollowRelationTest.java
@@ -1,0 +1,53 @@
+package io.spring.core.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class FollowRelationTest {
+
+  @Test
+  public void should_set_user_and_target_ids_on_construction() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+    assertThat(relation.getUserId()).isEqualTo("userId");
+    assertThat(relation.getTargetId()).isEqualTo("targetId");
+  }
+
+  @Test
+  public void should_allow_setting_ids_via_setters() {
+    FollowRelation relation = new FollowRelation();
+    relation.setUserId("userId");
+    relation.setTargetId("targetId");
+    assertThat(relation.getUserId()).isEqualTo("userId");
+    assertThat(relation.getTargetId()).isEqualTo("targetId");
+  }
+
+  @Test
+  public void should_be_equal_when_both_ids_match() {
+    FollowRelation first = new FollowRelation("userId", "targetId");
+    FollowRelation second = new FollowRelation("userId", "targetId");
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_user_id_differs() {
+    FollowRelation first = new FollowRelation("userId", "targetId");
+    FollowRelation second = new FollowRelation("otherUser", "targetId");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  public void should_not_be_equal_when_target_id_differs() {
+    FollowRelation first = new FollowRelation("userId", "targetId");
+    FollowRelation second = new FollowRelation("userId", "otherTarget");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  public void should_allow_null_ids() {
+    FollowRelation relation = new FollowRelation(null, null);
+    assertThat(relation.getUserId()).isNull();
+    assertThat(relation.getTargetId()).isNull();
+  }
+}

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -1,0 +1,110 @@
+package io.spring.core.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+  @Test
+  public void should_generate_id_on_construction() {
+    User user = new User("user@example.com", "username", "password", "bio", "image");
+    assertThat(user.getId()).isNotNull();
+    assertThat(user.getId()).isNotEmpty();
+  }
+
+  @Test
+  public void should_set_all_fields_on_construction() {
+    User user = new User("user@example.com", "username", "password", "bio", "image");
+    assertThat(user.getEmail()).isEqualTo("user@example.com");
+    assertThat(user.getUsername()).isEqualTo("username");
+    assertThat(user.getPassword()).isEqualTo("password");
+    assertThat(user.getBio()).isEqualTo("bio");
+    assertThat(user.getImage()).isEqualTo("image");
+  }
+
+  @Test
+  public void should_generate_distinct_ids_for_different_users() {
+    User first = new User("a@example.com", "a", "pw", "", "");
+    User second = new User("b@example.com", "b", "pw", "", "");
+    assertThat(first.getId()).isNotEqualTo(second.getId());
+  }
+
+  @Test
+  public void should_update_all_fields_when_all_values_present() {
+    User user = new User("old@example.com", "oldname", "oldpw", "oldbio", "oldimage");
+    user.update("new@example.com", "newname", "newpw", "newbio", "newimage");
+    assertThat(user.getEmail()).isEqualTo("new@example.com");
+    assertThat(user.getUsername()).isEqualTo("newname");
+    assertThat(user.getPassword()).isEqualTo("newpw");
+    assertThat(user.getBio()).isEqualTo("newbio");
+    assertThat(user.getImage()).isEqualTo("newimage");
+  }
+
+  @Test
+  public void should_not_update_fields_when_values_are_null() {
+    User user = new User("old@example.com", "oldname", "oldpw", "oldbio", "oldimage");
+    user.update(null, null, null, null, null);
+    assertThat(user.getEmail()).isEqualTo("old@example.com");
+    assertThat(user.getUsername()).isEqualTo("oldname");
+    assertThat(user.getPassword()).isEqualTo("oldpw");
+    assertThat(user.getBio()).isEqualTo("oldbio");
+    assertThat(user.getImage()).isEqualTo("oldimage");
+  }
+
+  @Test
+  public void should_not_update_fields_when_values_are_empty() {
+    User user = new User("old@example.com", "oldname", "oldpw", "oldbio", "oldimage");
+    user.update("", "", "", "", "");
+    assertThat(user.getEmail()).isEqualTo("old@example.com");
+    assertThat(user.getUsername()).isEqualTo("oldname");
+    assertThat(user.getPassword()).isEqualTo("oldpw");
+    assertThat(user.getBio()).isEqualTo("oldbio");
+    assertThat(user.getImage()).isEqualTo("oldimage");
+  }
+
+  @Test
+  public void should_partially_update_only_present_fields() {
+    User user = new User("old@example.com", "oldname", "oldpw", "oldbio", "oldimage");
+    user.update("new@example.com", "", null, "newbio", "");
+    assertThat(user.getEmail()).isEqualTo("new@example.com");
+    assertThat(user.getUsername()).isEqualTo("oldname");
+    assertThat(user.getPassword()).isEqualTo("oldpw");
+    assertThat(user.getBio()).isEqualTo("newbio");
+    assertThat(user.getImage()).isEqualTo("oldimage");
+  }
+
+  @Test
+  public void should_keep_id_stable_after_update() {
+    User user = new User("old@example.com", "oldname", "oldpw", "oldbio", "oldimage");
+    String originalId = user.getId();
+    user.update("new@example.com", "newname", "newpw", "newbio", "newimage");
+    assertThat(user.getId()).isEqualTo(originalId);
+  }
+
+  @Test
+  public void should_consider_users_equal_when_ids_match() {
+    User user = new User("user@example.com", "username", "password", "bio", "image");
+    User same = new User("other@example.com", "other", "otherpw", "otherbio", "otherimage");
+    setId(same, user.getId());
+    assertThat(user).isEqualTo(same);
+    assertThat(user.hashCode()).isEqualTo(same.hashCode());
+  }
+
+  @Test
+  public void should_consider_users_unequal_when_ids_differ() {
+    User first = new User("user@example.com", "username", "password", "bio", "image");
+    User second = new User("user@example.com", "username", "password", "bio", "image");
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  private void setId(User user, String id) {
+    try {
+      java.lang.reflect.Field field = User.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(user, id);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,265 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.article.Article;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.ArticlesConnection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleDatafetcherTest {
+
+  @Mock private ArticleQueryService articleQueryService;
+  @Mock private UserRepository userRepository;
+  @Mock private DataFetchingEnvironment env;
+  @Mock private DataFetchingEnvironment plainDfe;
+
+  private ArticleDatafetcher articleDatafetcher;
+  private DgsDataFetchingEnvironment dfe;
+
+  private final ProfileData author = new ProfileData("id", "jane", "bio", "image", false);
+
+  @BeforeEach
+  void setUp() {
+    articleDatafetcher = new ArticleDatafetcher(articleQueryService, userRepository);
+    dfe = new DgsDataFetchingEnvironment(env);
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private ArticleData articleData(String slug) {
+    return new ArticleData(
+        slug + "-id",
+        slug,
+        "title",
+        "desc",
+        "body",
+        false,
+        0,
+        new DateTime(),
+        new DateTime(),
+        Arrays.asList("java"),
+        author);
+  }
+
+  private CursorPager<ArticleData> pager(List<ArticleData> data, Direction direction) {
+    return new CursorPager<>(data, direction, false);
+  }
+
+  @Test
+  void feed_should_throw_when_neither_first_nor_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> articleDatafetcher.getFeed(null, null, null, null, dfe));
+  }
+
+  @Test
+  void feed_should_return_connection_for_first() {
+    when(articleQueryService.findUserFeedWithCursor(isNull(), any()))
+        .thenReturn(pager(Arrays.asList(articleData("a1"), articleData("a2")), Direction.NEXT));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(10, null, null, null, dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(2);
+    assertThat(result.getData().getEdges().get(0).getNode().getSlug()).isEqualTo("a1");
+    assertThat((Map<String, ?>) result.getLocalContext()).containsOnlyKeys("a1", "a2");
+  }
+
+  @Test
+  void feed_should_return_connection_for_last() {
+    when(articleQueryService.findUserFeedWithCursor(isNull(), any()))
+        .thenReturn(pager(Collections.singletonList(articleData("a1")), Direction.PREV));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(null, null, 5, null, dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void user_feed_should_throw_when_neither_first_nor_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> articleDatafetcher.userFeed(null, null, null, null, dfe));
+  }
+
+  @Test
+  void user_feed_should_throw_not_found_when_user_missing() {
+    io.spring.graphql.types.Profile profile =
+        io.spring.graphql.types.Profile.newBuilder().username("ghost").build();
+    when(env.<io.spring.graphql.types.Profile>getSource()).thenReturn(profile);
+    when(userRepository.findByUsername("ghost")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleDatafetcher.userFeed(10, null, null, null, dfe));
+  }
+
+  @Test
+  void user_feed_should_return_connection() {
+    io.spring.graphql.types.Profile profile =
+        io.spring.graphql.types.Profile.newBuilder().username("jane").build();
+    User target = new User("jane@example.com", "jane", "123", "bio", "image");
+    when(env.<io.spring.graphql.types.Profile>getSource()).thenReturn(profile);
+    when(userRepository.findByUsername("jane")).thenReturn(Optional.of(target));
+    when(articleQueryService.findUserFeedWithCursor(eq(target), any()))
+        .thenReturn(pager(Collections.singletonList(articleData("a1")), Direction.NEXT));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userFeed(10, null, null, null, dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void user_favorites_should_throw_when_neither_first_nor_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> articleDatafetcher.userFavorites(null, null, null, null, dfe));
+  }
+
+  @Test
+  void user_favorites_should_return_connection() {
+    io.spring.graphql.types.Profile profile =
+        io.spring.graphql.types.Profile.newBuilder().username("jane").build();
+    when(env.<io.spring.graphql.types.Profile>getSource()).thenReturn(profile);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), eq("jane"), any(), isNull()))
+        .thenReturn(pager(Collections.singletonList(articleData("a1")), Direction.NEXT));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userFavorites(10, null, null, null, dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void user_articles_should_return_connection() {
+    io.spring.graphql.types.Profile profile =
+        io.spring.graphql.types.Profile.newBuilder().username("jane").build();
+    when(env.<io.spring.graphql.types.Profile>getSource()).thenReturn(profile);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), eq("jane"), isNull(), any(), isNull()))
+        .thenReturn(pager(Collections.singletonList(articleData("a1")), Direction.NEXT));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userArticles(10, null, null, null, dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void get_articles_should_throw_when_neither_first_nor_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> articleDatafetcher.getArticles(null, null, null, null, null, null, null, dfe));
+  }
+
+  @Test
+  void get_articles_should_filter_by_tag_author_and_favorited() {
+    when(articleQueryService.findRecentArticlesWithCursor(
+            eq("java"), eq("bob"), eq("alice"), any(), isNull()))
+        .thenReturn(pager(Collections.singletonList(articleData("a1")), Direction.NEXT));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getArticles(10, null, null, null, "bob", "alice", "java", dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+    assertThat(result.getData().getEdges().get(0).getNode().getSlug()).isEqualTo("a1");
+  }
+
+  @Test
+  void get_article_should_return_article_from_local_context() {
+    Article article = new Article("title", "desc", "body", Arrays.asList("java"), "user-1");
+    when(plainDfe.<Article>getLocalContext()).thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), isNull()))
+        .thenReturn(Optional.of(articleData("the-slug")));
+
+    DataFetcherResult<io.spring.graphql.types.Article> result =
+        articleDatafetcher.getArticle(plainDfe);
+
+    assertThat(result.getData().getSlug()).isEqualTo("the-slug");
+    assertThat((Map<String, ?>) result.getLocalContext()).containsKey("the-slug");
+  }
+
+  @Test
+  void get_article_should_throw_not_found() {
+    Article article = new Article("title", "desc", "body", Arrays.asList("java"), "user-1");
+    when(plainDfe.<Article>getLocalContext()).thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), isNull())).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleDatafetcher.getArticle(plainDfe));
+  }
+
+  @Test
+  void get_comment_article_should_return_article() {
+    CommentData comment =
+        new CommentData("c1", "body", "article-1", new DateTime(), new DateTime(), author);
+    when(plainDfe.<CommentData>getLocalContext()).thenReturn(comment);
+    when(articleQueryService.findById(eq("article-1"), isNull()))
+        .thenReturn(Optional.of(articleData("the-slug")));
+
+    DataFetcherResult<io.spring.graphql.types.Article> result =
+        articleDatafetcher.getCommentArticle(plainDfe);
+
+    assertThat(result.getData().getSlug()).isEqualTo("the-slug");
+  }
+
+  @Test
+  void find_article_by_slug_should_return_article() {
+    when(articleQueryService.findBySlug(eq("the-slug"), isNull()))
+        .thenReturn(Optional.of(articleData("the-slug")));
+
+    DataFetcherResult<io.spring.graphql.types.Article> result =
+        articleDatafetcher.findArticleBySlug("the-slug");
+
+    assertThat(result.getData().getSlug()).isEqualTo("the-slug");
+    assertThat(result.getData().getTitle()).isEqualTo("title");
+  }
+
+  @Test
+  void find_article_by_slug_should_throw_not_found() {
+    when(articleQueryService.findBySlug(eq("ghost"), isNull())).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleDatafetcher.findArticleBySlug("ghost"));
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,283 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.article.UpdateArticleParam;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ArticlePayload;
+import io.spring.graphql.types.CreateArticleInput;
+import io.spring.graphql.types.DeletionStatus;
+import io.spring.graphql.types.UpdateArticleInput;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class ArticleMutationTest {
+
+  private ArticleCommandService articleCommandService;
+  private ArticleFavoriteRepository articleFavoriteRepository;
+  private ArticleRepository articleRepository;
+  private ArticleMutation articleMutation;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    articleCommandService = org.mockito.Mockito.mock(ArticleCommandService.class);
+    articleFavoriteRepository = org.mockito.Mockito.mock(ArticleFavoriteRepository.class);
+    articleRepository = org.mockito.Mockito.mock(ArticleRepository.class);
+    articleMutation =
+        new ArticleMutation(articleCommandService, articleFavoriteRepository, articleRepository);
+    user = new User("john@example.com", "john", "123", "", "");
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void authenticateAs(User u) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(u, null));
+  }
+
+  private void authenticateAnonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+
+  private Article articleBy(User author) {
+    return new Article("How to Test", "desc", "body", Arrays.asList("java"), author.getId());
+  }
+
+  @Test
+  void should_create_article_and_expose_it_via_local_context() {
+    authenticateAs(user);
+    CreateArticleInput input =
+        CreateArticleInput.newBuilder()
+            .title("How to Test")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+    Article created = articleBy(user);
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(user)))
+        .thenReturn(created);
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.createArticle(input);
+
+    assertThat(result.getData()).isNotNull();
+    assertThat(result.getLocalContext()).isEqualTo(created);
+
+    ArgumentCaptor<NewArticleParam> captor = ArgumentCaptor.forClass(NewArticleParam.class);
+    verify(articleCommandService).createArticle(captor.capture(), eq(user));
+    NewArticleParam param = captor.getValue();
+    assertThat(param.getTitle()).isEqualTo("How to Test");
+    assertThat(param.getDescription()).isEqualTo("desc");
+    assertThat(param.getBody()).isEqualTo("body");
+    assertThat(param.getTagList()).containsExactlyInAnyOrder("java", "spring");
+  }
+
+  @Test
+  void should_default_tag_list_to_empty_when_null() {
+    authenticateAs(user);
+    CreateArticleInput input =
+        CreateArticleInput.newBuilder()
+            .title("No Tags")
+            .description("desc")
+            .body("body")
+            .tagList(null)
+            .build();
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(user)))
+        .thenReturn(articleBy(user));
+
+    articleMutation.createArticle(input);
+
+    ArgumentCaptor<NewArticleParam> captor = ArgumentCaptor.forClass(NewArticleParam.class);
+    verify(articleCommandService).createArticle(captor.capture(), eq(user));
+    assertThat(captor.getValue().getTagList()).isEmpty();
+  }
+
+  @Test
+  void should_reject_create_article_when_not_authenticated() {
+    authenticateAnonymous();
+    CreateArticleInput input =
+        CreateArticleInput.newBuilder().title("t").description("d").body("b").build();
+
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> articleMutation.createArticle(input));
+    verify(articleCommandService, never()).createArticle(any(), any());
+  }
+
+  @Test
+  void should_update_article_when_author() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any(UpdateArticleParam.class)))
+        .thenReturn(article);
+    UpdateArticleInput changes =
+        UpdateArticleInput.newBuilder().title("new").body("nb").description("nd").build();
+
+    DataFetcherResult<ArticlePayload> result =
+        articleMutation.updateArticle(article.getSlug(), changes);
+
+    assertThat(result.getLocalContext()).isEqualTo(article);
+    verify(articleCommandService).updateArticle(eq(article), any(UpdateArticleParam.class));
+  }
+
+  @Test
+  void should_reject_update_article_when_missing() {
+    authenticateAs(user);
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(
+            () ->
+                articleMutation.updateArticle("missing", UpdateArticleInput.newBuilder().build()));
+  }
+
+  @Test
+  void should_reject_update_article_when_not_author() {
+    authenticateAs(user);
+    User another = new User("a@a.com", "another", "123", "", "");
+    Article article = articleBy(another);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    assertThatExceptionOfType(NoAuthorizationException.class)
+        .isThrownBy(
+            () ->
+                articleMutation.updateArticle(
+                    article.getSlug(), UpdateArticleInput.newBuilder().build()));
+    verify(articleCommandService, never()).updateArticle(any(), any());
+  }
+
+  @Test
+  void should_favorite_article() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.favoriteArticle(article.getSlug());
+
+    assertThat(result.getLocalContext()).isEqualTo(article);
+    ArgumentCaptor<ArticleFavorite> captor = ArgumentCaptor.forClass(ArticleFavorite.class);
+    verify(articleFavoriteRepository).save(captor.capture());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+  }
+
+  @Test
+  void should_reject_favorite_article_when_not_authenticated() {
+    authenticateAnonymous();
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> articleMutation.favoriteArticle("slug"));
+  }
+
+  @Test
+  void should_reject_favorite_article_when_missing() {
+    authenticateAs(user);
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleMutation.favoriteArticle("missing"));
+    verify(articleFavoriteRepository, never()).save(any());
+  }
+
+  @Test
+  void should_unfavorite_article_and_remove_existing_favorite() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), user.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.of(favorite));
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.unfavoriteArticle(article.getSlug());
+
+    assertThat(result.getLocalContext()).isEqualTo(article);
+    verify(articleFavoriteRepository).remove(favorite);
+  }
+
+  @Test
+  void should_unfavorite_article_without_removal_when_no_favorite() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.empty());
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.unfavoriteArticle(article.getSlug());
+
+    assertThat(result.getLocalContext()).isEqualTo(article);
+    verify(articleFavoriteRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_delete_article_when_author() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    DeletionStatus status = articleMutation.deleteArticle(article.getSlug());
+
+    assertThat(status.getSuccess()).isTrue();
+    verify(articleRepository).remove(article);
+  }
+
+  @Test
+  void should_reject_delete_article_when_not_author() {
+    authenticateAs(user);
+    User another = new User("a@a.com", "another", "123", "", "");
+    Article article = articleBy(another);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    assertThatExceptionOfType(NoAuthorizationException.class)
+        .isThrownBy(() -> articleMutation.deleteArticle(article.getSlug()));
+    verify(articleRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_reject_delete_article_when_missing() {
+    authenticateAs(user);
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleMutation.deleteArticle("missing"));
+  }
+
+  @Test
+  void should_reject_delete_article_when_not_authenticated() {
+    authenticateAnonymous();
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> articleMutation.deleteArticle("slug"));
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,148 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.CommentsConnection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class CommentDatafetcherTest {
+
+  @Mock private CommentQueryService commentQueryService;
+  @Mock private DataFetchingEnvironment env;
+
+  private CommentDatafetcher commentDatafetcher;
+  private DgsDataFetchingEnvironment dfe;
+
+  private final ProfileData author = new ProfileData("id", "jane", "bio", "image", false);
+
+  @BeforeEach
+  void setUp() {
+    commentDatafetcher = new CommentDatafetcher(commentQueryService);
+    dfe = new DgsDataFetchingEnvironment(env);
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private CommentData commentData(String id) {
+    return new CommentData(id, "body-" + id, "article-1", new DateTime(), new DateTime(), author);
+  }
+
+  @Test
+  void should_build_comment_from_local_context() {
+    CommentData data = commentData("c1");
+    when(env.<CommentData>getLocalContext()).thenReturn(data);
+
+    DataFetcherResult<Comment> result = commentDatafetcher.getComment(dfe);
+
+    assertThat(result.getData().getId()).isEqualTo("c1");
+    assertThat(result.getData().getBody()).isEqualTo("body-c1");
+    assertThat((Map<String, ?>) result.getLocalContext()).containsKey("c1");
+  }
+
+  @Test
+  void should_throw_when_neither_first_nor_last_provided() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> commentDatafetcher.articleComments(null, null, null, null, dfe));
+  }
+
+  @Test
+  void should_return_comments_connection_for_first() {
+    Article article = Article.newBuilder().slug("the-slug").build();
+    ArticleData articleData =
+        new ArticleData(
+            "article-1",
+            "the-slug",
+            "t",
+            "d",
+            "b",
+            false,
+            0,
+            new DateTime(),
+            new DateTime(),
+            Collections.emptyList(),
+            author);
+    when(env.<Article>getSource()).thenReturn(article);
+    when(env.<Map<String, ArticleData>>getLocalContext())
+        .thenReturn(Collections.singletonMap("the-slug", articleData));
+    CursorPager<CommentData> pager =
+        new CursorPager<>(
+            Arrays.asList(commentData("c1"), commentData("c2")), Direction.NEXT, false);
+    when(commentQueryService.findByArticleIdWithCursor(eq("article-1"), any(), any()))
+        .thenReturn(pager);
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(10, null, null, null, dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(2);
+    assertThat(result.getData().getEdges().get(0).getNode().getId()).isEqualTo("c1");
+    assertThat((Map<String, ?>) result.getLocalContext()).containsKeys("c1", "c2");
+  }
+
+  @Test
+  void should_return_comments_connection_for_last() {
+    Article article = Article.newBuilder().slug("the-slug").build();
+    ArticleData articleData =
+        new ArticleData(
+            "article-1",
+            "the-slug",
+            "t",
+            "d",
+            "b",
+            false,
+            0,
+            new DateTime(),
+            new DateTime(),
+            Collections.emptyList(),
+            author);
+    when(env.<Article>getSource()).thenReturn(article);
+    when(env.<Map<String, ArticleData>>getLocalContext())
+        .thenReturn(Collections.singletonMap("the-slug", articleData));
+    CursorPager<CommentData> pager =
+        new CursorPager<>(Collections.singletonList(commentData("c9")), Direction.PREV, true);
+    when(commentQueryService.findByArticleIdWithCursor(eq("article-1"), any(), any()))
+        .thenReturn(pager);
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(null, null, 5, null, dfe);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+    assertThat(result.getData().getPageInfo().isHasPreviousPage()).isTrue();
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,186 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.CommentQueryService;
+import io.spring.application.data.CommentData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.CommentPayload;
+import io.spring.graphql.types.DeletionStatus;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class CommentMutationTest {
+
+  private ArticleRepository articleRepository;
+  private CommentRepository commentRepository;
+  private CommentQueryService commentQueryService;
+  private CommentMutation commentMutation;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    articleRepository = mock(ArticleRepository.class);
+    commentRepository = mock(CommentRepository.class);
+    commentQueryService = mock(CommentQueryService.class);
+    commentMutation =
+        new CommentMutation(articleRepository, commentRepository, commentQueryService);
+    user = new User("john@example.com", "john", "123", "", "");
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void authenticateAs(User u) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(u, null));
+  }
+
+  private void authenticateAnonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+
+  private Article articleBy(User author) {
+    return new Article("Title", "desc", "body", Arrays.asList("java"), author.getId());
+  }
+
+  @Test
+  void should_create_comment_and_expose_data_via_local_context() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    CommentData data = mock(CommentData.class);
+    when(commentQueryService.findById(any(String.class), eq(user))).thenReturn(Optional.of(data));
+
+    DataFetcherResult<CommentPayload> result =
+        commentMutation.createComment(article.getSlug(), "nice post");
+
+    assertThat(result.getData()).isNotNull();
+    assertThat(result.getLocalContext()).isEqualTo(data);
+
+    ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+    verify(commentRepository).save(captor.capture());
+    assertThat(captor.getValue().getBody()).isEqualTo("nice post");
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+  }
+
+  @Test
+  void should_reject_create_comment_when_not_authenticated() {
+    authenticateAnonymous();
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> commentMutation.createComment("slug", "body"));
+    verify(commentRepository, never()).save(any());
+  }
+
+  @Test
+  void should_reject_create_comment_when_article_missing() {
+    authenticateAs(user);
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.createComment("missing", "body"));
+    verify(commentRepository, never()).save(any());
+  }
+
+  @Test
+  void should_reject_create_comment_when_saved_comment_not_readable() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(String.class), eq(user))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.createComment(article.getSlug(), "body"));
+  }
+
+  @Test
+  void should_remove_comment_when_author() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    Comment comment = new Comment("body", user.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    DeletionStatus status = commentMutation.removeComment(article.getSlug(), comment.getId());
+
+    assertThat(status.getSuccess()).isTrue();
+    verify(commentRepository).remove(comment);
+  }
+
+  @Test
+  void should_reject_remove_comment_when_not_authorized() {
+    authenticateAs(user);
+    User another = new User("a@a.com", "another", "123", "", "");
+    Article article = articleBy(another);
+    Comment comment = new Comment("body", another.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    assertThatExceptionOfType(NoAuthorizationException.class)
+        .isThrownBy(() -> commentMutation.removeComment(article.getSlug(), comment.getId()));
+    verify(commentRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_reject_remove_comment_when_article_missing() {
+    authenticateAs(user);
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.removeComment("missing", "cid"));
+  }
+
+  @Test
+  void should_reject_remove_comment_when_comment_missing() {
+    authenticateAs(user);
+    Article article = articleBy(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq("cid"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.removeComment(article.getSlug(), "cid"));
+    verify(commentRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_reject_remove_comment_when_not_authenticated() {
+    authenticateAnonymous();
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> commentMutation.removeComment("slug", "cid"));
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,109 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class MeDatafetcherTest {
+
+  @Mock private UserQueryService userQueryService;
+  @Mock private JwtService jwtService;
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+
+  private MeDatafetcher meDatafetcher;
+
+  private final User user = new User("user@example.com", "username", "123", "bio", "image");
+
+  @org.junit.jupiter.api.BeforeEach
+  void setUp() {
+    meDatafetcher = new MeDatafetcher(userQueryService, jwtService);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void authenticate(User principal) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, null));
+  }
+
+  @Test
+  void should_return_current_user_with_token_from_authorization_header() {
+    authenticate(user);
+    UserData userData = new UserData(user.getId(), user.getEmail(), user.getUsername(), "bio", "");
+    when(userQueryService.findById(user.getId())).thenReturn(Optional.of(userData));
+
+    DataFetcherResult<io.spring.graphql.types.User> result =
+        meDatafetcher.getMe("Token jwt-token-value", dataFetchingEnvironment);
+
+    assertThat(result.getData().getEmail()).isEqualTo(user.getEmail());
+    assertThat(result.getData().getUsername()).isEqualTo(user.getUsername());
+    assertThat(result.getData().getToken()).isEqualTo("jwt-token-value");
+    assertThat(result.getLocalContext()).isEqualTo(user);
+  }
+
+  @Test
+  void should_return_null_when_authentication_is_anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+
+    assertThat(meDatafetcher.getMe("Token jwt-token-value", dataFetchingEnvironment)).isNull();
+  }
+
+  @Test
+  void should_return_null_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertThat(meDatafetcher.getMe("Token jwt-token-value", dataFetchingEnvironment)).isNull();
+  }
+
+  @Test
+  void should_throw_not_found_when_user_missing() {
+    authenticate(user);
+    when(userQueryService.findById(user.getId())).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> meDatafetcher.getMe("Token jwt-token-value", dataFetchingEnvironment));
+  }
+
+  @Test
+  void should_build_user_payload_user_from_local_context() {
+    when(dataFetchingEnvironment.<User>getLocalContext()).thenReturn(user);
+    when(jwtService.toToken(user)).thenReturn("generated-token");
+
+    DataFetcherResult<io.spring.graphql.types.User> result =
+        meDatafetcher.getUserPayloadUser(dataFetchingEnvironment);
+
+    assertThat(result.getData().getEmail()).isEqualTo(user.getEmail());
+    assertThat(result.getData().getUsername()).isEqualTo(user.getUsername());
+    assertThat(result.getData().getToken()).isEqualTo("generated-token");
+    assertThat(result.getLocalContext()).isEqualTo(user);
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,137 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.Profile;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileDatafetcherTest {
+
+  @Mock private ProfileQueryService profileQueryService;
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+
+  private ProfileDatafetcher profileDatafetcher;
+
+  private final ProfileData profileData =
+      new ProfileData("id-1", "jane", "jane bio", "jane-image", true);
+
+  @BeforeEach
+  void setUp() {
+    profileDatafetcher = new ProfileDatafetcher(profileQueryService);
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void should_get_user_profile_from_local_context_user() {
+    User user = new User("jane@example.com", "jane", "123", "bio", "image");
+    when(dataFetchingEnvironment.<User>getLocalContext()).thenReturn(user);
+    when(profileQueryService.findByUsername(eq("jane"), any()))
+        .thenReturn(Optional.of(profileData));
+
+    Profile profile = profileDatafetcher.getUserProfile(dataFetchingEnvironment);
+
+    assertThat(profile.getUsername()).isEqualTo("jane");
+    assertThat(profile.getBio()).isEqualTo("jane bio");
+    assertThat(profile.getImage()).isEqualTo("jane-image");
+    assertThat(profile.getFollowing()).isTrue();
+  }
+
+  @Test
+  void should_get_author_from_article_source_and_local_context_map() {
+    Article article = Article.newBuilder().slug("the-slug").build();
+    ArticleData articleData =
+        new ArticleData(
+            "article-1",
+            "the-slug",
+            "title",
+            "desc",
+            "body",
+            false,
+            0,
+            null,
+            null,
+            Collections.emptyList(),
+            profileData);
+    when(dataFetchingEnvironment.<java.util.Map<String, ArticleData>>getLocalContext())
+        .thenReturn(Collections.singletonMap("the-slug", articleData));
+    when(dataFetchingEnvironment.<Article>getSource()).thenReturn(article);
+    when(profileQueryService.findByUsername(eq("jane"), any()))
+        .thenReturn(Optional.of(profileData));
+
+    Profile profile = profileDatafetcher.getAuthor(dataFetchingEnvironment);
+
+    assertThat(profile.getUsername()).isEqualTo("jane");
+  }
+
+  @Test
+  void should_get_comment_author_from_comment_source_and_local_context_map() {
+    Comment comment = Comment.newBuilder().id("comment-1").build();
+    CommentData commentData =
+        new CommentData("comment-1", "body", "article-1", null, null, profileData);
+    when(dataFetchingEnvironment.<java.util.Map<String, CommentData>>getLocalContext())
+        .thenReturn(Collections.singletonMap("comment-1", commentData));
+    when(dataFetchingEnvironment.<Comment>getSource()).thenReturn(comment);
+    when(profileQueryService.findByUsername(eq("jane"), any()))
+        .thenReturn(Optional.of(profileData));
+
+    Profile profile = profileDatafetcher.getCommentAuthor(dataFetchingEnvironment);
+
+    assertThat(profile.getUsername()).isEqualTo("jane");
+  }
+
+  @Test
+  void should_query_profile_by_argument_username() {
+    when(dataFetchingEnvironment.<String>getArgument("username")).thenReturn("jane");
+    when(profileQueryService.findByUsername(eq("jane"), any()))
+        .thenReturn(Optional.of(profileData));
+
+    ProfilePayload payload = profileDatafetcher.queryProfile("jane", dataFetchingEnvironment);
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo("jane");
+    assertThat(payload.getProfile().getFollowing()).isTrue();
+  }
+
+  @Test
+  void should_throw_not_found_when_profile_missing() {
+    when(dataFetchingEnvironment.<String>getArgument("username")).thenReturn("ghost");
+    when(profileQueryService.findByUsername(eq("ghost"), any())).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> profileDatafetcher.queryProfile("ghost", dataFetchingEnvironment));
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,155 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class RelationMutationTest {
+
+  private UserRepository userRepository;
+  private ProfileQueryService profileQueryService;
+  private RelationMutation relationMutation;
+
+  private User user;
+  private User target;
+
+  @BeforeEach
+  void setUp() {
+    userRepository = mock(UserRepository.class);
+    profileQueryService = mock(ProfileQueryService.class);
+    relationMutation = new RelationMutation(userRepository, profileQueryService);
+    user = new User("john@example.com", "john", "123", "", "");
+    target = new User("jane@example.com", "jane", "123", "jane bio", "jane.png");
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void authenticateAs(User u) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(u, null));
+  }
+
+  private void authenticateAnonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+
+  private ProfileData profileDataOf(User u, boolean following) {
+    return new ProfileData(u.getId(), u.getUsername(), u.getBio(), u.getImage(), following);
+  }
+
+  @Test
+  void should_follow_target_user() {
+    authenticateAs(user);
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername(eq(target.getUsername()), eq(user)))
+        .thenReturn(Optional.of(profileDataOf(target, true)));
+
+    ProfilePayload payload = relationMutation.follow(target.getUsername());
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo(target.getUsername());
+    assertThat(payload.getProfile().getBio()).isEqualTo(target.getBio());
+    assertThat(payload.getProfile().getImage()).isEqualTo(target.getImage());
+    assertThat(payload.getProfile().getFollowing()).isTrue();
+
+    ArgumentCaptor<FollowRelation> captor = ArgumentCaptor.forClass(FollowRelation.class);
+    verify(userRepository).saveRelation(captor.capture());
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().getTargetId()).isEqualTo(target.getId());
+  }
+
+  @Test
+  void should_reject_follow_when_not_authenticated() {
+    authenticateAnonymous();
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> relationMutation.follow("jane"));
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  void should_reject_follow_when_target_missing() {
+    authenticateAs(user);
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> relationMutation.follow("ghost"));
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  void should_unfollow_target_user() {
+    authenticateAs(user);
+    FollowRelation relation = new FollowRelation(user.getId(), target.getId());
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername(eq(target.getUsername()), eq(user)))
+        .thenReturn(Optional.of(profileDataOf(target, false)));
+
+    ProfilePayload payload = relationMutation.unfollow(target.getUsername());
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo(target.getUsername());
+    assertThat(payload.getProfile().getFollowing()).isFalse();
+    verify(userRepository).removeRelation(relation);
+  }
+
+  @Test
+  void should_reject_unfollow_when_target_missing() {
+    authenticateAs(user);
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> relationMutation.unfollow("ghost"));
+    verify(userRepository, never()).removeRelation(any());
+  }
+
+  @Test
+  void should_reject_unfollow_when_relation_missing() {
+    authenticateAs(user);
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> relationMutation.unfollow(target.getUsername()));
+    verify(userRepository, never()).removeRelation(any());
+  }
+
+  @Test
+  void should_reject_unfollow_when_not_authenticated() {
+    authenticateAnonymous();
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> relationMutation.unfollow("jane"));
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,53 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class SecurityUtilTest {
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void should_return_current_user_when_authenticated_with_user_principal() {
+    User user = new User("user@example.com", "username", "123", "bio", "image");
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(user, null, null));
+
+    Optional<User> result = SecurityUtil.getCurrentUser();
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(user);
+  }
+
+  @Test
+  void should_return_empty_when_authentication_is_anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  void should_return_empty_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,37 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TagDatafetcherTest {
+
+  @Mock private TagsQueryService tagsQueryService;
+
+  @InjectMocks private TagDatafetcher tagDatafetcher;
+
+  @Test
+  void should_return_all_tags_from_query_service() {
+    List<String> tags = Arrays.asList("java", "spring", "graphql");
+    when(tagsQueryService.allTags()).thenReturn(tags);
+
+    assertThat(tagDatafetcher.getTags()).containsExactly("java", "spring", "graphql");
+  }
+
+  @Test
+  void should_return_empty_list_when_no_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    assertThat(tagDatafetcher.getTags()).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,185 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.application.user.UserService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.CreateUserInput;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.UpdateUserInput;
+import io.spring.graphql.types.UserPayload;
+import io.spring.graphql.types.UserResult;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Path;
+import javax.validation.constraints.NotBlank;
+import javax.validation.metadata.ConstraintDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class UserMutationTest {
+
+  private UserRepository userRepository;
+  private PasswordEncoder encryptService;
+  private UserService userService;
+  private UserMutation userMutation;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    userRepository = mock(UserRepository.class);
+    encryptService = mock(PasswordEncoder.class);
+    userService = mock(UserService.class);
+    userMutation = new UserMutation(userRepository, encryptService, userService);
+    user = new User("john@example.com", "john", "encoded", "", "");
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void authenticateAs(User u) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(u, null));
+  }
+
+  private void authenticateAnonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+
+  private ConstraintViolationException constraintViolation(String field, String message) {
+    ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+    Path path = mock(Path.class);
+    when(path.toString()).thenReturn(field);
+    when(violation.getPropertyPath()).thenReturn(path);
+    when(violation.getMessage()).thenReturn(message);
+    when(violation.getRootBeanClass()).thenReturn((Class) User.class);
+    ConstraintDescriptor<?> descriptor = mock(ConstraintDescriptor.class);
+    Annotation annotation = mock(Annotation.class);
+    when(annotation.annotationType()).thenReturn((Class) NotBlank.class);
+    when(descriptor.getAnnotation()).thenReturn((Annotation) annotation);
+    when(violation.getConstraintDescriptor()).thenReturn((ConstraintDescriptor) descriptor);
+    Set<ConstraintViolation<?>> violations = Collections.singleton(violation);
+    return new ConstraintViolationException(violations);
+  }
+
+  @Test
+  void should_create_user_and_expose_user_via_local_context() {
+    CreateUserInput input =
+        CreateUserInput.newBuilder()
+            .email("john@example.com")
+            .username("john")
+            .password("secret")
+            .build();
+    when(userService.createUser(any(RegisterParam.class))).thenReturn(user);
+
+    DataFetcherResult<UserResult> result = userMutation.createUser(input);
+
+    assertThat(result.getData()).isInstanceOf(UserPayload.class);
+    assertThat(result.getLocalContext()).isEqualTo(user);
+  }
+
+  @Test
+  void should_return_error_result_when_create_user_violates_constraints() {
+    CreateUserInput input =
+        CreateUserInput.newBuilder().email("bad").username("").password("").build();
+    ConstraintViolationException cve = constraintViolation("email", "should be an email");
+    when(userService.createUser(any(RegisterParam.class))).thenThrow(cve);
+
+    DataFetcherResult<UserResult> result = userMutation.createUser(input);
+
+    assertThat(result.getData()).isInstanceOf(Error.class);
+    Error error = (Error) result.getData();
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).hasSize(1);
+    assertThat(error.getErrors().get(0).getKey()).isEqualTo("email");
+    assertThat(error.getErrors().get(0).getValue()).contains("should be an email");
+    assertThat(result.getLocalContext()).isNull();
+  }
+
+  @Test
+  void should_login_with_matching_password() {
+    when(userRepository.findByEmail(eq("john@example.com"))).thenReturn(Optional.of(user));
+    when(encryptService.matches(eq("secret"), eq(user.getPassword()))).thenReturn(true);
+
+    DataFetcherResult<UserPayload> result = userMutation.login("secret", "john@example.com");
+
+    assertThat(result.getLocalContext()).isEqualTo(user);
+    assertThat(result.getData()).isNotNull();
+  }
+
+  @Test
+  void should_reject_login_with_wrong_password() {
+    when(userRepository.findByEmail(eq("john@example.com"))).thenReturn(Optional.of(user));
+    when(encryptService.matches(eq("wrong"), eq(user.getPassword()))).thenReturn(false);
+
+    assertThatExceptionOfType(InvalidAuthenticationException.class)
+        .isThrownBy(() -> userMutation.login("wrong", "john@example.com"));
+  }
+
+  @Test
+  void should_reject_login_when_user_not_found() {
+    when(userRepository.findByEmail(eq("ghost@example.com"))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(InvalidAuthenticationException.class)
+        .isThrownBy(() -> userMutation.login("secret", "ghost@example.com"));
+  }
+
+  @Test
+  void should_update_current_user() {
+    authenticateAs(user);
+    UpdateUserInput input =
+        UpdateUserInput.newBuilder()
+            .email("new@example.com")
+            .username("newname")
+            .bio("new bio")
+            .password("newpass")
+            .image("new.png")
+            .build();
+
+    DataFetcherResult<UserPayload> result = userMutation.updateUser(input);
+
+    assertThat(result.getLocalContext()).isEqualTo(user);
+    verify(userService).updateUser(any(UpdateUserCommand.class));
+  }
+
+  @Test
+  void should_return_null_when_updating_user_anonymously() {
+    authenticateAnonymous();
+    UpdateUserInput input = UpdateUserInput.newBuilder().email("x@x.com").build();
+
+    DataFetcherResult<UserPayload> result = userMutation.updateUser(input);
+
+    assertThat(result).isNull();
+    verify(userService, never()).updateUser(any());
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -1,0 +1,108 @@
+package io.spring.graphql.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import graphql.GraphQLError;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.graphql.types.Error;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Path;
+import javax.validation.constraints.NotBlank;
+import javax.validation.metadata.ConstraintDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GraphQLCustomizeExceptionHandlerTest {
+
+  private GraphQLCustomizeExceptionHandler handler;
+  private DataFetchingEnvironment dataFetchingEnvironment;
+
+  @BeforeEach
+  void setUp() {
+    handler = new GraphQLCustomizeExceptionHandler();
+    dataFetchingEnvironment = mock(DataFetchingEnvironment.class);
+    ExecutionStepInfo stepInfo = mock(ExecutionStepInfo.class);
+    when(stepInfo.getPath()).thenReturn(ResultPath.rootPath());
+    when(dataFetchingEnvironment.getExecutionStepInfo()).thenReturn(stepInfo);
+  }
+
+  private DataFetcherExceptionHandlerParameters parametersFor(Throwable throwable) {
+    return DataFetcherExceptionHandlerParameters.newExceptionParameters()
+        .dataFetchingEnvironment(dataFetchingEnvironment)
+        .exception(throwable)
+        .build();
+  }
+
+  private ConstraintViolationException constraintViolation(String field, String message) {
+    ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+    Path path = mock(Path.class);
+    when(path.toString()).thenReturn(field);
+    when(violation.getPropertyPath()).thenReturn(path);
+    when(violation.getMessage()).thenReturn(message);
+    when(violation.getRootBeanClass()).thenReturn((Class) String.class);
+    ConstraintDescriptor<?> descriptor = mock(ConstraintDescriptor.class);
+    Annotation annotation = mock(Annotation.class);
+    when(annotation.annotationType()).thenReturn((Class) NotBlank.class);
+    when(descriptor.getAnnotation()).thenReturn((Annotation) annotation);
+    when(violation.getConstraintDescriptor()).thenReturn((ConstraintDescriptor) descriptor);
+    Set<ConstraintViolation<?>> violations = Collections.singleton(violation);
+    return new ConstraintViolationException(violations);
+  }
+
+  @Test
+  void should_map_invalid_authentication_to_unauthenticated_error() {
+    InvalidAuthenticationException exception = new InvalidAuthenticationException();
+
+    DataFetcherExceptionHandlerResult result = handler.onException(parametersFor(exception));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("invalid email or password");
+    assertThat(error.getExtensions().get("errorType").toString()).isEqualTo("UNAUTHENTICATED");
+  }
+
+  @Test
+  void should_map_constraint_violation_to_bad_request_error() {
+    ConstraintViolationException exception = constraintViolation("email", "should be an email");
+
+    DataFetcherExceptionHandlerResult result = handler.onException(parametersFor(exception));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getExtensions().get("errorType").toString()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getExtensions()).containsKey("email");
+  }
+
+  @Test
+  void should_delegate_unhandled_exception_to_default_handler() {
+    RuntimeException exception = new RuntimeException("boom");
+
+    DataFetcherExceptionHandlerResult result = handler.onException(parametersFor(exception));
+
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).contains("boom");
+  }
+
+  @Test
+  void should_build_error_data_from_constraint_violation() {
+    ConstraintViolationException exception = constraintViolation("username", "can't be empty");
+
+    Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(exception);
+
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).hasSize(1);
+    assertThat(error.getErrors().get(0).getKey()).isEqualTo("username");
+    assertThat(error.getErrors().get(0).getValue()).contains("can't be empty");
+  }
+}


### PR DESCRIPTION
## Summary

Adds code-coverage measurement (JaCoCo) and fills the highest-impact test gaps across the GraphQL layer, application command/query services, validators, core domain, and REST exception handling.

**Coverage (excluding DGS-generated sources):**

| Metric | Before | After |
|---|---|---|
| Instruction | 46.8% | **77.3%** |
| Branch | 22.5% | **39.4%** |
| Line | 53.6% | **93.7%** |
| Method | 68.8% | **90.5%** |
| Class | 89.6% | **100%** |

### Build changes (`build.gradle`)
- Add the `jacoco` plugin; `test` is `finalizedBy jacocoTestReport`.
- `jacocoTestReport dependsOn test` and emits HTML + XML.
- `jacocoTestCoverageVerification` added (permissive rule, `minimum = 0.0` — reporting only, doesn't fail the build).
- Generated DGS sources excluded from coverage:
  ```groovy
  def coverageExcludes = ['io/spring/graphql/DgsConstants**', 'io/spring/graphql/types/**', 'io/spring/graphql/client/**']
  // applied via classDirectories.setFrom(fileTree(dir: it, exclude: coverageExcludes))
  ```

### New tests
- **GraphQL** (`io.spring.graphql`): `ArticleDatafetcher`, `CommentDatafetcher`, `MeDatafetcher`, `ProfileDatafetcher`, `TagDatafetcher`, `ArticleMutation`, `CommentMutation`, `RelationMutation`, `UserMutation`, `SecurityUtil`, and `GraphQLCustomizeExceptionHandler`. Datafetchers/mutations are exercised with mocked services and `SecurityContextHolder` auth (authenticated vs. anonymous), covering the `first/last` cursor branches and the auth/not-found/no-authorization error paths.
- **Application services**: `UserService` (create/update), `UpdateUserValidator` (all branches: email/username free, owned by the same user, taken by another user), `ArticleCommandService`, `UserQueryService` (mocked repositories).
- **Validators**: `DuplicatedEmailValidator`, `DuplicatedUsernameValidator`, `DuplicatedArticleValidator`.
- **Core domain**: `AuthorizationService` (`canWriteArticle`/`canWriteComment`), `User`, `Comment`, `FollowRelation`, `ArticleFavorite`, `Tag`, plus article behavior.
- **REST exceptions**: `CustomizeExceptionHandler`, `ErrorResourceSerializer`.
- **`TagsApiTest`**: mirrors existing `*ApiTest` style (rest-assured + spring-mock-mvc via `@WebMvcTest`).

### Verification
`./gradlew test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` passes (spotless is skipped per the repo's documented JDK17 limitation). Report generated at `build/reports/jacoco/test/`.


Link to Devin session: https://app.devin.ai/sessions/89d58e94f82a46ddb65e745a805206fa
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/833?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->