### PR TITLE
test: cover pagination utilities and TagsApi

### DIFF
--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -1,0 +1,75 @@
+package io.spring.api;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.JacksonCustomizations;
+import io.spring.api.security.WebSecurityConfig;
+import io.spring.application.TagsQueryService;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TagsApi.class)
+@Import({WebSecurityConfig.class, JacksonCustomizations.class})
+public class TagsApiTest extends TestWithCurrentUser {
+  @Autowired private MockMvc mvc;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @Override
+  @BeforeEach
+  public void setUp() throws Exception {
+    super.setUp();
+    RestAssuredMockMvc.mockMvc(mvc);
+  }
+
+  @Test
+  public void should_get_all_tags_without_authentication() {
+    when(tagsQueryService.allTags()).thenReturn(asList("reactjs", "angularjs", "dragons"));
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", hasSize(3))
+        .body("tags", contains("reactjs", "angularjs", "dragons"));
+  }
+
+  @Test
+  public void should_get_empty_tags_list() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", empty());
+  }
+
+  @Test
+  public void should_get_all_tags_with_authentication() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.singletonList("reactjs"));
+
+    given()
+        .header("Authorization", "Token " + token)
+        .when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", contains("reactjs"));
+  }
+}

--- a/src/test/java/io/spring/application/CursorPageParameterTest.java
+++ b/src/test/java/io/spring/application/CursorPageParameterTest.java
@@ -1,0 +1,89 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.application.CursorPager.Direction;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class CursorPageParameterTest {
+
+  @Test
+  public void should_use_default_limit_with_no_args_constructor() {
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>();
+
+    assertThat(parameter.getLimit()).isEqualTo(20);
+    assertThat(parameter.getQueryLimit()).isEqualTo(21);
+    assertThat(parameter.getCursor()).isNull();
+    assertThat(parameter.getDirection()).isNull();
+    assertThat(parameter.isNext()).isFalse();
+  }
+
+  @ParameterizedTest(name = "limit {0} -> limit={1}, queryLimit={2}")
+  @CsvSource({
+    "1,     1,    2",
+    "20,    20,   21",
+    "1000,  1000, 1001",
+    // limit above MAX_LIMIT is clamped to 1000
+    "1001,  1000, 1001",
+    "999999, 1000, 1001",
+    // limit <= 0 falls back to the default 20
+    "0,     20,   21",
+    "-1,    20,   21",
+  })
+  public void should_clamp_limit_and_fetch_one_extra_row(
+      int limit, int expectedLimit, int expectedQueryLimit) {
+    CursorPageParameter<DateTime> parameter =
+        new CursorPageParameter<>(DateTime.now(), limit, Direction.NEXT);
+
+    assertThat(parameter.getLimit()).isEqualTo(expectedLimit);
+    assertThat(parameter.getQueryLimit()).isEqualTo(expectedQueryLimit);
+  }
+
+  @Test
+  public void should_keep_the_given_cursor() {
+    DateTime cursor = new DateTime(1_600_000_000_000L);
+
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(cursor, 10, Direction.NEXT);
+
+    assertThat(parameter.getCursor()).isEqualTo(cursor);
+  }
+
+  @Test
+  public void should_allow_null_cursor_for_the_first_page() {
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(null, 10, Direction.NEXT);
+
+    assertThat(parameter.getCursor()).isNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(Direction.class)
+  public void should_report_next_only_for_next_direction(Direction direction) {
+    CursorPageParameter<DateTime> parameter =
+        new CursorPageParameter<>(DateTime.now(), 10, direction);
+
+    assertThat(parameter.getDirection()).isEqualTo(direction);
+    assertThat(parameter.isNext()).isEqualTo(direction == Direction.NEXT);
+  }
+
+  @Test
+  public void should_expose_both_directions_in_the_enum() {
+    assertThat(Direction.values()).containsExactly(Direction.PREV, Direction.NEXT);
+    assertThat(Direction.valueOf("NEXT")).isEqualTo(Direction.NEXT);
+    assertThat(Direction.valueOf("PREV")).isEqualTo(Direction.PREV);
+  }
+
+  @Test
+  public void should_be_equal_for_same_cursor_limit_and_direction() {
+    DateTime cursor = new DateTime(1_600_000_000_000L);
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(cursor, 10, Direction.NEXT);
+    CursorPageParameter<DateTime> same = new CursorPageParameter<>(cursor, 10, Direction.NEXT);
+    CursorPageParameter<DateTime> other = new CursorPageParameter<>(cursor, 10, Direction.PREV);
+
+    assertThat(parameter).isEqualTo(same).hasSameHashCodeAs(same);
+    assertThat(parameter).isNotEqualTo(other);
+  }
+}

--- a/src/test/java/io/spring/application/CursorPagerTest.java
+++ b/src/test/java/io/spring/application/CursorPagerTest.java
@@ -1,0 +1,199 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.application.CursorPager.Direction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+public class CursorPagerTest {
+
+  private static final DateTime EPOCH = new DateTime(0L, DateTimeZone.UTC);
+
+  /** Minimal {@link Node} whose cursor is derived from a fixed offset in milliseconds. */
+  private static class TestNode implements Node {
+    private final long millis;
+
+    TestNode(long millis) {
+      this.millis = millis;
+    }
+
+    @Override
+    public PageCursor getCursor() {
+      return new DateTimeCursor(EPOCH.withMillis(millis));
+    }
+
+    @Override
+    public String toString() {
+      return "TestNode(" + millis + ")";
+    }
+  }
+
+  private static List<TestNode> nodes(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> new TestNode(i + 1))
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  private static List<Long> millisOf(List<TestNode> data) {
+    return data.stream().map(node -> node.millis).collect(Collectors.toList());
+  }
+
+  /**
+   * Mirrors what the query services do with the rows returned for {@code getQueryLimit()}: drop the
+   * extra probe row and, for backward paging, restore ascending order.
+   */
+  private static CursorPager<TestNode> page(
+      List<TestNode> fetched, CursorPageParameter<DateTime> parameter) {
+    List<TestNode> data = new ArrayList<>(fetched);
+    boolean hasExtra = data.size() > parameter.getLimit();
+    if (hasExtra) {
+      data.remove(parameter.getLimit());
+    }
+    if (!parameter.isNext()) {
+      Collections.reverse(data);
+    }
+    return new CursorPager<>(data, parameter.getDirection(), hasExtra);
+  }
+
+  @Test
+  public void should_have_next_and_no_previous_when_paging_forward_with_extra_row() {
+    CursorPager<TestNode> pager = new CursorPager<>(nodes(3), Direction.NEXT, true);
+
+    assertThat(pager.hasNext()).isTrue();
+    assertThat(pager.hasPrevious()).isFalse();
+    assertThat(pager.isNext()).isTrue();
+    assertThat(pager.isPrevious()).isFalse();
+  }
+
+  @Test
+  public void should_have_no_next_when_paging_forward_without_extra_row() {
+    CursorPager<TestNode> pager = new CursorPager<>(nodes(3), Direction.NEXT, false);
+
+    assertThat(pager.hasNext()).isFalse();
+    assertThat(pager.hasPrevious()).isFalse();
+  }
+
+  @Test
+  public void should_have_previous_and_no_next_when_paging_backward_with_extra_row() {
+    CursorPager<TestNode> pager = new CursorPager<>(nodes(3), Direction.PREV, true);
+
+    assertThat(pager.hasPrevious()).isTrue();
+    assertThat(pager.hasNext()).isFalse();
+  }
+
+  @Test
+  public void should_have_no_previous_when_paging_backward_without_extra_row() {
+    CursorPager<TestNode> pager = new CursorPager<>(nodes(3), Direction.PREV, false);
+
+    assertThat(pager.hasPrevious()).isFalse();
+    assertThat(pager.hasNext()).isFalse();
+  }
+
+  @Test
+  public void should_expose_the_data_it_was_built_with() {
+    List<TestNode> data = nodes(3);
+
+    CursorPager<TestNode> pager = new CursorPager<>(data, Direction.NEXT, false);
+
+    assertThat(pager.getData()).containsExactlyElementsOf(data);
+  }
+
+  @Test
+  public void should_return_null_cursors_for_an_empty_page() {
+    CursorPager<TestNode> pager = new CursorPager<>(new ArrayList<>(), Direction.NEXT, false);
+
+    assertThat(pager.getData()).isEmpty();
+    assertThat(pager.getStartCursor()).isNull();
+    assertThat(pager.getEndCursor()).isNull();
+    assertThat(pager.hasNext()).isFalse();
+    assertThat(pager.hasPrevious()).isFalse();
+  }
+
+  @Test
+  public void should_take_cursors_from_the_first_and_last_node() {
+    CursorPager<TestNode> pager = new CursorPager<>(nodes(3), Direction.NEXT, false);
+
+    assertThat(pager.getStartCursor().toString()).isEqualTo("1");
+    assertThat(pager.getEndCursor().toString()).isEqualTo("3");
+  }
+
+  @Test
+  public void should_use_the_same_cursor_for_start_and_end_of_a_single_element_page() {
+    CursorPager<TestNode> pager = new CursorPager<>(nodes(1), Direction.PREV, false);
+
+    assertThat(pager.getStartCursor().toString()).isEqualTo("1");
+    assertThat(pager.getEndCursor().toString()).isEqualTo("1");
+  }
+
+  @Test
+  public void should_trim_the_probe_row_and_report_next_when_paging_forward() {
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(EPOCH, 2, Direction.NEXT);
+
+    // the read services fetch getQueryLimit() (= limit + 1) rows to detect a further page
+    CursorPager<TestNode> pager = page(nodes(parameter.getQueryLimit()), parameter);
+
+    assertThat(millisOf(pager.getData())).containsExactly(1L, 2L);
+    assertThat(pager.hasNext()).isTrue();
+    assertThat(pager.hasPrevious()).isFalse();
+    assertThat(pager.getStartCursor().toString()).isEqualTo("1");
+    assertThat(pager.getEndCursor().toString()).isEqualTo("2");
+  }
+
+  @Test
+  public void should_keep_all_rows_when_the_last_forward_page_is_not_full() {
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(EPOCH, 5, Direction.NEXT);
+
+    CursorPager<TestNode> pager = page(nodes(3), parameter);
+
+    assertThat(millisOf(pager.getData())).containsExactly(1L, 2L, 3L);
+    assertThat(pager.hasNext()).isFalse();
+  }
+
+  @Test
+  public void should_keep_all_rows_when_the_forward_page_is_exactly_full() {
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(EPOCH, 3, Direction.NEXT);
+
+    CursorPager<TestNode> pager = page(nodes(3), parameter);
+
+    assertThat(millisOf(pager.getData())).containsExactly(1L, 2L, 3L);
+    assertThat(pager.hasNext()).isFalse();
+  }
+
+  @Test
+  public void should_trim_the_probe_row_and_reverse_when_paging_backward() {
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(EPOCH, 2, Direction.PREV);
+
+    // backward reads come back newest-first: 3, 2, 1 (1 being the probe row)
+    List<TestNode> fetched = nodes(parameter.getQueryLimit());
+    Collections.reverse(fetched);
+
+    CursorPager<TestNode> pager = page(fetched, parameter);
+
+    assertThat(millisOf(pager.getData())).containsExactly(2L, 3L);
+    assertThat(pager.hasPrevious()).isTrue();
+    assertThat(pager.hasNext()).isFalse();
+    assertThat(pager.getStartCursor().toString()).isEqualTo("2");
+    assertThat(pager.getEndCursor().toString()).isEqualTo("3");
+  }
+
+  @Test
+  public void should_report_no_previous_when_the_backward_page_reaches_the_beginning() {
+    CursorPageParameter<DateTime> parameter = new CursorPageParameter<>(EPOCH, 5, Direction.PREV);
+
+    List<TestNode> fetched = nodes(2);
+    Collections.reverse(fetched);
+
+    CursorPager<TestNode> pager = page(fetched, parameter);
+
+    assertThat(millisOf(pager.getData())).containsExactly(1L, 2L);
+    assertThat(pager.hasPrevious()).isFalse();
+    assertThat(pager.hasNext()).isFalse();
+  }
+}

--- a/src/test/java/io/spring/application/DateTimeCursorTest.java
+++ b/src/test/java/io/spring/application/DateTimeCursorTest.java
@@ -1,0 +1,61 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class DateTimeCursorTest {
+
+  @Test
+  public void should_encode_the_date_time_as_epoch_millis() {
+    DateTime dateTime = new DateTime(1_600_000_000_123L, DateTimeZone.UTC);
+
+    DateTimeCursor cursor = new DateTimeCursor(dateTime);
+
+    assertThat(cursor.getData()).isEqualTo(dateTime);
+    assertThat(cursor.toString()).isEqualTo("1600000000123");
+  }
+
+  @Test
+  public void should_encode_the_same_instant_regardless_of_time_zone() {
+    DateTime utc = new DateTime(1_600_000_000_000L, DateTimeZone.UTC);
+    DateTime shifted = utc.withZone(DateTimeZone.forOffsetHours(8));
+
+    assertThat(new DateTimeCursor(shifted).toString())
+        .isEqualTo(new DateTimeCursor(utc).toString());
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {0L, 1L, 1_600_000_000_000L, 4_102_444_800_000L})
+  public void should_round_trip_through_parse(long millis) {
+    DateTimeCursor cursor = new DateTimeCursor(new DateTime(millis, DateTimeZone.UTC));
+
+    DateTime parsed = DateTimeCursor.parse(cursor.toString());
+
+    assertThat(parsed.getMillis()).isEqualTo(millis);
+    assertThat(parsed.getZone()).isEqualTo(DateTimeZone.UTC);
+  }
+
+  @Test
+  public void should_parse_null_cursor_to_null() {
+    assertThat(DateTimeCursor.parse(null)).isNull();
+  }
+
+  @Test
+  public void should_reject_a_non_numeric_cursor() {
+    assertThatThrownBy(() -> DateTimeCursor.parse("not-a-number"))
+        .isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  public void should_fail_to_render_a_cursor_without_data() {
+    DateTimeCursor cursor = new DateTimeCursor(null);
+
+    assertThatThrownBy(cursor::toString).isInstanceOf(NullPointerException.class);
+  }
+}

--- a/src/test/java/io/spring/application/PageCursorTest.java
+++ b/src/test/java/io/spring/application/PageCursorTest.java
@@ -1,0 +1,47 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+public class PageCursorTest {
+
+  private static class StringCursor extends PageCursor<String> {
+    StringCursor(String data) {
+      super(data);
+    }
+  }
+
+  @Test
+  public void should_expose_the_wrapped_data() {
+    StringCursor cursor = new StringCursor("abc");
+
+    assertThat(cursor.getData()).isEqualTo("abc");
+  }
+
+  @Test
+  public void should_render_the_wrapped_data_by_default() {
+    assertThat(new StringCursor("abc").toString()).isEqualTo("abc");
+  }
+
+  @Test
+  public void should_allow_null_data_but_fail_to_render_it() {
+    StringCursor cursor = new StringCursor(null);
+
+    assertThat(cursor.getData()).isNull();
+    assertThatThrownBy(cursor::toString).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void should_let_subclasses_override_the_rendering() {
+    DateTime dateTime = new DateTime(42L, DateTimeZone.UTC);
+
+    PageCursor<DateTime> cursor = new DateTimeCursor(dateTime);
+
+    assertThat(cursor.getData()).isEqualTo(dateTime);
+    assertThat(cursor.toString()).isEqualTo("42").isNotEqualTo(dateTime.toString());
+  }
+}

--- a/src/test/java/io/spring/application/PageTest.java
+++ b/src/test/java/io/spring/application/PageTest.java
@@ -1,0 +1,60 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class PageTest {
+
+  @Test
+  public void should_use_default_offset_and_limit_with_no_args_constructor() {
+    Page page = new Page();
+
+    assertThat(page.getOffset()).isEqualTo(0);
+    assertThat(page.getLimit()).isEqualTo(20);
+  }
+
+  @ParameterizedTest(name = "new Page({0}, {1}) -> offset={2}, limit={3}")
+  @CsvSource({
+    // offset, limit, expectedOffset, expectedLimit
+    "0,    10,   0,   10",
+    "5,    10,   5,   10",
+    "10,   100,  10,  100",
+    // offset <= 0 falls back to the default 0
+    "-1,   10,   0,   10",
+    "-100, 10,   0,   10",
+    // limit <= 0 falls back to the default 20
+    "5,    0,    5,   20",
+    "5,    -1,   5,   20",
+    // limit above MAX_LIMIT is clamped to 100
+    "5,    101,  5,   100",
+    "5,    5000, 5,   100",
+  })
+  public void should_clamp_offset_and_limit(
+      int offset, int limit, int expectedOffset, int expectedLimit) {
+    Page page = new Page(offset, limit);
+
+    assertThat(page.getOffset()).isEqualTo(expectedOffset);
+    assertThat(page.getLimit()).isEqualTo(expectedLimit);
+  }
+
+  @Test
+  public void should_keep_limit_exactly_at_max_limit() {
+    Page page = new Page(0, 100);
+
+    assertThat(page.getLimit()).isEqualTo(100);
+  }
+
+  @Test
+  public void should_be_equal_for_same_offset_and_limit() {
+    Page page = new Page(3, 7);
+    Page same = new Page(3, 7);
+    Page other = new Page(3, 8);
+
+    assertThat(page).isEqualTo(same).hasSameHashCodeAs(same);
+    assertThat(page).isNotEqualTo(other);
+    assertThat(page.toString()).contains("offset=3", "limit=7");
+  }
+}


### PR DESCRIPTION
## Summary

Adds 36 new tests (123 total suite cases pass) covering the `io.spring.application` pagination primitives and `TagsApi`. Test-only change: no file under `src/main/`, `build.gradle`, or existing `src/test/` files was touched.

Classes covered:

- **`Page`** — defaults (`offset=0`, `limit=20`), and table-driven clamping: `offset <= 0 -> 0`, `limit <= 0 -> 20`, `limit > MAX_LIMIT(100) -> 100`, boundary at exactly 100; plus Lombok `equals`/`hashCode`/`toString`.
- **`CursorPageParameter`** — same clamping against its own `MAX_LIMIT` of 1000, `getQueryLimit() == limit + 1` (the probe row), `isNext()` per `Direction`, null cursor for a first page, and the `Direction` enum ordering.
- **`CursorPager`** — `hasNext()`/`hasPrevious()` for all four `(direction, hasExtra)` combinations, cursor extraction from first/last `Node`, single-element pages, and `null` start/end cursors for an empty page. Because `CursorPager` itself does *not* trim the probe row, the paging pipeline is exercised through a small test helper that mirrors what `ArticleQueryService`/`CommentQueryService` do:

  ```java
  boolean hasExtra = data.size() > parameter.getLimit();
  if (hasExtra) data.remove(parameter.getLimit());
  if (!parameter.isNext()) Collections.reverse(data);
  return new CursorPager<>(data, parameter.getDirection(), hasExtra);
  ```

  so trimming, backward-page reordering and the resulting cursors are asserted end-to-end.
- **`DateTimeCursor` / `PageCursor`** — epoch-millis `toString()`, time-zone independence, `parse` round-trip (UTC zone on the way back), `parse(null) -> null`, `NumberFormatException` on garbage input, and the `NullPointerException` both cursors throw when rendering null data.
- **`Node`** — exercised via a `TestNode` implementation in `CursorPagerTest`.
- **`TagsApi`** — `@WebMvcTest(TagsApi.class)` + `@Import({WebSecurityConfig.class, JacksonCustomizations.class})` with a `@MockBean TagsQueryService`, extending `TestWithCurrentUser` (its mocks are needed by `JwtTokenFilter` inside `WebSecurityConfig`). Asserts the `{"tags": [...]}` shape for populated and empty lists, and that `GET /tags` works both unauthenticated and with a token.

## Not covered / notes

- `CursorPager` is documented in the task as trimming the probe element; it does not — trimming lives in each query service (duplicated three times in `ArticleQueryService`/`CommentQueryService`). The behavior is asserted at the pipeline level instead, but pulling that logic into `CursorPager` would remove the duplication. Not changed (production code is out of scope for this PR).
- `PageCursor.toString()` and `DateTimeCursor.toString()` NPE on null data, and `DateTimeCursor.parse` propagates `NumberFormatException` for a malformed client cursor, which surfaces as a 500 rather than a 400. Tests pin the current behavior; no fix made.
- `DateTimeCursor.parse` uses `new DateTime().withMillis(...)`, i.e. it constructs a "now" instance only to overwrite it — harmless but wasteful.
- `TagsApi.getTags()` returns a raw `ResponseEntity` built from a double-brace-initialized anonymous `HashMap` subclass (holds a reference to the enclosing controller); the tests cover it as-is.

## Verification

- `./gradlew test` — BUILD SUCCESSFUL, 123 tests, 0 failures/errors.
- `./gradlew spotlessApply` / `spotlessCheck` — clean. Note `spotlessApply` also rewrites the pre-existing violation in `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java`; that file is deliberately **not** part of this commit.


Link to Devin session: https://app.devin.ai/sessions/8c7688325c11461abe557eafee5ed24b
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/872?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->