### PR TITLE
test: cover User, Comment and the duplicate-value bean validators

### DIFF
--- a/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
+++ b/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
@@ -1,0 +1,91 @@
+package io.spring.application.article;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.core.user.User;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DuplicatedArticleValidatorTest {
+
+  @Mock private ArticleQueryService articleQueryService;
+
+  @InjectMocks private DuplicatedArticleValidator validator;
+
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  public void should_be_valid_when_no_article_found_with_the_slug() {
+    when(articleQueryService.findBySlug(eq("a-new-title"), any())).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("a new title", null), is(true));
+  }
+
+  @Test
+  public void should_be_invalid_when_an_article_already_uses_the_slug() {
+    User user = new User("john@example.com", "john", "123", "", "");
+    when(articleQueryService.findBySlug(eq("a-new-title"), any()))
+        .thenReturn(Optional.of(TestHelper.articleDataFixture("test", user)));
+
+    assertThat(validator.isValid("a new title", null), is(false));
+  }
+
+  @Test
+  public void should_look_up_with_the_slugified_title_not_the_raw_title() {
+    when(articleQueryService.findBySlug(any(), any())).thenReturn(Optional.empty());
+
+    validator.isValid("A NEW   Title?", null);
+
+    verify(articleQueryService).findBySlug("a-new-title-", null);
+    verify(articleQueryService, never()).findBySlug(eq("A NEW   Title?"), any());
+  }
+
+  @Test
+  public void should_pass_null_user_to_the_query_service() {
+    when(articleQueryService.findBySlug(any(), any())).thenReturn(Optional.empty());
+
+    validator.isValid("title", null);
+
+    verify(articleQueryService).findBySlug("title", null);
+  }
+
+  @Test
+  public void should_be_valid_for_empty_title_when_nothing_matches() {
+    when(articleQueryService.findBySlug(eq(""), any())).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("", null), is(true));
+
+    verify(articleQueryService).findBySlug("", null);
+  }
+
+  @Test
+  public void should_throw_on_null_title() {
+    assertThrows(NullPointerException.class, () -> validator.isValid(null, null));
+
+    verify(articleQueryService, never()).findBySlug(any(), any());
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
@@ -1,0 +1,77 @@
+package io.spring.application.user;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DuplicatedEmailValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedEmailValidator validator;
+
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  public void should_be_valid_when_no_user_has_the_email() {
+    when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("john@example.com", null), is(true));
+
+    verify(userRepository).findByEmail("john@example.com");
+  }
+
+  @Test
+  public void should_be_invalid_when_a_user_already_has_the_email() {
+    when(userRepository.findByEmail("john@example.com"))
+        .thenReturn(Optional.of(new User("john@example.com", "john", "123", "", "")));
+
+    assertThat(validator.isValid("john@example.com", null), is(false));
+  }
+
+  @Test
+  public void should_be_valid_for_null_email_without_hitting_the_repository() {
+    assertThat(validator.isValid(null, null), is(true));
+
+    verify(userRepository, never()).findByEmail(any());
+  }
+
+  @Test
+  public void should_be_valid_for_empty_email_without_hitting_the_repository() {
+    assertThat(validator.isValid("", null), is(true));
+
+    verify(userRepository, never()).findByEmail(any());
+  }
+
+  @Test
+  public void should_query_the_repository_for_a_blank_email() {
+    when(userRepository.findByEmail(" ")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid(" ", null), is(true));
+
+    verify(userRepository).findByEmail(" ");
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
@@ -1,0 +1,77 @@
+package io.spring.application.user;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DuplicatedUsernameValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedUsernameValidator validator;
+
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  public void should_be_valid_when_no_user_has_the_username() {
+    when(userRepository.findByUsername("john")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("john", null), is(true));
+
+    verify(userRepository).findByUsername("john");
+  }
+
+  @Test
+  public void should_be_invalid_when_a_user_already_has_the_username() {
+    when(userRepository.findByUsername("john"))
+        .thenReturn(Optional.of(new User("john@example.com", "john", "123", "", "")));
+
+    assertThat(validator.isValid("john", null), is(false));
+  }
+
+  @Test
+  public void should_be_valid_for_null_username_without_hitting_the_repository() {
+    assertThat(validator.isValid(null, null), is(true));
+
+    verify(userRepository, never()).findByUsername(any());
+  }
+
+  @Test
+  public void should_be_valid_for_empty_username_without_hitting_the_repository() {
+    assertThat(validator.isValid("", null), is(true));
+
+    verify(userRepository, never()).findByUsername(any());
+  }
+
+  @Test
+  public void should_query_the_repository_for_a_blank_username() {
+    when(userRepository.findByUsername(" ")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid(" ", null), is(true));
+
+    verify(userRepository).findByUsername(" ");
+  }
+}

