### PR TITLE
Externalize JWT signing secret out of source control

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,18 @@ And the code is organized as this:
 
 Integration with Spring Security and add other filter for jwt token process.
 
-The secret key is stored in `application.properties`.
+The JWT signing secret is **not** stored in source control. It must be supplied
+at runtime through the `JWT_SECRET` environment variable (see
+`jwt.secret=${JWT_SECRET}` in `application.properties`). The application will fail
+to start if it is missing, which prevents accidentally running with a known key.
+
+Use a long, random, high-entropy value (HS512 requires at least 64 bytes), e.g.:
+
+    export JWT_SECRET="$(openssl rand -base64 64)"
+    ./gradlew bootRun
+
+If this repository was ever deployed with the previously hardcoded secret, rotate
+it immediately — any token signed with the old key must be considered forgeable.
 
 # Database
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	// Test-only, throwaway signing secret. Real deployments must provide JWT_SECRET
+	// via the environment; it is intentionally absent from source control.
+	environment 'JWT_SECRET', System.getenv('JWT_SECRET') ?:
+		'test-only-do-not-use-in-production-jwt-signing-secret-0123456789abcdef'
 }
 
 tasks.named('clean') {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.jackson.deserialization.UNWRAP_ROOT_VALUE=true
 
 image.default=https://static.productionready.io/images/smiley-cyrus.jpg
 
-jwt.secret=nRvyYC4soFxBdZ-F-5Nnzz5USXstR1YylsTd-mA0aKtI9HUlriGrtkf-TiuDapkLiUCogO3JOK7kwZisrHp6wA
+jwt.secret=${JWT_SECRET}
 jwt.sessionTime=86400
 
 mybatis.configuration.cache-enabled=true


### PR DESCRIPTION
## Summary

The JWT HMAC-SHA512 signing secret was hardcoded in `application.properties` and committed to source control. Because the same symmetric key both signs (`toToken`) and verifies (`getSubFromToken`), anyone with repo access could forge a JWT with an arbitrary `sub` (user id) and be accepted by `JwtTokenFilter` as that user — a full authentication bypass.

This removes the secret from source and requires it to be supplied at runtime:

```diff
- jwt.secret=nRvyYC4soFxBdZ-...redacted...isrHp6wA
+ jwt.secret=${JWT_SECRET}
```

`@Value("${jwt.secret}")` in `DefaultJwtService` is unchanged — with no default, Spring **fails to start** if `JWT_SECRET` is absent, so a deployment can never silently run with a known/empty key.

Tests get a throwaway secret injected via the Gradle `test` task (kept out of any shipped config), so full-context tests like `RealworldApplicationTests` still load:

```groovy
tasks.named('test') {
    environment 'JWT_SECRET', System.getenv('JWT_SECRET') ?: 'test-only-...'
}
```

`README.md` now documents providing `JWT_SECRET` (e.g. `openssl rand -base64 64`) and notes the previously committed secret must be rotated, since any token signed with it must be treated as forgeable.

## Notes
- No Java logic changed; the fix is purely removing the hardcoded key and requiring it from the environment.
- `spotlessCheck` fails on `src/main/java/io/spring/api/ArticleApi.java` (a file untouched by this PR) due to a preexisting google-java-format/JDK reflection incompatibility; `./gradlew test` passes.


Link to Devin session: https://app.devin.ai/sessions/a0a619fea37f43c897cadb71f73780f4
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/834?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->