### PR TITLE
Child C: DGS 8.x+ (9.1.2) + MyBatis 3.x + dependency bumps for Boot 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 version = '0.0.1-SNAPSHOT'
 ext['rest-assured.version'] = '5.5.1'
+ext['json-smart.version'] = '2.5.2' // GHSA-pq2g-wx69-c263: uncontrolled-recursion DoS in json-smart 2.5.0/2.5.1
 sourceCompatibility = '17'
 targetCompatibility = '17'
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ configurations {
 }
 
 dependencies {
+    constraints {
+        implementation('com.google.protobuf:protobuf-java:4.28.3') {
+            because 'CVE-2024-7254: protobuf-java < 4.27.5/4.28.3 allows DoS via deeply nested groups; pulled transitively via DGS Apollo federation support'
+        }
+    }
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@ plugins {
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'java'
-    id "com.netflix.dgs.codegen" version "5.0.6"
-    id "com.diffplug.spotless" version "6.2.1"
+    id "com.netflix.dgs.codegen" version "7.0.3"
+    id "com.diffplug.spotless" version "6.25.0"
 }
 
 version = '0.0.1-SNAPSHOT'
+ext['rest-assured.version'] = '5.5.1'
 sourceCompatibility = '17'
 targetCompatibility = '17'
 
@@ -24,6 +25,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:9.1.2"
+    }
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -35,25 +42,25 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
-    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter'
     implementation 'org.flywaydb:flyway-core'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation 'joda-time:joda-time:2.10.13'
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.46.1.3'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'io.rest-assured:rest-assured:4.5.1'
-    testImplementation 'io.rest-assured:json-path:4.5.1'
-    testImplementation 'io.rest-assured:xml-path:4.5.1'
-    testImplementation 'io.rest-assured:spring-mock-mvc:4.5.1'
+    testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'io.rest-assured:json-path'
+    testImplementation 'io.rest-assured:xml-path'
+    testImplementation 'io.rest-assured:spring-mock-mvc'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## Summary
Remaining `build.gradle` dependency/plugin bumps needed for Spring Boot 3.3.5 / Java 17 compatibility (Child C of the coordinated upgrade). Only `build.gradle` is touched — the boot/dependency-management plugin versions, `sourceCompatibility`, and the Gradle wrapper were already set by the parent branch. No `.java` files changed.

### Version changes (old -> new)
| Dependency / plugin | Old | New |
|---|---|---|
| `com.netflix.dgs.codegen` (gradle plugin) | `5.0.6` | `7.0.3` |
| Netflix DGS framework | starter pinned `4.9.21` | managed by DGS platform BOM `graphql-dgs-platform-dependencies:9.1.2`, starter declared **versionless** |
| `com.diffplug.spotless` | `6.2.1` | `6.25.0` (still `googleJavaFormat()`) |
| `org.mybatis.spring.boot:mybatis-spring-boot-starter` | `2.2.2` | `3.0.4` |
| `org.mybatis.spring.boot:mybatis-spring-boot-starter-test` | `2.2.2` | `3.0.4` |
| `io.rest-assured:*` (`rest-assured`, `json-path`, `xml-path`, `spring-mock-mvc`) | `4.5.1` | `5.5.1` |
| `org.xerial:sqlite-jdbc` | `3.36.0.3` | `3.46.1.3` |
| `org.flywaydb:flyway-core` | unversioned | unversioned (Boot BOM manages `10.10.0`) |
| `io.jsonwebtoken:jjwt-*` | `0.11.2` | unchanged (0.11.x is Boot-3 safe) |
| `joda-time` | `2.10.13` | unchanged |
| `com.google.protobuf:protobuf-java` (transitive, constrained) | `4.26.1` (via DGS) | `4.28.3` (security fix) |
| `net.minidev:json-smart` (transitive, BOM property) | `2.5.1` (Boot BOM) | `2.5.2` (security fix) |

### DGS approach
Uses the DGS-recommended platform BOM:
```groovy
dependencyManagement {
    imports { mavenBom "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:9.1.2" }
}
implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter'  // versionless
```
DGS 9.1.2 targets Spring 6.1 / Boot 3.3. Codegen plugin `7.0.3` runs cleanly on Gradle 8.10.2 + Java 17 and bundles its matching codegen runtime. No schema/codegen config changes were needed — the schema uses no custom scalars, so the existing `generateJava` block (`packageName = 'io.spring.graphql'`) is unchanged.

### rest-assured version skew fix
The Spring Boot 3.3 BOM manages rest-assured to `5.4.0`, which downgraded the transitive `rest-assured-common` / `spring-commons` to `5.4.0` while the explicit artifacts were `5.5.1`. Added `ext['rest-assured.version'] = '5.5.1'` to override the BOM property so **all** rest-assured artifacts resolve consistently to `5.5.1`, and made the four rest-assured test deps versionless (managed by the overridden property).

### Security fixes (Snyk PR check)
The dependency bumps introduced two HIGH-severity transitive vulnerabilities that Snyk flags; both are pinned to patched versions:
- **protobuf-java CVE-2024-7254** — DGS's `federation-graphql-java-support:5.0.0` pulls `protobuf-java:4.26.1` (DoS via unbounded recursion). Added a dependency constraint pinning it to `4.28.3`.
- **json-smart GHSA-pq2g-wx69-c263** — `json-path` (via rest-assured 5.5.1) pulls `json-smart:2.5.1` (uncontrolled-recursion DoS, fixed in 2.5.2). The Spring Boot BOM manages `json-smart` and overrides plain Gradle constraints, so this is fixed via the BOM property `ext['json-smart.version'] = '2.5.2'` (also aligns `accessors-smart` to 2.5.2).

Note: the remaining vulnerabilities Snyk may report for `spring-*`, `tomcat-embed-*`, `jackson-*`, `logback-*`, `spring-security-*`, `commons-lang3`, etc. are all managed by the **parent branch's Spring Boot 3.3.5 BOM** (present in the base branch, not introduced by this PR) and are out of this slice's scope — this PR intentionally does not change the Boot version.

## Verification
`./gradlew clean generateJava` — DGS codegen succeeds and generates 28 `io.spring.graphql.types.*` classes into `build/generated`:
```
> Task :generateJava
BUILD SUCCESSFUL in 3s
```
Generated types include `Article`, `ArticlesConnection`, `User`, `UserResult`, `ProfilePayload`, `CreateUserInput`, etc.

`./gradlew dependencies --configuration compileClasspath` and `--configuration testRuntimeClasspath` — resolve with no conflicts. Resolved: DGS `9.1.2`, MyBatis `3.0.4`, sqlite-jdbc `3.46.1.3`, flyway-core `10.10.0`, rest-assured `5.5.1` (all sub-artifacts), protobuf-java `4.28.3`, json-smart `2.5.2`.

Note: a full `./gradlew clean build` does not compile yet by design — Spring Security 6 rewrite, javax->jakarta migration, and exception-handler signature changes are owned by the other child sessions.


Link to Devin session: https://app.devin.ai/sessions/8d3cf6624bd1490ea9f4f955fa06d20e
Requested by: @kylie-chang
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/859?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->