--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -1,0 +1,105 @@
+package io.spring.core.comment;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+
+  @Test
+  public void should_set_all_fields_on_construction() {
+    Comment comment = new Comment("comment body", "user-id", "article-id");
+
+    assertThat(comment.getBody(), is("comment body"));
+    assertThat(comment.getUserId(), is("user-id"));
+    assertThat(comment.getArticleId(), is("article-id"));
+  }
+
+  @Test
+  public void should_generate_uuid_as_id() {
+    Comment comment = new Comment("comment body", "user-id", "article-id");
+
+    assertThat(comment.getId(), is(notNullValue()));
+    assertThat(UUID.fromString(comment.getId()).toString(), is(comment.getId()));
+  }
+
+  @Test
+  public void should_generate_different_id_for_each_comment() {
+    Comment one = new Comment("comment body", "user-id", "article-id");
+    Comment another = new Comment("comment body", "user-id", "article-id");
+
+    assertThat(one.getId(), is(not(another.getId())));
+  }
+
+  @Test
+  public void should_initialize_created_at_to_now() {
+    DateTime before = new DateTime().minusSeconds(1);
+
+    Comment comment = new Comment("comment body", "user-id", "article-id");
+
+    DateTime after = new DateTime().plusSeconds(1);
+    assertThat(comment.getCreatedAt(), is(notNullValue()));
+    assertThat(comment.getCreatedAt().isAfter(before), is(true));
+    assertThat(comment.getCreatedAt().isBefore(after), is(true));
+  }
+
+  @Test
+  public void should_leave_fields_null_with_default_constructor() {
+    Comment comment = new Comment();
+
+    assertThat(comment.getId(), is((String) null));
+    assertThat(comment.getBody(), is((String) null));
+    assertThat(comment.getUserId(), is((String) null));
+    assertThat(comment.getArticleId(), is((String) null));
+    assertThat(comment.getCreatedAt(), is((DateTime) null));
+  }
+
+  @Test
+  public void should_be_equal_when_id_is_equal() {
+    Comment comment = new Comment("comment body", "user-id", "article-id");
+    Comment sameId = new Comment("other body", "other-user", "other-article");
+    setId(sameId, comment.getId());
+
+    assertThat(comment.equals(sameId), is(true));
+    assertThat(comment.hashCode(), is(sameId.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_id_differs() {
+    Comment comment = new Comment("comment body", "user-id", "article-id");
+    Comment another = new Comment("comment body", "user-id", "article-id");
+
+    assertThat(comment.equals(another), is(false));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    Comment comment = new Comment("comment body", "user-id", "article-id");
+
+    assertThat(comment.equals(null), is(false));
+    assertThat(comment.equals("comment body"), is(false));
+  }
+
+  @Test
+  public void should_be_equal_to_itself() {
+    Comment comment = new Comment("comment body", "user-id", "article-id");
+
+    assertThat(comment.equals(comment), is(true));
+    assertThat(comment.hashCode(), is(comment.hashCode()));
+  }
+
+  private void setId(Comment comment, String id) {
+    try {
+      java.lang.reflect.Field field = Comment.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(comment, id);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -1,0 +1,166 @@
+package io.spring.core.user;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+  @Test
+  public void should_set_all_fields_on_construction() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.getEmail(), is("john@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_generate_uuid_as_id() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.getId(), is(notNullValue()));
+    assertThat(UUID.fromString(user.getId()).toString(), is(user.getId()));
+  }
+
+  @Test
+  public void should_generate_different_id_for_each_user() {
+    User one = new User("john@example.com", "john", "123", "bio", "image");
+    User another = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(one.getId(), is(not(another.getId())));
+  }
+
+  @Test
+  public void should_leave_id_null_with_default_constructor() {
+    User user = new User();
+
+    assertThat(user.getId(), is((String) null));
+    assertThat(user.getEmail(), is((String) null));
+  }
+
+  @Test
+  public void should_update_all_fields() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update("new@example.com", "newname", "newpassword", "new bio", "new image");
+
+    assertThat(user.getEmail(), is("new@example.com"));
+    assertThat(user.getUsername(), is("newname"));
+    assertThat(user.getPassword(), is("newpassword"));
+    assertThat(user.getBio(), is("new bio"));
+    assertThat(user.getImage(), is("new image"));
+  }
+
+  @Test
+  public void should_ignore_null_fields_on_update() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update(null, null, null, null, null);
+
+    assertThat(user.getEmail(), is("john@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_ignore_empty_fields_on_update() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update("", "", "", "", "");
+
+    assertThat(user.getEmail(), is("john@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_update_only_provided_fields() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update("new@example.com", "", null, "new bio", "");
+
+    assertThat(user.getEmail(), is("new@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("new bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_not_keep_id_unchanged_after_update() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+    String id = user.getId();
+
+    user.update("new@example.com", "newname", "newpassword", "new bio", "new image");
+
+    assertThat(user.getId(), is(id));
+  }
+
+  @Test
+  public void should_treat_blank_string_as_non_empty_on_update() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update(" ", " ", " ", " ", " ");
+
+    assertThat(user.getEmail(), is(" "));
+    assertThat(user.getUsername(), is(" "));
+    assertThat(user.getPassword(), is(" "));
+    assertThat(user.getBio(), is(" "));
+    assertThat(user.getImage(), is(" "));
+  }
+
+  @Test
+  public void should_be_equal_when_id_is_equal() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+    User sameId = new User("other@example.com", "other", "456", "other bio", "other image");
+    setId(sameId, user.getId());
+
+    assertThat(user.equals(sameId), is(true));
+    assertThat(user.hashCode(), is(sameId.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_id_differs() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+    User another = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.equals(another), is(false));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.equals(null), is(false));
+    assertThat(user.equals("john"), is(false));
+  }
+
+  @Test
+  public void should_be_equal_to_itself() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.equals(user), is(true));
+    assertThat(user.hashCode(), is(user.hashCode()));
+  }
+
+  private void setId(User user, String id) {
+    try {
+      java.lang.reflect.Field field = User.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(user, id);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -98,7 +98,7 @@ public class UserTest {
   }
 
   @Test
-  public void should_not_keep_id_unchanged_after_update() {
+  public void should_keep_id_unchanged_after_update() {
     User user = new User("john@example.com", "john", "123", "bio", "image");
     String id = user.getId();
 


### PR DESCRIPTION
## Summary

Adds 39 plain unit tests (no Spring context) for two core entities and the three `ConstraintValidator`s, in the style of the existing `io.spring.core.article.ArticleTest`. Test-only change; nothing under `src/main/`, `build.gradle` or `src/test/` existing files was touched.

New files:

| file | tests | class under test |
| --- | --- | --- |
| `src/test/java/io/spring/core/user/UserTest.java` | 14 | `io.spring.core.user.User` |
| `src/test/java/io/spring/core/comment/CommentTest.java` | 9 | `io.spring.core.comment.Comment` |
| `src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java` | 6 | `DuplicatedArticleValidator` |
| `src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java` | 5 | `DuplicatedEmailValidator` |
| `src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java` | 5 | `DuplicatedUsernameValidator` |

Points worth knowing:

- `User.update` / `Comment` equality semantics are pinned to what the code actually does, not what one might assume. Both entities are `@EqualsAndHashCode(of = "id")`, so two entities with identical field values but different generated UUIDs are **not** equal; the "equal ids ⇒ equal entities" case is exercised by reflectively overwriting `id` (the field is final-in-spirit but has no setter).
- `update()` skips a field only when `Util.isEmpty` (null or `""`) — a single space **is** written through. That is asserted explicitly (`should_treat_blank_string_as_non_empty_on_update`) so a future change to `isBlank()` semantics fails loudly.
- `DuplicatedArticleValidator` depends on `ArticleQueryService`, not `ArticleRepository` as one might expect from the task framing, and the lookup is `findBySlug(Article.toSlug(value), null)`. The slugification is asserted directly:
  ```java
  validator.isValid("A NEW   Title?", null);
  verify(articleQueryService).findBySlug("a-new-title-", null);   // not the raw title
  ```
- Mocks are wired with `@Mock` + `@InjectMocks` + `MockitoAnnotations.openMocks` (field injection matches the `@Autowired private` fields on the validators, which have no constructors/setters). `DuplicatedArticleValidator` and `DuplicatedUsernameValidator` are package-private, hence the tests live in the same packages.

## Production-code smells noticed, deliberately not fixed

1. **`DuplicatedArticleValidator` NPEs on null input.** `Article.toSlug(value)` calls `value.toLowerCase()` unguarded, so `isValid(null, ctx)` throws `NullPointerException` instead of returning `true`. The other two validators short-circuit on null/empty. Current behavior is pinned by `should_throw_on_null_title` — a fix would need that test updated. (Practically masked today because the DTO fields also carry `@NotBlank`, and bean-validation constraint ordering is not guaranteed.)
2. **Inconsistent null handling across the three validators** — the email/username ones treat null and `""` as valid; the article one does not.
3. **Empty title slugifies to `""`**, which is then looked up as a real slug rather than rejected.
4. **`@Autowired` field injection on validators** makes them untestable without reflection/`@InjectMocks`; constructor injection would be cleaner. No test-visibility or production change was made to work around this.

## Verification

- `./gradlew test` — full suite green (25 test classes, no failures/errors).
- `./gradlew spotlessApply` run; the only file it rewrites besides the new ones is the pre-existing violation in `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java`, which is intentionally **not** included in this PR.


Link to Devin session: https://app.devin.ai/sessions/08d441af550f47a39d1bb9959dccf56f
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/871?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->