### PR TITLE
build: add JaCoCo coverage reporting + baseline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'jacoco'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
 }
@@ -58,6 +59,44 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacoco {
+    toolVersion = '0.8.11'
+}
+
+def jacocoExcludes = [
+    'io/spring/graphql/types/**',
+    'io/spring/graphql/DgsConstants**',
+    'io/spring/graphql/client/**',
+    'io/spring/Application*'
+]
+
+tasks.named('jacocoTestReport') {
+    dependsOn tasks.named('test')
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = true
+    }
+    classDirectories.setFrom(files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: jacocoExcludes)
+    }))
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    dependsOn tasks.named('jacocoTestReport')
+    classDirectories.setFrom(files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: jacocoExcludes)
+    }))
+    violationRules {
+        rule {
+            limit {
+                counter = 'INSTRUCTION'
+                minimum = 0.0
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,9 @@ jacoco {
 
 def jacocoExcludes = [
     'io/spring/graphql/types/**',
-    'io/spring/graphql/DgsConstants**',
+    'io/spring/graphql/DgsConstants*',
     'io/spring/graphql/client/**',
-    'io/spring/Application*'
+    'io/spring/RealWorldApplication*'
 ]
 
 tasks.named('jacocoTestReport') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,8 @@
+# google-java-format (used by spotless) reflects into javac internals, which are
+# sealed off from JDK 16 onward. Export them so spotlessApply/spotlessCheck run
+# on modern JDKs.
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds the `jacoco` Gradle plugin so we can measure test coverage before a batch of coverage-improving PRs lands, and unblocks `spotless` on modern JDKs. No production code changes.

**1. JaCoCo.** DGS codegen emits thousands of instructions of generated POJOs into `io.spring.graphql.types` / `DgsConstants` / `client`, which would dominate the report. Those (plus the bootstrap class) are stripped from `classDirectories` for both the report and verification tasks:

```groovy
def jacocoExcludes = ['io/spring/graphql/types/**', 'io/spring/graphql/DgsConstants*',
                      'io/spring/graphql/client/**', 'io/spring/RealWorldApplication*']
classDirectories.setFrom(files(classDirectories.files.collect { fileTree(dir: it, exclude: jacocoExcludes) }))
```

`jacocoTestReport` `dependsOn test` and emits XML + HTML + CSV. `jacocoTestCoverageVerification` is wired up with a `minimum = 0.0` instruction rule — a placeholder so the task exists and passes today; raise the threshold once the coverage PRs merge.

**2. `gradle.properties` (new).** `./gradlew spotlessApply` / `spotlessCheck` previously died with `InvocationTargetException` on JDK 16+ because google-java-format reflects into sealed javac internals. Adding the five `--add-exports` flags to `org.gradle.jvmargs` makes the whole `./gradlew build` (including `spotlessCheck`) pass on the JDK 17 toolchain, so contributors no longer need `-x spotlessJava -x spotlessJavaCheck`. This also surfaced one pre-existing formatting violation in `DefaultJwtServiceTest`, fixed by `spotlessApply`.

Run coverage with:
```
./gradlew test jacocoTestReport
# HTML: build/reports/jacoco/test/html/index.html
```

## Baseline coverage (`master` @ 1b03279e)

| Metric | Covered |
|---|---|
| Instruction | **46.8%** (3474/7427) |
| Branch | **22.5%** (146/650) |
| Line | **53.7%** (741/1380) |
| Method | **68.9%** (346/502) |

Per-package, worst first — these are the gaps the follow-up PRs target:

| Package | Instruction | Line |
|---|---|---|
| `io.spring.graphql.exception` | 3.0% | 3.2% (2/62) |
| `io.spring.graphql` | 4.9% | 2.0% (9/453) |
| `io.spring.application.article` | 20.5% | 26.7% (8/30) |
| `io.spring.application.data` | 25.7% | 98.4% (61/62) |
| `io.spring.infrastructure.mybatis` | 52.2% | 63.6% (7/11) |
| `io.spring.application.user` | 52.2% | 75.8% (50/66) |
| `io.spring.core.favorite` | 54.5% | 100% (8/8) |
| `io.spring.application` | 64.4% | 76.4% (165/216) |
| `io.spring.core.comment` | 69.0% | 100% (14/14) |
| `io.spring.core.article` | 70.8% | 91.1% (41/45) |
| `io.spring.core.user` | 71.8% | 94.3% (33/35) |
| `io.spring.api.exception` | 78.4% | 72.6% (61/84) |
| `io.spring` | 87.5% | 85.7% (12/14) |
| `io.spring.core.service` | 88.0% | 66.7% (2/3) |
| `io.spring.infrastructure.repository` | 94.0% | 94.4% (51/54) |
| `io.spring.api` | 97.0% | 96.6% (141/146) |
| `io.spring.api.security` | 99.2% | 98.4% (61/62) |
| `io.spring.infrastructure.service` | 100% | 100% (15/15) |

`io.spring.graphql` (the DGS datafetchers/mutations, 453 lines) is by far the largest gap: essentially untested. Note the high *line* / low *instruction* percentages on Lombok-heavy packages like `io.spring.application.data` — Lombok-generated `equals`/`hashCode`/builders inflate the instruction denominator.


Link to Devin session: https://app.devin.ai/sessions/43856a34f2bb4b91bc124c5f49bc0962
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/870?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->