### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
@@ -62,7 +62,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
     Assertions.assertTrue(optional.isPresent());
 
     ArticleData fetched = optional.get();
-    Assertions.assertEquals(fetched.getFavoritesCount(), 0);
+    Assertions.assertEquals(0, fetched.getFavoritesCount());
     Assertions.assertFalse(fetched.isFavorited());
     Assertions.assertNotNull(fetched.getCreatedAt());
     Assertions.assertNotNull(fetched.getUpdatedAt());


### PR DESCRIPTION
## Summary
Weekly SonarQube sweep on project `choikh0423_demo-spring-boot-test-coverage`. Selected the top 5 open issues ranked by severity (desc) → type → effort (asc) → recency, and fixed each with minimal changes. All 4 `CRITICAL` issues are included plus the highest-ranked `MAJOR` issue. `./gradlew test` passes; touched files are clean under `spotlessCheck`.

### Issues fixed

| # | Key | Severity / Type | Rule | Location | Fix |
|---|-----|-----------------|------|----------|-----|
| 1 | `AZ1u3HBdEnUkF3fpjVtN` | CRITICAL / CODE_SMELL | java:S1948 | `InvalidRequestException.java:7` | Serializable exception held a non-serializable `Errors` field. Marked it `transient`. |
| 2 | `AZ1u3HCaEnUkF3fpjVtj` | CRITICAL / CODE_SMELL | java:S1452 | `ArticleApi.java:36` | Removed generic wildcard from method return type. |
| 3 | `AZ1u3HCaEnUkF3fpjVtk` | CRITICAL / CODE_SMELL | java:S1452 | `ArticleApi.java:45` | Removed generic wildcard from method return type. |
| 4 | `AZ1u3HBkEnUkF3fpjVtQ` | CRITICAL / CODE_SMELL | java:S1452 | `CommentsApi.java:41` | Removed generic wildcard from method return type. |
| 5 | `AZ1u3HJJEnUkF3fpjVwb` | MAJOR / CODE_SMELL | java:S3415 | `ArticleQueryServiceTest.java:65` | Swapped `assertEquals` args into `(expected, actual)` order. |

### What changed

```diff
// InvalidRequestException.java (S1948) — Errors is not Serializable
- private final Errors errors;
+ private final transient Errors errors;

// ArticleApi.java / CommentsApi.java (S1452) — wildcard return type has no use at an output position
- public ResponseEntity<?> article(...)      -> public ResponseEntity article(...)
- public ResponseEntity<?> updateArticle(...) -> public ResponseEntity updateArticle(...)
- public ResponseEntity<?> createComment(...) -> public ResponseEntity createComment(...)

// ArticleQueryServiceTest.java (S3415)
- Assertions.assertEquals(fetched.getFavoritesCount(), 0);
+ Assertions.assertEquals(0, fetched.getFavoritesCount());
```

The raw `ResponseEntity` return type matches the existing convention already used by the sibling `deleteArticle`/`getComments`/`deleteComment` handlers.

### Verification
- `./gradlew test` (Java 11): BUILD SUCCESSFUL.
- `./gradlew spotlessCheck`: the 5 changed lines are format-clean. One preexisting, unrelated formatting violation remains in `DefaultJwtServiceTest.java` (present on `master`); left untouched to keep this PR scoped to the sweep.

### Notes
No `BLOCKER` issues exist; the top 4 by severity are all `CRITICAL` and equal in type (all reported as `CODE_SMELL` in this instance), so the 5th slot went to the most recent low-effort `MAJOR` issue.


Link to Devin session: https://app.devin.ai/sessions/4a11805723894761a0b732eb685c5a47
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/835?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->