### PR TITLE
Add CRM module for LPs, activities and pipeline stages

### DIFF
--- a/src/main/java/io/spring/api/LPApi.java
+++ b/src/main/java/io/spring/api/LPApi.java
@@ -1,0 +1,107 @@
+package io.spring.api;
+
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.lp.LPCommandService;
+import io.spring.application.lp.LPQueryService;
+import io.spring.application.lp.NewActivityParam;
+import io.spring.application.lp.UpdateLPParam;
+import io.spring.application.lp.UpdateStageParam;
+import io.spring.core.lp.Activity;
+import io.spring.core.lp.LP;
+import io.spring.core.lp.LPRepository;
+import io.spring.core.user.User;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/lps/{id}")
+@AllArgsConstructor
+public class LPApi {
+  private LPQueryService lpQueryService;
+  private LPRepository lpRepository;
+  private LPCommandService lpCommandService;
+
+  @GetMapping
+  public ResponseEntity<?> getLP(
+      @PathVariable("id") String id, @AuthenticationPrincipal User user) {
+    return ResponseEntity.ok(lpResponse(findOwnedLP(id, user)));
+  }
+
+  @PutMapping
+  public ResponseEntity<?> updateLP(
+      @PathVariable("id") String id,
+      @AuthenticationPrincipal User user,
+      @Valid @RequestBody UpdateLPParam updateLPParam) {
+    LP lp = lpCommandService.updateLP(findOwnedLP(id, user), updateLPParam);
+    return ResponseEntity.ok(lpResponse(lp));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<?> deleteLP(
+      @PathVariable("id") String id, @AuthenticationPrincipal User user) {
+    lpRepository.remove(findOwnedLP(id, user));
+    return ResponseEntity.noContent().build();
+  }
+
+  @PutMapping(path = "stage")
+  public ResponseEntity<?> updateStage(
+      @PathVariable("id") String id,
+      @AuthenticationPrincipal User user,
+      @Valid @RequestBody UpdateStageParam updateStageParam) {
+    LP lp = lpCommandService.updateStage(findOwnedLP(id, user), updateStageParam.getStage());
+    return ResponseEntity.ok(lpResponse(lp));
+  }
+
+  @PostMapping(path = "activities")
+  public ResponseEntity<?> createActivity(
+      @PathVariable("id") String id,
+      @AuthenticationPrincipal User user,
+      @Valid @RequestBody NewActivityParam newActivityParam) {
+    Activity activity =
+        lpCommandService.createActivity(findOwnedLP(id, user), newActivityParam, user);
+    return ResponseEntity.ok(
+        new HashMap<String, Object>() {
+          {
+            put("activity", activity);
+          }
+        });
+  }
+
+  @GetMapping(path = "activities")
+  public ResponseEntity<?> getActivities(
+      @PathVariable("id") String id, @AuthenticationPrincipal User user) {
+    List<Activity> activities = lpQueryService.findActivities(findOwnedLP(id, user));
+    return ResponseEntity.ok(
+        new HashMap<String, Object>() {
+          {
+            put("activities", activities);
+            put("activitiesCount", activities.size());
+          }
+        });
+  }
+
+  private LP findOwnedLP(String id, User user) {
+    return lpQueryService.findById(id, user).orElseThrow(ResourceNotFoundException::new);
+  }
+
+  private Map<String, Object> lpResponse(LP lp) {
+    return new HashMap<String, Object>() {
+      {
+        put("lp", lp);
+      }
+    };
+  }
+}

--- a/src/main/java/io/spring/api/LPsApi.java
+++ b/src/main/java/io/spring/api/LPsApi.java
@@ -1,0 +1,54 @@
+package io.spring.api;
+
+import io.spring.application.lp.LPCommandService;
+import io.spring.application.lp.LPQueryService;
+import io.spring.application.lp.NewLPParam;
+import io.spring.core.lp.LP;
+import io.spring.core.lp.Stage;
+import io.spring.core.user.User;
+import java.util.HashMap;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/lps")
+@AllArgsConstructor
+public class LPsApi {
+  private LPCommandService lpCommandService;
+  private LPQueryService lpQueryService;
+
+  @PostMapping
+  public ResponseEntity<?> createLP(
+      @Valid @RequestBody NewLPParam newLPParam, @AuthenticationPrincipal User user) {
+    LP lp = lpCommandService.createLP(newLPParam, user);
+    return ResponseEntity.ok(
+        new HashMap<String, Object>() {
+          {
+            put("lp", lp);
+          }
+        });
+  }
+
+  @GetMapping
+  public ResponseEntity<?> getLPs(
+      @RequestParam(value = "stage", required = false) Stage stage,
+      @AuthenticationPrincipal User user) {
+    List<LP> lps = lpQueryService.findUserLPs(user, stage);
+    return ResponseEntity.ok(
+        new HashMap<String, Object>() {
+          {
+            put("lps", lps);
+            put("lpsCount", lps.size());
+          }
+        });
+  }
+}

--- a/src/main/java/io/spring/application/lp/LPCommandService.java
+++ b/src/main/java/io/spring/application/lp/LPCommandService.java
@@ -1,0 +1,53 @@
+package io.spring.application.lp;
+
+import io.spring.core.lp.Activity;
+import io.spring.core.lp.ActivityRepository;
+import io.spring.core.lp.LP;
+import io.spring.core.lp.LPRepository;
+import io.spring.core.lp.Stage;
+import io.spring.core.user.User;
+import javax.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+@Service
+@Validated
+@AllArgsConstructor
+public class LPCommandService {
+
+  private LPRepository lpRepository;
+  private ActivityRepository activityRepository;
+
+  public LP createLP(@Valid NewLPParam newLPParam, User creator) {
+    LP lp =
+        new LP(
+            newLPParam.getName(),
+            newLPParam.getCompany(),
+            newLPParam.getEmail(),
+            newLPParam.getStage(),
+            creator.getId());
+    lpRepository.save(lp);
+    return lp;
+  }
+
+  public LP updateLP(LP lp, @Valid UpdateLPParam updateLPParam) {
+    lp.update(updateLPParam.getName(), updateLPParam.getCompany(), updateLPParam.getEmail());
+    lpRepository.save(lp);
+    return lp;
+  }
+
+  public LP updateStage(LP lp, Stage stage) {
+    lp.moveToStage(stage);
+    lpRepository.save(lp);
+    return lp;
+  }
+
+  public Activity createActivity(LP lp, @Valid NewActivityParam newActivityParam, User creator) {
+    Activity activity =
+        new Activity(
+            lp.getId(), creator.getId(), newActivityParam.getType(), newActivityParam.getNotes());
+    activityRepository.save(activity);
+    return activity;
+  }
+}

--- a/src/main/java/io/spring/application/lp/LPQueryService.java
+++ b/src/main/java/io/spring/application/lp/LPQueryService.java
@@ -1,0 +1,36 @@
+package io.spring.application.lp;
+
+import io.spring.core.lp.Activity;
+import io.spring.core.lp.ActivityRepository;
+import io.spring.core.lp.LP;
+import io.spring.core.lp.LPRepository;
+import io.spring.core.lp.Stage;
+import io.spring.core.user.User;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class LPQueryService {
+  private LPRepository lpRepository;
+  private ActivityRepository activityRepository;
+
+  public Optional<LP> findById(String id, User user) {
+    return lpRepository.findById(id).filter(lp -> lp.getUserId().equals(user.getId()));
+  }
+
+  public List<LP> findUserLPs(User user, Stage stage) {
+    List<LP> lps = lpRepository.findByUserId(user.getId());
+    if (stage == null) {
+      return lps;
+    }
+    return lps.stream().filter(lp -> lp.getStage() == stage).collect(Collectors.toList());
+  }
+
+  public List<Activity> findActivities(LP lp) {
+    return activityRepository.findByLpId(lp.getId());
+  }
+}

--- a/src/main/java/io/spring/application/lp/NewActivityParam.java
+++ b/src/main/java/io/spring/application/lp/NewActivityParam.java
@@ -1,0 +1,20 @@
+package io.spring.application.lp;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonRootName("activity")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewActivityParam {
+  @NotBlank(message = "can't be empty")
+  private String type;
+
+  private String notes = "";
+}

--- a/src/main/java/io/spring/application/lp/NewLPParam.java
+++ b/src/main/java/io/spring/application/lp/NewLPParam.java
@@ -1,0 +1,29 @@
+package io.spring.application.lp;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import io.spring.core.lp.Stage;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonRootName("lp")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewLPParam {
+  @NotBlank(message = "can't be empty")
+  private String name;
+
+  @NotBlank(message = "can't be empty")
+  private String company;
+
+  @Email(message = "should be an email")
+  @NotBlank(message = "can't be empty")
+  private String email;
+
+  private Stage stage;
+}

--- a/src/main/java/io/spring/application/lp/UpdateLPParam.java
+++ b/src/main/java/io/spring/application/lp/UpdateLPParam.java
@@ -1,0 +1,20 @@
+package io.spring.application.lp;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import javax.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonRootName("lp")
+public class UpdateLPParam {
+  private String name = "";
+
+  private String company = "";
+
+  @Email(message = "should be an email")
+  private String email = "";
+}

--- a/src/main/java/io/spring/application/lp/UpdateStageParam.java
+++ b/src/main/java/io/spring/application/lp/UpdateStageParam.java
@@ -1,0 +1,17 @@
+package io.spring.application.lp;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import io.spring.core.lp.Stage;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonRootName("lp")
+public class UpdateStageParam {
+  @NotNull(message = "can't be empty")
+  private Stage stage;
+}

--- a/src/main/java/io/spring/core/lp/Activity.java
+++ b/src/main/java/io/spring/core/lp/Activity.java
@@ -1,0 +1,32 @@
+package io.spring.core.lp;
+
+import java.util.UUID;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode(of = {"id"})
+public class Activity {
+  private String id;
+  private String lpId;
+  private String userId;
+  private String type;
+  private String notes;
+  private DateTime createdAt;
+
+  public Activity(String lpId, String userId, String type, String notes) {
+    this(lpId, userId, type, notes, new DateTime());
+  }
+
+  public Activity(String lpId, String userId, String type, String notes, DateTime createdAt) {
+    this.id = UUID.randomUUID().toString();
+    this.lpId = lpId;
+    this.userId = userId;
+    this.type = type;
+    this.notes = notes;
+    this.createdAt = createdAt;
+  }
+}

--- a/src/main/java/io/spring/core/lp/ActivityRepository.java
+++ b/src/main/java/io/spring/core/lp/ActivityRepository.java
@@ -1,0 +1,15 @@
+package io.spring.core.lp;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ActivityRepository {
+
+  void save(Activity activity);
+
+  Optional<Activity> findById(String id);
+
+  List<Activity> findByLpId(String lpId);
+
+  void remove(Activity activity);
+}

--- a/src/main/java/io/spring/core/lp/LP.java
+++ b/src/main/java/io/spring/core/lp/LP.java
@@ -1,0 +1,64 @@
+package io.spring.core.lp;
+
+import io.spring.Util;
+import java.util.UUID;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode(of = {"id"})
+public class LP {
+  private String id;
+  private String userId;
+  private String name;
+  private String company;
+  private String email;
+  private Stage stage;
+  private DateTime createdAt;
+  private DateTime updatedAt;
+
+  public LP(String name, String company, String email, String userId) {
+    this(name, company, email, Stage.TERRITORY, userId, new DateTime());
+  }
+
+  public LP(String name, String company, String email, Stage stage, String userId) {
+    this(name, company, email, stage, userId, new DateTime());
+  }
+
+  public LP(
+      String name, String company, String email, Stage stage, String userId, DateTime createdAt) {
+    this.id = UUID.randomUUID().toString();
+    this.name = name;
+    this.company = company;
+    this.email = email;
+    this.stage = stage == null ? Stage.TERRITORY : stage;
+    this.userId = userId;
+    this.createdAt = createdAt;
+    this.updatedAt = createdAt;
+  }
+
+  public void update(String name, String company, String email) {
+    if (!Util.isEmpty(name)) {
+      this.name = name;
+      this.updatedAt = new DateTime();
+    }
+    if (!Util.isEmpty(company)) {
+      this.company = company;
+      this.updatedAt = new DateTime();
+    }
+    if (!Util.isEmpty(email)) {
+      this.email = email;
+      this.updatedAt = new DateTime();
+    }
+  }
+
+  public void moveToStage(Stage stage) {
+    if (stage != null && stage != this.stage) {
+      this.stage = stage;
+      this.updatedAt = new DateTime();
+    }
+  }
+}

--- a/src/main/java/io/spring/core/lp/LPRepository.java
+++ b/src/main/java/io/spring/core/lp/LPRepository.java
@@ -1,0 +1,21 @@
+package io.spring.core.lp;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LPRepository {
+
+  void save(LP lp);
+
+  Optional<LP> findById(String id);
+
+  List<LP> findByUserId(String userId);
+
+  void remove(LP lp);
+
+  void saveRelationship(Relationship relationship);
+
+  List<Relationship> findRelationships(String lpId);
+
+  void removeRelationship(Relationship relationship);
+}

--- a/src/main/java/io/spring/core/lp/Relationship.java
+++ b/src/main/java/io/spring/core/lp/Relationship.java
@@ -1,0 +1,18 @@
+package io.spring.core.lp;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Data
+public class Relationship {
+  private String lpId;
+  private String contactId;
+  private String role;
+
+  public Relationship(String lpId, String contactId, String role) {
+    this.lpId = lpId;
+    this.contactId = contactId;
+    this.role = role;
+  }
+}

--- a/src/main/java/io/spring/core/lp/Stage.java
+++ b/src/main/java/io/spring/core/lp/Stage.java
@@ -1,0 +1,11 @@
+package io.spring.core.lp;
+
+public enum Stage {
+  TERRITORY,
+  QUALIFICATION,
+  MEETING,
+  SECOND,
+  PACT_SENDS,
+  NEGOTIATION,
+  CLOSED
+}

--- a/src/main/java/io/spring/infrastructure/mybatis/mapper/ActivityMapper.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/mapper/ActivityMapper.java
@@ -1,0 +1,17 @@
+package io.spring.infrastructure.mybatis.mapper;
+
+import io.spring.core.lp.Activity;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ActivityMapper {
+  void insert(@Param("activity") Activity activity);
+
+  Activity findById(@Param("id") String id);
+
+  List<Activity> findByLpId(@Param("lpId") String lpId);
+
+  void delete(@Param("id") String id);
+}

--- a/src/main/java/io/spring/infrastructure/mybatis/mapper/LPMapper.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/mapper/LPMapper.java
@@ -1,0 +1,28 @@
+package io.spring.infrastructure.mybatis.mapper;
+
+import io.spring.core.lp.LP;
+import io.spring.core.lp.Relationship;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface LPMapper {
+  void insert(@Param("lp") LP lp);
+
+  LP findById(@Param("id") String id);
+
+  List<LP> findByUserId(@Param("userId") String userId);
+
+  void update(@Param("lp") LP lp);
+
+  void delete(@Param("id") String id);
+
+  void insertRelationship(@Param("relationship") Relationship relationship);
+
+  Relationship findRelationship(@Param("lpId") String lpId, @Param("contactId") String contactId);
+
+  List<Relationship> findRelationships(@Param("lpId") String lpId);
+
+  void deleteRelationship(@Param("relationship") Relationship relationship);
+}

--- a/src/main/java/io/spring/infrastructure/repository/MyBatisActivityRepository.java
+++ b/src/main/java/io/spring/infrastructure/repository/MyBatisActivityRepository.java
@@ -1,0 +1,39 @@
+package io.spring.infrastructure.repository;
+
+import io.spring.core.lp.Activity;
+import io.spring.core.lp.ActivityRepository;
+import io.spring.infrastructure.mybatis.mapper.ActivityMapper;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MyBatisActivityRepository implements ActivityRepository {
+  private final ActivityMapper activityMapper;
+
+  public MyBatisActivityRepository(ActivityMapper activityMapper) {
+    this.activityMapper = activityMapper;
+  }
+
+  @Override
+  public void save(Activity activity) {
+    if (activityMapper.findById(activity.getId()) == null) {
+      activityMapper.insert(activity);
+    }
+  }
+
+  @Override
+  public Optional<Activity> findById(String id) {
+    return Optional.ofNullable(activityMapper.findById(id));
+  }
+
+  @Override
+  public List<Activity> findByLpId(String lpId) {
+    return activityMapper.findByLpId(lpId);
+  }
+
+  @Override
+  public void remove(Activity activity) {
+    activityMapper.delete(activity.getId());
+  }
+}

--- a/src/main/java/io/spring/infrastructure/repository/MyBatisLPRepository.java
+++ b/src/main/java/io/spring/infrastructure/repository/MyBatisLPRepository.java
@@ -1,0 +1,61 @@
+package io.spring.infrastructure.repository;
+
+import io.spring.core.lp.LP;
+import io.spring.core.lp.LPRepository;
+import io.spring.core.lp.Relationship;
+import io.spring.infrastructure.mybatis.mapper.LPMapper;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class MyBatisLPRepository implements LPRepository {
+  private final LPMapper lpMapper;
+
+  public MyBatisLPRepository(LPMapper lpMapper) {
+    this.lpMapper = lpMapper;
+  }
+
+  @Override
+  @Transactional
+  public void save(LP lp) {
+    if (lpMapper.findById(lp.getId()) == null) {
+      lpMapper.insert(lp);
+    } else {
+      lpMapper.update(lp);
+    }
+  }
+
+  @Override
+  public Optional<LP> findById(String id) {
+    return Optional.ofNullable(lpMapper.findById(id));
+  }
+
+  @Override
+  public List<LP> findByUserId(String userId) {
+    return lpMapper.findByUserId(userId);
+  }
+
+  @Override
+  public void remove(LP lp) {
+    lpMapper.delete(lp.getId());
+  }
+
+  @Override
+  public void saveRelationship(Relationship relationship) {
+    if (lpMapper.findRelationship(relationship.getLpId(), relationship.getContactId()) == null) {
+      lpMapper.insertRelationship(relationship);
+    }
+  }
+
+  @Override
+  public List<Relationship> findRelationships(String lpId) {
+    return lpMapper.findRelationships(lpId);
+  }
+
+  @Override
+  public void removeRelationship(Relationship relationship) {
+    lpMapper.deleteRelationship(relationship);
+  }
+}

--- a/src/main/resources/db/migration/V2__create_crm_tables.sql
+++ b/src/main/resources/db/migration/V2__create_crm_tables.sql
@@ -1,0 +1,26 @@
+create table lps (
+  id varchar(255) primary key,
+  user_id varchar(255) not null,
+  name varchar(255),
+  company varchar(255),
+  email varchar(255),
+  stage varchar(255) not null,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+create table activities (
+  id varchar(255) primary key,
+  lp_id varchar(255) not null,
+  user_id varchar(255) not null,
+  type varchar(255),
+  notes text,
+  created_at TIMESTAMP NOT NULL
+);
+
+create table lp_relationships (
+  lp_id varchar(255) not null,
+  contact_id varchar(255) not null,
+  role varchar(255),
+  primary key(lp_id, contact_id)
+);

--- a/src/main/resources/mapper/ActivityMapper.xml
+++ b/src/main/resources/mapper/ActivityMapper.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="io.spring.infrastructure.mybatis.mapper.ActivityMapper">
+    <insert id="insert">
+        insert into activities(id, lp_id, user_id, type, notes, created_at)
+        values(
+          #{activity.id},
+          #{activity.lpId},
+          #{activity.userId},
+          #{activity.type},
+          #{activity.notes},
+          #{activity.createdAt})
+    </insert>
+    <delete id="delete">
+        delete from activities where id = #{id}
+    </delete>
+
+    <sql id="selectActivity">
+        select
+        A.id activityId,
+        A.lp_id activityLpId,
+        A.user_id activityUserId,
+        A.type activityType,
+        A.notes activityNotes,
+        A.created_at activityCreatedAt
+        from activities A
+    </sql>
+
+    <select id="findById" resultMap="activity">
+        <include refid="selectActivity"/>
+        where A.id = #{id}
+    </select>
+
+    <select id="findByLpId" resultMap="activity">
+        <include refid="selectActivity"/>
+        where A.lp_id = #{lpId}
+        order by A.created_at desc
+    </select>
+
+    <resultMap id="activity" type="io.spring.core.lp.Activity">
+        <id column="activityId" property="id"/>
+        <result column="activityLpId" property="lpId"/>
+        <result column="activityUserId" property="userId"/>
+        <result column="activityType" property="type"/>
+        <result column="activityNotes" property="notes"/>
+        <result column="activityCreatedAt" property="createdAt"/>
+    </resultMap>
+</mapper>

--- a/src/main/resources/mapper/LPMapper.xml
+++ b/src/main/resources/mapper/LPMapper.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="io.spring.infrastructure.mybatis.mapper.LPMapper">
+    <insert id="insert">
+        insert into lps(id, user_id, name, company, email, stage, created_at, updated_at)
+        values(
+          #{lp.id},
+          #{lp.userId},
+          #{lp.name},
+          #{lp.company},
+          #{lp.email},
+          #{lp.stage},
+          #{lp.createdAt},
+          #{lp.updatedAt})
+    </insert>
+    <update id="update">
+        update lps
+        set name = #{lp.name},
+            company = #{lp.company},
+            email = #{lp.email},
+            stage = #{lp.stage},
+            updated_at = #{lp.updatedAt}
+        where id = #{lp.id}
+    </update>
+    <delete id="delete">
+        delete from lps where id = #{id}
+    </delete>
+    <insert id="insertRelationship">
+        insert into lp_relationships (lp_id, contact_id, role)
+        values(#{relationship.lpId}, #{relationship.contactId}, #{relationship.role})
+    </insert>
+    <delete id="deleteRelationship">
+        delete from lp_relationships
+        where lp_id = #{relationship.lpId} and contact_id = #{relationship.contactId}
+    </delete>
+
+    <sql id="selectLP">
+        select
+        L.id lpId,
+        L.user_id lpUserId,
+        L.name lpName,
+        L.company lpCompany,
+        L.email lpEmail,
+        L.stage lpStage,
+        L.created_at lpCreatedAt,
+        L.updated_at lpUpdatedAt
+        from lps L
+    </sql>
+
+    <select id="findById" resultMap="lp">
+        <include refid="selectLP"/>
+        where L.id = #{id}
+    </select>
+
+    <select id="findByUserId" resultMap="lp">
+        <include refid="selectLP"/>
+        where L.user_id = #{userId}
+        order by L.created_at desc
+    </select>
+
+    <select id="findRelationship" resultMap="relationship">
+        select lp_id, contact_id, role from lp_relationships
+        where lp_id = #{lpId} and contact_id = #{contactId}
+    </select>
+
+    <select id="findRelationships" resultMap="relationship">
+        select lp_id, contact_id, role from lp_relationships where lp_id = #{lpId}
+    </select>
+
+    <resultMap id="lp" type="io.spring.core.lp.LP">
+        <id column="lpId" property="id"/>
+        <result column="lpUserId" property="userId"/>
+        <result column="lpName" property="name"/>
+        <result column="lpCompany" property="company"/>
+        <result column="lpEmail" property="email"/>
+        <result column="lpStage" property="stage"/>
+        <result column="lpCreatedAt" property="createdAt"/>
+        <result column="lpUpdatedAt" property="updatedAt"/>
+    </resultMap>
+
+    <resultMap id="relationship" type="io.spring.core.lp.Relationship">
+        <result column="lp_id" property="lpId"/>
+        <result column="contact_id" property="contactId"/>
+        <result column="role" property="role"/>
+    </resultMap>
+</mapper>

--- a/src/test/java/io/spring/infrastructure/lp/MyBatisLPRepositoryTest.java
+++ b/src/test/java/io/spring/infrastructure/lp/MyBatisLPRepositoryTest.java
@@ -1,0 +1,138 @@
+package io.spring.infrastructure.lp;
+
+import io.spring.core.lp.Activity;
+import io.spring.core.lp.ActivityRepository;
+import io.spring.core.lp.LP;
+import io.spring.core.lp.LPRepository;
+import io.spring.core.lp.Relationship;
+import io.spring.core.lp.Stage;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisActivityRepository;
+import io.spring.infrastructure.repository.MyBatisLPRepository;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import({MyBatisLPRepository.class, MyBatisActivityRepository.class, MyBatisUserRepository.class})
+public class MyBatisLPRepositoryTest extends DbTestBase {
+  @Autowired private LPRepository lpRepository;
+
+  @Autowired private ActivityRepository activityRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  private User user;
+  private LP lp;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("aisensiy@gmail.com", "aisensiy", "123", "bio", "default");
+    userRepository.save(user);
+    lp = new LP("John Doe", "ACME", "john@acme.com", user.getId());
+  }
+
+  @Test
+  public void should_create_and_fetch_lp_success() {
+    lpRepository.save(lp);
+
+    Optional<LP> optional = lpRepository.findById(lp.getId());
+    Assertions.assertTrue(optional.isPresent());
+    LP fetched = optional.get();
+    Assertions.assertEquals(lp, fetched);
+    Assertions.assertEquals("John Doe", fetched.getName());
+    Assertions.assertEquals("ACME", fetched.getCompany());
+    Assertions.assertEquals("john@acme.com", fetched.getEmail());
+    Assertions.assertEquals(Stage.TERRITORY, fetched.getStage());
+    Assertions.assertEquals(user.getId(), fetched.getUserId());
+  }
+
+  @Test
+  public void should_update_and_fetch_lp_success() {
+    lpRepository.save(lp);
+
+    lp.update("Jane Doe", "", "jane@acme.com");
+    lpRepository.save(lp);
+
+    LP fetched = lpRepository.findById(lp.getId()).get();
+    Assertions.assertEquals("Jane Doe", fetched.getName());
+    Assertions.assertEquals("ACME", fetched.getCompany());
+    Assertions.assertEquals("jane@acme.com", fetched.getEmail());
+  }
+
+  @Test
+  public void should_move_lp_to_another_stage() {
+    lpRepository.save(lp);
+
+    lp.moveToStage(Stage.NEGOTIATION);
+    lpRepository.save(lp);
+
+    Assertions.assertEquals(Stage.NEGOTIATION, lpRepository.findById(lp.getId()).get().getStage());
+  }
+
+  @Test
+  public void should_fetch_lps_of_user() {
+    lpRepository.save(lp);
+    lpRepository.save(new LP("Other", "Other Inc", "other@other.com", "another-user"));
+
+    List<LP> lps = lpRepository.findByUserId(user.getId());
+    Assertions.assertEquals(1, lps.size());
+    Assertions.assertEquals(lp, lps.get(0));
+  }
+
+  @Test
+  public void should_delete_lp() {
+    lpRepository.save(lp);
+
+    lpRepository.remove(lp);
+    Assertions.assertFalse(lpRepository.findById(lp.getId()).isPresent());
+  }
+
+  @Test
+  public void should_save_and_remove_relationship() {
+    lpRepository.save(lp);
+    Relationship relationship = new Relationship(lp.getId(), "contact-id", "CTO");
+
+    lpRepository.saveRelationship(relationship);
+    lpRepository.saveRelationship(relationship);
+
+    List<Relationship> relationships = lpRepository.findRelationships(lp.getId());
+    Assertions.assertEquals(1, relationships.size());
+    Assertions.assertEquals(relationship, relationships.get(0));
+
+    lpRepository.removeRelationship(relationship);
+    Assertions.assertTrue(lpRepository.findRelationships(lp.getId()).isEmpty());
+  }
+
+  @Test
+  public void should_create_and_fetch_activities_of_lp() {
+    lpRepository.save(lp);
+    Activity activity = new Activity(lp.getId(), user.getId(), "CALL", "first call");
+    activityRepository.save(activity);
+
+    Optional<Activity> optional = activityRepository.findById(activity.getId());
+    Assertions.assertTrue(optional.isPresent());
+    Assertions.assertEquals("CALL", optional.get().getType());
+    Assertions.assertEquals("first call", optional.get().getNotes());
+
+    List<Activity> activities = activityRepository.findByLpId(lp.getId());
+    Assertions.assertEquals(1, activities.size());
+    Assertions.assertEquals(activity, activities.get(0));
+  }
+
+  @Test
+  public void should_delete_activity() {
+    lpRepository.save(lp);
+    Activity activity = new Activity(lp.getId(), user.getId(), "EMAIL", "sent pact");
+    activityRepository.save(activity);
+
+    activityRepository.remove(activity);
+    Assertions.assertTrue(activityRepository.findByLpId(lp.getId()).isEmpty());
+  }
+}

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds a CRM domain (`LP` accounts/prospects, their `Activity` log, and contact `Relationship`s) with a 7-stage pipeline, mirroring the existing `Article` layering: `core` entities + repository interfaces, MyBatis repositories/XML in `infrastructure`, CQRS services in `application`, REST controllers in `api`.

Pipeline: `Stage = TERRITORY | QUALIFICATION | MEETING | SECOND | PACT_SENDS | NEGOTIATION | CLOSED`, persisted as a varchar via MyBatis' default enum handler. `LP` defaults to `TERRITORY` when no stage is supplied and only bumps `updatedAt` on an actual change:

```java
lp.update(name, company, email); // ignores empty strings, like Article.update
lp.moveToStage(Stage.NEGOTIATION); // no-op if same/null stage
```

Ownership is enforced at the query layer rather than via `AuthorizationService`, so a non-owner gets 404 instead of leaking existence:

```java
lpQueryService.findById(id, user) // = lpRepository.findById(id).filter(lp -> lp.getUserId().equals(user.getId()))
```

Endpoints (all authenticated by the existing `anyRequest().authenticated()` rule, no `WebSecurityConfig` change needed). Bodies are root-wrapped (`UNWRAP_ROOT_VALUE` is on globally): `{"lp": {...}}` / `{"activity": {...}}`.

- `POST /lps`, `GET /lps?stage=MEETING`
- `GET|PUT|DELETE /lps/{id}`, `PUT /lps/{id}/stage`
- `POST /lps/{id}/activities`, `GET /lps/{id}/activities`

Schema: `V2__create_crm_tables.sql` creates `lps`, `activities`, `lp_relationships` following the `V1` style.

Tests: `MyBatisLPRepositoryTest` (extends `DbTestBase`) covers create/update/delete, stage change, per-user listing, idempotent relationship save/remove, and activity create/fetch/delete. `./gradlew build` (spotless + tests) passes.

Unrelated: `DefaultJwtServiceTest` picked up a one-line reformat from `spotlessApply` (it was violating google-java-format on master).


Link to Devin session: https://app.devin.ai/sessions/3595ecb69f1a479385c23d9a9fd29541
Requested by: @giladsamuels-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/869?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->