### PR TITLE
test: unit-test the command/write-side application services

### DIFF
--- a/src/test/java/io/spring/application/UserQueryServiceTest.java
+++ b/src/test/java/io/spring/application/UserQueryServiceTest.java
@@ -1,0 +1,89 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.application.data.UserData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.mybatis.readservice.UserReadService;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import({UserQueryService.class, MyBatisUserRepository.class})
+public class UserQueryServiceTest extends DbTestBase {
+
+  @Autowired private UserQueryService userQueryService;
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private UserReadService userReadService;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("aisensiy@gmail.com", "aisensiy", "123", "my bio", "my image");
+    userRepository.save(user);
+  }
+
+  @Test
+  public void should_fetch_user_by_id() {
+    Optional<UserData> optional = userQueryService.findById(user.getId());
+
+    assertThat(optional).isPresent();
+    UserData userData = optional.get();
+    assertThat(userData.getId()).isEqualTo(user.getId());
+    assertThat(userData.getEmail()).isEqualTo("aisensiy@gmail.com");
+    assertThat(userData.getUsername()).isEqualTo("aisensiy");
+    assertThat(userData.getBio()).isEqualTo("my bio");
+    assertThat(userData.getImage()).isEqualTo("my image");
+  }
+
+  @Test
+  public void should_return_empty_optional_for_unknown_id() {
+    assertThat(userQueryService.findById(UUID.randomUUID().toString())).isEmpty();
+  }
+
+  @Test
+  public void should_return_empty_optional_for_null_id() {
+    assertThat(userQueryService.findById(null)).isEmpty();
+  }
+
+  @Test
+  public void should_read_the_updated_user_after_it_is_saved_again() {
+    user.update("updated@gmail.com", "updated", "", "updated bio", "updated image");
+    userRepository.save(user);
+
+    UserData userData = userQueryService.findById(user.getId()).get();
+    assertThat(userData.getEmail()).isEqualTo("updated@gmail.com");
+    assertThat(userData.getUsername()).isEqualTo("updated");
+    assertThat(userData.getBio()).isEqualTo("updated bio");
+    assertThat(userData.getImage()).isEqualTo("updated image");
+  }
+
+  /**
+   * {@link UserQueryService} exposes no username lookup, so the read path used by the profile and
+   * login flows is asserted straight against {@link UserReadService}.
+   */
+  @Test
+  public void should_read_user_by_username() {
+    UserData userData = userReadService.findByUsername("aisensiy");
+
+    assertThat(userData).isNotNull();
+    assertThat(userData.getId()).isEqualTo(user.getId());
+    assertThat(userData.getEmail()).isEqualTo("aisensiy@gmail.com");
+    assertThat(userData.getBio()).isEqualTo("my bio");
+    assertThat(userData.getImage()).isEqualTo("my image");
+  }
+
+  @Test
+  public void should_read_null_for_unknown_username() {
+    assertThat(userReadService.findByUsername("nobody")).isNull();
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,338 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.article.Tag;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+public class ArticleCommandServiceTest {
+
+  @Mock private ArticleRepository articleRepository;
+
+  @Mock private ArticleQueryService articleQueryService;
+
+  @Captor private ArgumentCaptor<Article> articleCaptor;
+
+  private ArticleCommandService articleCommandService;
+
+  private User creator;
+
+  private AutoCloseable mocks;
+
+  private AnnotationConfigApplicationContext validationContext;
+
+  @BeforeEach
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    articleCommandService = new ArticleCommandService(articleRepository);
+    creator = new User("john@test.com", "john", "123", "bio", "image");
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (validationContext != null) {
+      validationContext.close();
+    }
+    mocks.close();
+  }
+
+  @Test
+  public void should_create_article_with_slug_generated_from_title() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("How to train your Dragon")
+            .description("a description")
+            .body("a body")
+            .tagList(Arrays.asList("java"))
+            .build();
+
+    Article created = articleCommandService.createArticle(param, creator);
+
+    assertThat(created.getSlug()).isEqualTo("how-to-train-your-dragon");
+    assertThat(created.getTitle()).isEqualTo("How to train your Dragon");
+    assertThat(created.getDescription()).isEqualTo("a description");
+    assertThat(created.getBody()).isEqualTo("a body");
+    assertThat(created.getUserId()).isEqualTo(creator.getId());
+    assertThat(created.getId()).isNotBlank();
+    assertThat(created.getCreatedAt()).isNotNull();
+    assertThat(created.getUpdatedAt()).isEqualTo(created.getCreatedAt());
+  }
+
+  @Test
+  public void should_squash_punctuation_and_repeated_separators_into_the_slug() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("Cats, Dogs & Other  Pets?")
+            .description("desc")
+            .body("body")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Article created = articleCommandService.createArticle(param, creator);
+
+    assertThat(created.getSlug()).isEqualTo("cats-dogs-other-pets-");
+  }
+
+  @Test
+  public void should_persist_the_created_article_through_the_repository() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("a new title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("spring"))
+            .build();
+
+    Article created = articleCommandService.createArticle(param, creator);
+
+    verify(articleRepository).save(articleCaptor.capture());
+    Article saved = articleCaptor.getValue();
+    assertThat(saved).isSameAs(created);
+    assertThat(saved.getSlug()).isEqualTo("a-new-title");
+    assertThat(tagNamesOf(saved)).containsExactly("spring");
+  }
+
+  @Test
+  public void should_create_one_tag_per_distinct_tag_name() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("tagged")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring", "java"))
+            .build();
+
+    Article created = articleCommandService.createArticle(param, creator);
+
+    assertThat(created.getTags()).hasSize(2);
+    assertThat(tagNamesOf(created)).containsExactlyInAnyOrder("java", "spring");
+    Set<String> tagIds = created.getTags().stream().map(Tag::getId).collect(Collectors.toSet());
+    assertThat(tagIds).hasSize(2);
+  }
+
+  @Test
+  public void should_create_article_without_any_tag() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("no tags here")
+            .description("desc")
+            .body("body")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Article created = articleCommandService.createArticle(param, creator);
+
+    assertThat(created.getTags()).isEmpty();
+    verify(articleRepository).save(created);
+  }
+
+  @Test
+  public void should_update_only_the_title_and_regenerate_the_slug() {
+    Article article = existingArticle();
+    String originalDescription = article.getDescription();
+    String originalBody = article.getBody();
+
+    Article updated =
+        articleCommandService.updateArticle(article, new UpdateArticleParam("new title", "", ""));
+
+    assertThat(updated).isSameAs(article);
+    assertThat(updated.getTitle()).isEqualTo("new title");
+    assertThat(updated.getSlug()).isEqualTo("new-title");
+    assertThat(updated.getDescription()).isEqualTo(originalDescription);
+    assertThat(updated.getBody()).isEqualTo(originalBody);
+    verify(articleRepository).save(article);
+  }
+
+  @Test
+  public void should_update_only_the_body_and_keep_the_slug() {
+    Article article = existingArticle();
+    String originalSlug = article.getSlug();
+
+    Article updated =
+        articleCommandService.updateArticle(article, new UpdateArticleParam("", "new body", ""));
+
+    assertThat(updated.getBody()).isEqualTo("new body");
+    assertThat(updated.getTitle()).isEqualTo("original title");
+    assertThat(updated.getSlug()).isEqualTo(originalSlug);
+    assertThat(updated.getDescription()).isEqualTo("original description");
+  }
+
+  @Test
+  public void should_update_only_the_description_and_keep_the_slug() {
+    Article article = existingArticle();
+    String originalSlug = article.getSlug();
+
+    Article updated =
+        articleCommandService.updateArticle(
+            article, new UpdateArticleParam("", "", "new description"));
+
+    assertThat(updated.getDescription()).isEqualTo("new description");
+    assertThat(updated.getTitle()).isEqualTo("original title");
+    assertThat(updated.getBody()).isEqualTo("original body");
+    assertThat(updated.getSlug()).isEqualTo(originalSlug);
+  }
+
+  @Test
+  public void should_update_title_body_and_description_together() {
+    Article article = existingArticle();
+
+    Article updated =
+        articleCommandService.updateArticle(
+            article, new UpdateArticleParam("brand new title", "brand new body", "brand new desc"));
+
+    assertThat(updated.getTitle()).isEqualTo("brand new title");
+    assertThat(updated.getBody()).isEqualTo("brand new body");
+    assertThat(updated.getDescription()).isEqualTo("brand new desc");
+    assertThat(updated.getSlug()).isEqualTo("brand-new-title");
+    verify(articleRepository).save(articleCaptor.capture());
+    assertThat(articleCaptor.getValue().getSlug()).isEqualTo("brand-new-title");
+  }
+
+  @Test
+  public void should_leave_article_untouched_when_all_update_fields_are_empty() {
+    Article article = existingArticle();
+    String originalSlug = article.getSlug();
+
+    Article updated =
+        articleCommandService.updateArticle(article, new UpdateArticleParam("", "", ""));
+
+    assertThat(updated.getTitle()).isEqualTo("original title");
+    assertThat(updated.getBody()).isEqualTo("original body");
+    assertThat(updated.getDescription()).isEqualTo("original description");
+    assertThat(updated.getSlug()).isEqualTo(originalSlug);
+    verify(articleRepository).save(article);
+  }
+
+  @Test
+  public void should_not_touch_the_repository_before_a_command_is_issued() {
+    verify(articleRepository, never()).save(any());
+  }
+
+  /**
+   * The service is {@code @Validated}, so the {@code @Valid} parameter is only checked by the
+   * Spring proxy. A bare instance performs no validation at all, which is what the unit tests above
+   * rely on; the constraints themselves are asserted directly against a validator below.
+   */
+  @Test
+  public void should_not_validate_new_article_param_when_service_is_not_proxied() {
+    NewArticleParam invalid =
+        NewArticleParam.builder()
+            .title("")
+            .description("")
+            .body("")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Article created = articleCommandService.createArticle(invalid, creator);
+
+    assertThat(created.getTitle()).isEmpty();
+    verify(articleRepository).save(created);
+  }
+
+  @Test
+  public void should_reject_new_article_param_with_blank_fields() {
+    NewArticleParam invalid =
+        NewArticleParam.builder()
+            .title("")
+            .description("")
+            .body("")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Set<ConstraintViolation<NewArticleParam>> violations = validator().validate(invalid);
+
+    assertThat(violations)
+        .extracting(violation -> violation.getPropertyPath().toString())
+        .containsExactlyInAnyOrder("title", "description", "body");
+    assertThat(violations)
+        .allSatisfy(violation -> assertThat(violation.getMessage()).isEqualTo("can't be empty"));
+  }
+
+  @Test
+  public void should_reject_new_article_param_with_a_duplicated_title() {
+    when(articleQueryService.findBySlug(eq("duplicated-title"), any()))
+        .thenReturn(Optional.of(new ArticleData()));
+    NewArticleParam duplicated =
+        NewArticleParam.builder()
+            .title("duplicated title")
+            .description("desc")
+            .body("body")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Set<ConstraintViolation<NewArticleParam>> violations = validator().validate(duplicated);
+
+    assertThat(violations).hasSize(1);
+    ConstraintViolation<NewArticleParam> violation = violations.iterator().next();
+    assertThat(violation.getPropertyPath().toString()).isEqualTo("title");
+    assertThat(violation.getMessage()).isEqualTo("article name exists");
+  }
+
+  @Test
+  public void should_accept_a_valid_new_article_param() {
+    NewArticleParam valid =
+        NewArticleParam.builder()
+            .title("a fresh title")
+            .description("desc")
+            .body("body")
+            .tagList(Collections.emptyList())
+            .build();
+
+    assertThat(validator().validate(valid)).isEmpty();
+  }
+
+  private Article existingArticle() {
+    return new Article(
+        "original title",
+        "original description",
+        "original body",
+        Arrays.asList("java"),
+        creator.getId());
+  }
+
+  private List<String> tagNamesOf(Article article) {
+    return article.getTags().stream().map(Tag::getName).collect(Collectors.toList());
+  }
+
+  /**
+   * Builds a validator whose constraint validators are created by Spring, so that {@link
+   * DuplicatedArticleConstraint} gets its {@link ArticleQueryService} injected from the mock above.
+   */
+  private Validator validator() {
+    validationContext = new AnnotationConfigApplicationContext();
+    validationContext
+        .getBeanFactory()
+        .registerSingleton("articleQueryService", articleQueryService);
+    validationContext.refresh();
+    LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.setApplicationContext(validationContext);
+    validatorFactoryBean.afterPropertiesSet();
+    return validatorFactoryBean;
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -3,6 +3,7 @@ package io.spring.application.article;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -276,7 +277,7 @@ public class ArticleCommandServiceTest {
 
   @Test
   public void should_reject_new_article_param_with_a_duplicated_title() {
-    when(articleQueryService.findBySlug(eq("duplicated-title"), any()))
+    when(articleQueryService.findBySlug(eq("duplicated-title"), isNull()))
         .thenReturn(Optional.of(new ArticleData()));
     NewArticleParam duplicated =
         NewArticleParam.builder()

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,261 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+public class UserServiceTest {
+
+  private static final String DEFAULT_IMAGE = "https://static.productionready.io/images/smiley.jpg";
+
+  @Mock private UserRepository userRepository;
+
+  @Captor private ArgumentCaptor<User> userCaptor;
+
+  private PasswordEncoder passwordEncoder;
+
+  private UserService userService;
+
+  private AutoCloseable mocks;
+
+  private AnnotationConfigApplicationContext validationContext;
+
+  @BeforeEach
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    passwordEncoder = new BCryptPasswordEncoder();
+    userService = new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (validationContext != null) {
+      validationContext.close();
+    }
+    mocks.close();
+  }
+
+  @Test
+  public void should_create_user_with_hashed_password() {
+    RegisterParam registerParam = new RegisterParam("john@test.com", "john", "plain-password");
+
+    User created = userService.createUser(registerParam);
+
+    assertThat(created.getPassword()).isNotEqualTo("plain-password");
+    assertThat(passwordEncoder.matches("plain-password", created.getPassword())).isTrue();
+  }
+
+  @Test
+  public void should_create_user_with_default_image_and_empty_bio() {
+    RegisterParam registerParam = new RegisterParam("john@test.com", "john", "plain-password");
+
+    User created = userService.createUser(registerParam);
+
+    assertThat(created.getEmail()).isEqualTo("john@test.com");
+    assertThat(created.getUsername()).isEqualTo("john");
+    assertThat(created.getBio()).isEmpty();
+    assertThat(created.getImage()).isEqualTo(DEFAULT_IMAGE);
+    assertThat(created.getId()).isNotBlank();
+  }
+
+  @Test
+  public void should_persist_the_created_user_through_the_repository() {
+    RegisterParam registerParam = new RegisterParam("john@test.com", "john", "plain-password");
+
+    User created = userService.createUser(registerParam);
+
+    verify(userRepository).save(userCaptor.capture());
+    User saved = userCaptor.getValue();
+    assertThat(saved).isSameAs(created);
+    assertThat(saved.getUsername()).isEqualTo("john");
+    assertThat(passwordEncoder.matches("plain-password", saved.getPassword())).isTrue();
+  }
+
+  @Test
+  public void should_update_every_provided_field() {
+    User targetUser = new User("old@test.com", "old", "old-password", "old bio", "old image");
+    UpdateUserParam param =
+        UpdateUserParam.builder()
+            .email("new@test.com")
+            .username("new")
+            .password("new-password")
+            .bio("new bio")
+            .image("new image")
+            .build();
+
+    userService.updateUser(new UpdateUserCommand(targetUser, param));
+
+    verify(userRepository).save(userCaptor.capture());
+    User saved = userCaptor.getValue();
+    assertThat(saved).isSameAs(targetUser);
+    assertThat(saved.getEmail()).isEqualTo("new@test.com");
+    assertThat(saved.getUsername()).isEqualTo("new");
+    assertThat(saved.getPassword()).isEqualTo("new-password");
+    assertThat(saved.getBio()).isEqualTo("new bio");
+    assertThat(saved.getImage()).isEqualTo("new image");
+  }
+
+  @Test
+  public void should_ignore_empty_fields_on_update() {
+    User targetUser = new User("old@test.com", "old", "old-password", "old bio", "old image");
+    UpdateUserParam param = UpdateUserParam.builder().bio("only the bio changes").build();
+
+    userService.updateUser(new UpdateUserCommand(targetUser, param));
+
+    assertThat(targetUser.getBio()).isEqualTo("only the bio changes");
+    assertThat(targetUser.getEmail()).isEqualTo("old@test.com");
+    assertThat(targetUser.getUsername()).isEqualTo("old");
+    assertThat(targetUser.getPassword()).isEqualTo("old-password");
+    assertThat(targetUser.getImage()).isEqualTo("old image");
+    verify(userRepository).save(targetUser);
+  }
+
+  @Test
+  public void should_keep_every_field_when_the_update_param_is_completely_empty() {
+    User targetUser = new User("old@test.com", "old", "old-password", "old bio", "old image");
+
+    userService.updateUser(new UpdateUserCommand(targetUser, UpdateUserParam.builder().build()));
+
+    assertThat(targetUser.getEmail()).isEqualTo("old@test.com");
+    assertThat(targetUser.getUsername()).isEqualTo("old");
+    assertThat(targetUser.getPassword()).isEqualTo("old-password");
+    assertThat(targetUser.getBio()).isEqualTo("old bio");
+    assertThat(targetUser.getImage()).isEqualTo("old image");
+    verify(userRepository).save(targetUser);
+  }
+
+  /**
+   * {@code io.spring.Util#isEmpty} only rejects null and "", so a blank value overwrites the
+   * existing one. Documented here as current behaviour rather than as desired behaviour.
+   */
+  @Test
+  public void should_apply_a_blank_username_because_only_empty_values_are_ignored() {
+    User targetUser = new User("old@test.com", "old", "old-password", "old bio", "old image");
+    UpdateUserParam param = UpdateUserParam.builder().username("   ").build();
+
+    userService.updateUser(new UpdateUserCommand(targetUser, param));
+
+    assertThat(targetUser.getUsername()).isEqualTo("   ");
+  }
+
+  /**
+   * The service is {@code @Validated}, so the {@code @Valid} parameters are only checked through
+   * the Spring proxy; a bare instance applies no validation. The constraints themselves are
+   * asserted directly against a validator below.
+   */
+  @Test
+  public void should_not_validate_register_param_when_service_is_not_proxied() {
+    User created = userService.createUser(new RegisterParam("not-an-email", "", ""));
+
+    assertThat(created.getEmail()).isEqualTo("not-an-email");
+    verify(userRepository).save(created);
+  }
+
+  @Test
+  public void should_reject_register_param_with_blank_fields() {
+    Set<ConstraintViolation<RegisterParam>> violations =
+        validator().validate(new RegisterParam("", "", ""));
+
+    assertThat(violations)
+        .extracting(violation -> violation.getPropertyPath().toString())
+        .containsExactlyInAnyOrder("email", "username", "password");
+    assertThat(violations)
+        .allSatisfy(violation -> assertThat(violation.getMessage()).isEqualTo("can't be empty"));
+  }
+
+  @Test
+  public void should_reject_register_param_with_an_invalid_email() {
+    Set<ConstraintViolation<RegisterParam>> violations =
+        validator().validate(new RegisterParam("not-an-email", "john", "123"));
+
+    assertThat(violations).hasSize(1);
+    ConstraintViolation<RegisterParam> violation = violations.iterator().next();
+    assertThat(violation.getPropertyPath().toString()).isEqualTo("email");
+    assertThat(violation.getMessage()).isEqualTo("should be an email");
+  }
+
+  @Test
+  public void should_reject_register_param_with_an_existing_email_or_username() {
+    User existing = new User("john@test.com", "john", "123", "", "");
+    when(userRepository.findByEmail("john@test.com")).thenReturn(Optional.of(existing));
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(existing));
+
+    Set<ConstraintViolation<RegisterParam>> violations =
+        validator().validate(new RegisterParam("john@test.com", "john", "123"));
+
+    assertThat(violations)
+        .extracting(violation -> violation.getPropertyPath().toString())
+        .containsExactlyInAnyOrder("email", "username");
+  }
+
+  @Test
+  public void should_accept_a_valid_register_param() {
+    assertThat(validator().validate(new RegisterParam("fresh@test.com", "fresh", "123"))).isEmpty();
+  }
+
+  @Test
+  public void should_reject_update_command_taking_an_email_owned_by_another_user() {
+    User targetUser = new User("old@test.com", "old", "123", "", "");
+    when(userRepository.findByEmail("taken@test.com"))
+        .thenReturn(Optional.of(new User("taken@test.com", "other", "123", "", "")));
+
+    Set<ConstraintViolation<UpdateUserCommand>> violations =
+        validator()
+            .validate(
+                new UpdateUserCommand(
+                    targetUser, UpdateUserParam.builder().email("taken@test.com").build()));
+
+    assertThat(violations).hasSize(1);
+    ConstraintViolation<UpdateUserCommand> violation = violations.iterator().next();
+    assertThat(violation.getPropertyPath().toString()).isEqualTo("email");
+    assertThat(violation.getMessage()).isEqualTo("email already exist");
+  }
+
+  @Test
+  public void should_accept_update_command_keeping_the_current_user_own_email_and_username() {
+    User targetUser = new User("old@test.com", "old", "123", "", "");
+    when(userRepository.findByEmail("old@test.com")).thenReturn(Optional.of(targetUser));
+    when(userRepository.findByUsername("old")).thenReturn(Optional.of(targetUser));
+
+    Set<ConstraintViolation<UpdateUserCommand>> violations =
+        validator()
+            .validate(
+                new UpdateUserCommand(
+                    targetUser,
+                    UpdateUserParam.builder().email("old@test.com").username("old").build()));
+
+    assertThat(violations).isEmpty();
+  }
+
+  /**
+   * Builds a validator whose constraint validators are created by Spring, so that the duplicated
+   * email/username constraints get the mocked {@link UserRepository} injected.
+   */
+  private Validator validator() {
+    validationContext = new AnnotationConfigApplicationContext();
+    validationContext.getBeanFactory().registerSingleton("userRepository", userRepository);
+    validationContext.refresh();
+    LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.setApplicationContext(validationContext);
+    validatorFactoryBean.afterPropertiesSet();
+    return validatorFactoryBean;
+  }
+}


### PR DESCRIPTION
## Summary

Adds 35 tests covering the write-side application services, which were the least-covered application packages (`io.spring.application.article` 20.5% instruction / 26.7% line, `io.spring.application.user` 52.2% / 75.8%, `io.spring.application` 64.4% / 76.4%). Test-only change; nothing under `src/main`, `build.gradle` or existing test files was touched.

New files:

| file | tests | class under test |
| --- | --- | --- |
| `src/test/java/io/spring/application/article/ArticleCommandServiceTest.java` | 15 | `ArticleCommandService` (+ `NewArticleParam` constraints) |
| `src/test/java/io/spring/application/user/UserServiceTest.java` | 14 | `UserService` (+ `RegisterParam` / `UpdateUserCommand` constraints) |
| `src/test/java/io/spring/application/UserQueryServiceTest.java` | 6 | `UserQueryService` (+ `UserReadService.findByUsername`) |

What is asserted (behaviour, not call counts):

- **`ArticleCommandService.createArticle`** — slug derived from the title (`"How to train your Dragon"` → `how-to-train-your-dragon`, `"Cats, Dogs & Other  Pets?"` → `cats-dogs-other-pets-`), `tagList` deduplication into distinct `Tag`s with distinct ids, empty tag list, `userId`/timestamps, and that the persisted instance is the returned one (`verify(articleRepository).save(captor.capture())` then asserting on the captured `Article`).
- **`ArticleCommandService.updateArticle`** — title-only / body-only / description-only / all-three; slug is regenerated only when the title is non-empty, and an all-empty `UpdateArticleParam` leaves the article untouched (but still calls `save`).
- **`UserService.createUser`** — password is hashed (`assertThat(created.getPassword()).isNotEqualTo("plain-password")` plus `passwordEncoder.matches(...)` with a real `BCryptPasswordEncoder`, not a mock), default image and empty bio applied, and the saved instance captured.
- **`UserService.updateUser`** — every field applied, empty fields ignored, fully-empty param is a no-op.
- **`UserQueryServiceTest`** — `DbTestBase`/`@MybatisTest` style matching `ArticleQueryServiceTest`/`ProfileQueryServiceTest`: `findById` returns the mapped `UserData`, reflects a subsequent save, and returns `Optional.empty()` for an unknown and for a `null` id.

### Bean validation

Both command services are `@Validated` with `@Valid` parameters, so validation only fires through the Spring proxy — a bare instance validates nothing. Each unit test class therefore asserts the constraints separately against a `LocalValidatorFactoryBean`, and one test in each class documents that the un-proxied object happily accepts invalid input:

```java
private Validator validator() {
  validationContext = new AnnotationConfigApplicationContext();
  validationContext.getBeanFactory().registerSingleton("userRepository", userRepository); // the mock
  validationContext.refresh();
  LocalValidatorFactoryBean v = new LocalValidatorFactoryBean();
  v.setApplicationContext(validationContext); // so @Autowired inside the ConstraintValidators is honoured
  v.afterPropertiesSet();
  return v;
}
```

`AnnotationConfigApplicationContext` (not `GenericApplicationContext`) is required: without the annotation-config post-processors, `DuplicatedArticleValidator` / `DuplicatedEmailValidator` / `UpdateUserValidator` are instantiated with their `@Autowired` fields still null and every validation throws. This covers `can't be empty`, `should be an email`, `article name exists`, `email already exist`, and the "user keeps their own email/username" pass case.

## Not covered / notes

- `UserQueryService` exposes only `findById`; there is no username lookup on it, so the by-username read path is asserted directly against the `UserReadService` mapper in the same test class.
- No `src/main` change was made. Smells noticed and deliberately left alone:
  - `io.spring.Util.isEmpty` only rejects `null` and `""`, so a whitespace-only value overwrites the stored one — `UserService.updateUser` with `username = "   "` sets the username to `"   "`. There is a test pinning this as *current* behaviour (`should_apply_a_blank_username_because_only_empty_values_are_ignored`), not as desired behaviour.
  - `Article.toSlug` leaves a trailing `-` for titles ending in punctuation (`"Cats, Dogs & Other  Pets?"` → `cats-dogs-other-pets-`) and does not strip other punctuation such as `!` or `:`.
  - `ArticleCommandService.updateArticle` calls `articleRepository.save` even when the update param is entirely empty, i.e. a guaranteed no-op write.
  - `UpdateArticleParam`/`UpdateUserParam` use `""` rather than `null` as "not provided", so a caller cannot clear a field.
- `spotlessApply` also reformats the pre-existing `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java`; that file is intentionally **not** part of this PR.
- Verified locally: `./gradlew test` passes fully (all suites, not just the new ones) and `./gradlew spotlessCheck` passes.


Link to Devin session: https://app.devin.ai/sessions/5638d55baeb9442b8b0efeb1afabb4dd
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/873?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->