### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,34 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
+  }
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar());
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar());
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Weekly SonarQube sweep against project `choikh0423_demo-spring-boot-test-coverage` (the analyzed project for this repo; there is no separately-keyed `spring-boot-realworld-example-app` project). 265 open issues; ranked by severity → type → effort → recency, which puts the 4 CRITICAL issues first and the single MAJOR **BUG**-type issue fifth.

| # | Issue key | Rule | Severity / Type | Location | Fix |
|---|-----------|------|-----------------|----------|-----|
| 1 | `AZ1u3HBdEnUkF3fpjVtN` | java:S1948 | CRITICAL / CODE_SMELL | `InvalidRequestException.java:7` | Non-serializable `Errors` field in a `Serializable` exception → marked `transient` |
| 2 | `AZ1u3HCaEnUkF3fpjVtj` | java:S1452 | CRITICAL / CODE_SMELL | `ArticleApi.java:36` | `ResponseEntity<?>` → `ResponseEntity<Map<String, Object>>` |
| 3 | `AZ1u3HCaEnUkF3fpjVtk` | java:S1452 | CRITICAL / CODE_SMELL | `ArticleApi.java:45` | same as above (`updateArticle`) |
| 4 | `AZ1u3HBkEnUkF3fpjVtQ` | java:S1452 | CRITICAL / CODE_SMELL | `CommentsApi.java:41` | same as above (`createComment`) |
| 5 | `AZ1u3HAmEnUkF3fpjVtC` | java:S2885 | MAJOR / BUG | `DateTimeHandler.java:18` | Shared `static Calendar` (not thread-safe) removed |

The only behavioral change is #5. `DateTimeHandler` is a singleton MyBatis type handler invoked concurrently, and `Calendar` is mutable/not thread-safe — `getTimestamp`/`setTimestamp` mutate the passed calendar, so the shared instance was a real data race:

```java
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
+  }
```

Sonar's suggested remediation ("make it an instance variable") would not fix the race, since the handler instance is itself shared; a fresh calendar per call does.

`DefaultJwtServiceTest.java` is also touched: it had a pre-existing `spotlessCheck` violation on master that had to be fixed by `spotlessApply` for lint to pass.

Verified with `./gradlew spotlessCheck` and `./gradlew test` (both green, on JDK 11 — google-java-format 1.x in this build crashes on JDK 17).

Link to Devin session: https://app.devin.ai/sessions/ea805fc4fb9e40e6bd6ce3cbc479609f
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/863?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->