### PR TITLE
test: dedicated tests for the JWT filter chain, security access rules and REST exception handling

### DIFF
--- a/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
@@ -1,0 +1,226 @@
+package io.spring.api.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.executable.ExecutableValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+public class CustomizeExceptionHandlerTest {
+
+  private CustomizeExceptionHandler handler;
+  private WebRequest webRequest;
+  private MockMvc mvc;
+
+  @BeforeEach
+  public void setUp() {
+    handler = new CustomizeExceptionHandler();
+    webRequest = new ServletWebRequest(new MockHttpServletRequest());
+    mvc =
+        MockMvcBuilders.standaloneSetup(new TestController())
+            .setControllerAdvice(new CustomizeExceptionHandler())
+            .build();
+  }
+
+  @Test
+  public void should_map_invalid_request_to_422_with_field_errors() {
+    Errors errors = new BeanPropertyBindingResult(new RegisterFixture(), "registerParam");
+    errors.rejectValue("email", "INVALID", "should be an email");
+    errors.rejectValue("username", "DUPLICATED", "is already taken");
+
+    ResponseEntity<Object> response =
+        handler.handleInvalidRequest(new InvalidRequestException(errors), webRequest);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+    ErrorResource body = (ErrorResource) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getFieldErrors())
+        .extracting(
+            FieldErrorResource::getResource,
+            FieldErrorResource::getField,
+            FieldErrorResource::getCode,
+            FieldErrorResource::getMessage)
+        .containsExactly(
+            tuple("registerParam", "email", "INVALID", "should be an email"),
+            tuple("registerParam", "username", "DUPLICATED", "is already taken"));
+  }
+
+  @Test
+  public void should_keep_the_errors_available_on_the_invalid_request_exception() {
+    Errors errors = new BeanPropertyBindingResult(new RegisterFixture(), "registerParam");
+    errors.rejectValue("email", "INVALID", "should be an email");
+
+    InvalidRequestException exception = new InvalidRequestException(errors);
+
+    assertThat(exception.getErrors()).isSameAs(errors);
+    assertThat(exception.getMessage()).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void should_map_invalid_authentication_to_422_with_a_message() {
+    ResponseEntity<Object> response =
+        handler.handleInvalidAuthentication(new InvalidAuthenticationException(), webRequest);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(response.getBody()).isInstanceOf(Map.class);
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertThat(body).containsExactly(entry("message", "invalid email or password"));
+  }
+
+  @Test
+  public void should_map_constraint_violations_of_a_bean_to_field_errors() {
+    Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    Set<ConstraintViolation<RegisterFixture>> violations =
+        validator.validate(new RegisterFixture());
+
+    ErrorResource errorResource =
+        handler.handleConstraintViolation(new ConstraintViolationException(violations), webRequest);
+
+    assertThat(errorResource.getFieldErrors())
+        .extracting(FieldErrorResource::getField, FieldErrorResource::getCode)
+        .containsExactlyInAnyOrder(tuple("email", "NotBlank"), tuple("username", "NotBlank"));
+    assertThat(errorResource.getFieldErrors())
+        .allSatisfy(
+            error -> assertThat(error.getResource()).isEqualTo(RegisterFixture.class.getName()));
+  }
+
+  @Test
+  public void should_strip_the_method_prefix_of_a_method_validation_path() throws Exception {
+    ExecutableValidator executableValidator =
+        Validation.buildDefaultValidatorFactory().getValidator().forExecutables();
+    TestController target = new TestController();
+    Method method = TestController.class.getMethod("validated", RegisterFixture.class);
+    Set<ConstraintViolation<TestController>> violations =
+        executableValidator.validateParameters(
+            target, method, new Object[] {new RegisterFixture()});
+
+    ErrorResource errorResource =
+        handler.handleConstraintViolation(new ConstraintViolationException(violations), webRequest);
+
+    assertThat(errorResource.getFieldErrors())
+        .extracting(FieldErrorResource::getField)
+        .containsExactlyInAnyOrder("email", "username");
+  }
+
+  @Test
+  public void should_render_invalid_request_through_mvc_as_realworld_error_body() throws Exception {
+    mvc.perform(get("/invalid-request"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.errors.email[0]").value("should be an email"))
+        .andExpect(jsonPath("$.errors.username[0]").value("is already taken"));
+  }
+
+  @Test
+  public void should_render_bean_validation_failures_as_realworld_error_body() throws Exception {
+    mvc.perform(
+            post("/validated-body")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"\",\"username\":\"\"}"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.errors.email").isArray())
+        .andExpect(jsonPath("$.errors.username").isArray());
+  }
+
+  @Test
+  public void should_render_invalid_authentication_through_mvc() throws Exception {
+    mvc.perform(get("/invalid-authentication"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.message").value("invalid email or password"));
+  }
+
+  @Test
+  public void should_map_resource_not_found_to_404() throws Exception {
+    mvc.perform(get("/not-found")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void should_map_no_authorization_to_403() throws Exception {
+    mvc.perform(get("/forbidden")).andExpect(status().isForbidden());
+  }
+
+  static class RegisterFixture {
+    @NotBlank
+    @Email(message = "should be an email")
+    private String email = "";
+
+    @NotBlank private String username = "";
+
+    public String getEmail() {
+      return email;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+  }
+
+  @RestController
+  static class TestController {
+
+    @GetMapping("/invalid-request")
+    public String invalidRequest() {
+      Errors errors = new BeanPropertyBindingResult(new RegisterFixture(), "registerParam");
+      errors.rejectValue("email", "INVALID", "should be an email");
+      errors.rejectValue("username", "DUPLICATED", "is already taken");
+      throw new InvalidRequestException(errors);
+    }
+
+    @GetMapping("/invalid-authentication")
+    public String invalidAuthentication() {
+      throw new InvalidAuthenticationException();
+    }
+
+    @GetMapping("/not-found")
+    public String notFound() {
+      throw new ResourceNotFoundException();
+    }
+
+    @GetMapping("/forbidden")
+    public String forbidden() {
+      throw new NoAuthorizationException();
+    }
+
+    @PostMapping("/validated-body")
+    public String validatedBody(@Valid @RequestBody RegisterFixture fixture) {
+      return "ok";
+    }
+
+    public String validated(@Valid RegisterFixture fixture) {
+      return "ok";
+    }
+  }
+}

--- a/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
@@ -136,6 +136,25 @@ public class CustomizeExceptionHandlerTest {
   }
 
   @Test
+  public void should_lose_the_field_name_of_a_constraint_on_a_method_parameter() throws Exception {
+    // A violation on the parameter itself has a two segment path ("directlyValidated.arg0"), which
+    // getParam strips down to an empty field name.
+    ExecutableValidator executableValidator =
+        Validation.buildDefaultValidatorFactory().getValidator().forExecutables();
+    TestController target = new TestController();
+    Method method = TestController.class.getMethod("directlyValidated", String.class);
+    Set<ConstraintViolation<TestController>> violations =
+        executableValidator.validateParameters(target, method, new Object[] {""});
+
+    ErrorResource errorResource =
+        handler.handleConstraintViolation(new ConstraintViolationException(violations), webRequest);
+
+    assertThat(errorResource.getFieldErrors())
+        .extracting(FieldErrorResource::getField, FieldErrorResource::getCode)
+        .containsExactly(tuple("", "NotBlank"));
+  }
+
+  @Test
   public void should_render_invalid_request_through_mvc_as_realworld_error_body() throws Exception {
     mvc.perform(get("/invalid-request"))
         .andExpect(status().isUnprocessableEntity())
@@ -220,6 +239,10 @@ public class CustomizeExceptionHandlerTest {
     }
 
     public String validated(@Valid RegisterFixture fixture) {
+      return "ok";
+    }
+
+    public String directlyValidated(@NotBlank String value) {
       return "ok";
     }
   }

--- a/src/test/java/io/spring/api/exception/ErrorResourceSerializerTest.java
+++ b/src/test/java/io/spring/api/exception/ErrorResourceSerializerTest.java
@@ -1,0 +1,85 @@
+package io.spring.api.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.spring.JacksonCustomizations;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ErrorResourceSerializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  public void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JacksonCustomizations.RealWorldModules());
+  }
+
+  @Test
+  public void should_serialize_a_single_field_error() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Collections.singletonList(
+                new FieldErrorResource("registerParam", "email", "NotBlank", "can't be empty")));
+
+    assertThat(objectMapper.writeValueAsString(errorResource))
+        .isEqualTo("{\"errors\":{\"email\":[\"can't be empty\"]}}");
+  }
+
+  @Test
+  public void should_group_multiple_messages_of_the_same_field() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Arrays.asList(
+                new FieldErrorResource("registerParam", "email", "NotBlank", "can't be empty"),
+                new FieldErrorResource("registerParam", "email", "Email", "should be an email")));
+
+    assertThat(objectMapper.writeValueAsString(errorResource))
+        .isEqualTo("{\"errors\":{\"email\":[\"can't be empty\",\"should be an email\"]}}");
+  }
+
+  @Test
+  public void should_serialize_errors_of_several_fields() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Arrays.asList(
+                new FieldErrorResource("registerParam", "email", "Email", "should be an email"),
+                new FieldErrorResource("registerParam", "username", "NotBlank", "can't be empty"),
+                new FieldErrorResource("registerParam", "username", "Duplicated", "is taken")));
+
+    JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(errorResource));
+
+    assertThat(json.fieldNames()).toIterable().containsExactly("errors");
+    JsonNode errors = json.get("errors");
+    assertThat(errors.fieldNames()).toIterable().containsExactlyInAnyOrder("email", "username");
+    assertThat(errors.get("email").isArray()).isTrue();
+    assertThat(errors.get("email").get(0).asText()).isEqualTo("should be an email");
+    assertThat(errors.get("username").size()).isEqualTo(2);
+    assertThat(errors.get("username").get(0).asText()).isEqualTo("can't be empty");
+    assertThat(errors.get("username").get(1).asText()).isEqualTo("is taken");
+  }
+
+  @Test
+  public void should_serialize_an_empty_error_list_to_an_empty_errors_object() throws Exception {
+    assertThat(objectMapper.writeValueAsString(new ErrorResource(Collections.emptyList())))
+        .isEqualTo("{\"errors\":{}}");
+  }
+
+  @Test
+  public void should_keep_the_field_error_details_available_on_the_resource() {
+    FieldErrorResource fieldError =
+        new FieldErrorResource("registerParam", "email", "NotBlank", "can't be empty");
+    ErrorResource errorResource = new ErrorResource(Collections.singletonList(fieldError));
+
+    assertThat(errorResource.getFieldErrors()).containsExactly(fieldError);
+    assertThat(fieldError.getResource()).isEqualTo("registerParam");
+    assertThat(fieldError.getField()).isEqualTo("email");
+    assertThat(fieldError.getCode()).isEqualTo("NotBlank");
+    assertThat(fieldError.getMessage()).isEqualTo("can't be empty");
+  }
+}

--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -1,0 +1,168 @@
+package io.spring.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Collections;
+import java.util.Optional;
+import javax.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class JwtTokenFilterTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private JwtService jwtService;
+  @Mock private FilterChain filterChain;
+
+  private AutoCloseable mocks;
+  private JwtTokenFilter filter;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    filter = new JwtTokenFilter();
+    ReflectionTestUtils.setField(filter, "userRepository", userRepository);
+    ReflectionTestUtils.setField(filter, "jwtService", jwtService);
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    SecurityContextHolder.clearContext();
+    mocks.close();
+  }
+
+  @Test
+  public void should_not_authenticate_when_no_authorization_header() throws Exception {
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    verifyNoInteractions(jwtService, userRepository);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  public void should_not_authenticate_when_header_has_no_token_part() throws Exception {
+    request.addHeader("Authorization", "Token");
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    verifyNoInteractions(jwtService, userRepository);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  public void should_not_authenticate_when_token_is_invalid() throws Exception {
+    request.addHeader("Authorization", "Token expired.jwt.value");
+    when(jwtService.getSubFromToken(eq("expired.jwt.value"))).thenReturn(Optional.empty());
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    verifyNoInteractions(userRepository);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  public void should_not_authenticate_when_user_of_token_is_gone() throws Exception {
+    request.addHeader("Authorization", "Token valid.jwt.value");
+    when(jwtService.getSubFromToken(eq("valid.jwt.value"))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.empty());
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  public void should_authenticate_current_user_with_valid_token() throws Exception {
+    request.addHeader("Authorization", "Token valid.jwt.value");
+    when(jwtService.getSubFromToken(eq("valid.jwt.value"))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.getPrincipal()).isSameAs(user);
+    assertThat(authentication.getCredentials()).isNull();
+    assertThat(authentication.getAuthorities()).isEmpty();
+    assertThat(authentication.isAuthenticated()).isTrue();
+    assertThat(authentication.getDetails()).isInstanceOf(WebAuthenticationDetails.class);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  public void should_keep_existing_authentication_untouched() throws Exception {
+    User anotherUser = new User("another@test.com", "another", "123", "", "");
+    UsernamePasswordAuthenticationToken existing =
+        new UsernamePasswordAuthenticationToken(anotherUser, null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(existing);
+
+    request.addHeader("Authorization", "Token valid.jwt.value");
+    when(jwtService.getSubFromToken(eq("valid.jwt.value"))).thenReturn(Optional.of(user.getId()));
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(existing);
+    verify(userRepository, never()).findById(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  public void should_accept_any_header_prefix_before_the_token() throws Exception {
+    // The filter only splits on whitespace, so the documented "Token " prefix is not actually
+    // enforced: a "Bearer " prefixed header authenticates just the same.
+    request.addHeader("Authorization", "Bearer valid.jwt.value");
+    when(jwtService.getSubFromToken(eq("valid.jwt.value"))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+    assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+        .isSameAs(user);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  public void should_always_continue_the_filter_chain() throws Exception {
+    filter.doFilterInternal(request, response, filterChain);
+
+    MockHttpServletRequest withToken = new MockHttpServletRequest();
+    withToken.addHeader("Authorization", "Token valid.jwt.value");
+    when(jwtService.getSubFromToken(eq("valid.jwt.value"))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+    filter.doFilterInternal(withToken, response, filterChain);
+
+    verify(filterChain, times(2)).doFilter(any(), eq(response));
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+}

--- a/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
+++ b/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
@@ -76,7 +76,7 @@ public class WebSecurityConfigTest {
   }
 
   @Test
-  public void should_permit_cors_preflight_on_protected_paths() throws Exception {
+  public void should_permit_options_requests_on_protected_paths() throws Exception {
     mvc.perform(options("/user")).andExpect(status().isOk());
   }
 

--- a/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
+++ b/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
@@ -1,0 +1,184 @@
+package io.spring.api.security;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Verifies the access rules declared by {@link WebSecurityConfig} against a throwaway controller
+ * that mirrors the routes of the real API, so the assertions are about the security configuration
+ * only and not about controller behaviour.
+ */
+@WebMvcTest(controllers = WebSecurityConfigTest.RoutesController.class)
+@Import({WebSecurityConfig.class, WebSecurityConfigTest.RouteConfiguration.class})
+public class WebSecurityConfigTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private JwtService jwtService;
+
+  private User user;
+  private String token;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    token = "valid.jwt.token";
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+  }
+
+  @Test
+  public void should_permit_user_registration_and_login() throws Exception {
+    mvc.perform(post("/users")).andExpect(status().isOk());
+    mvc.perform(post("/users/login")).andExpect(status().isOk());
+  }
+
+  @Test
+  public void should_permit_reading_articles_profiles_and_tags() throws Exception {
+    mvc.perform(get("/articles")).andExpect(status().isOk());
+    mvc.perform(get("/articles/some-slug")).andExpect(status().isOk());
+    mvc.perform(get("/articles/some-slug/comments")).andExpect(status().isOk());
+    mvc.perform(get("/profiles/johnjacob")).andExpect(status().isOk());
+    mvc.perform(get("/tags")).andExpect(status().isOk());
+  }
+
+  @Test
+  public void should_permit_graphql_endpoints() throws Exception {
+    mvc.perform(get("/graphiql")).andExpect(status().isOk());
+    mvc.perform(post("/graphql")).andExpect(status().isOk());
+  }
+
+  @Test
+  public void should_permit_cors_preflight_on_protected_paths() throws Exception {
+    mvc.perform(options("/user")).andExpect(status().isOk());
+  }
+
+  @Test
+  public void should_require_authentication_for_the_article_feed() throws Exception {
+    mvc.perform(get("/articles/feed")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  public void should_require_authentication_for_current_user_endpoints() throws Exception {
+    mvc.perform(get("/user")).andExpect(status().isUnauthorized());
+    mvc.perform(put("/user")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  public void should_require_authentication_for_writing_endpoints() throws Exception {
+    mvc.perform(post("/articles")).andExpect(status().isUnauthorized());
+    mvc.perform(put("/articles/some-slug")).andExpect(status().isUnauthorized());
+    mvc.perform(delete("/articles/some-slug")).andExpect(status().isUnauthorized());
+    mvc.perform(post("/articles/some-slug/comments")).andExpect(status().isUnauthorized());
+    mvc.perform(post("/articles/some-slug/favorite")).andExpect(status().isUnauthorized());
+    mvc.perform(post("/profiles/johnjacob/follow")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  public void should_reject_a_protected_request_carrying_an_unknown_token() throws Exception {
+    when(jwtService.getSubFromToken(eq("garbage"))).thenReturn(Optional.empty());
+
+    mvc.perform(get("/user").header("Authorization", "Token garbage"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  public void should_allow_a_protected_request_carrying_a_valid_token() throws Exception {
+    mvc.perform(get("/user").header("Authorization", "Token " + token)).andExpect(status().isOk());
+    mvc.perform(get("/articles/feed").header("Authorization", "Token " + token))
+        .andExpect(status().isOk());
+    mvc.perform(post("/articles").header("Authorization", "Token " + token))
+        .andExpect(status().isOk());
+  }
+
+  @TestConfiguration
+  static class RouteConfiguration {
+    @Bean
+    public RoutesController routesController() {
+      return new RoutesController();
+    }
+  }
+
+  @RestController
+  static class RoutesController {
+
+    @PostMapping("/users")
+    public String createUser() {
+      return "created";
+    }
+
+    @PostMapping("/users/login")
+    public String login() {
+      return "logged in";
+    }
+
+    @GetMapping({"/user", "/tags", "/graphiql"})
+    public String read() {
+      return "read";
+    }
+
+    @PutMapping("/user")
+    public String updateUser() {
+      return "updated";
+    }
+
+    @GetMapping({
+      "/articles",
+      "/articles/feed",
+      "/articles/{slug}",
+      "/articles/{slug}/comments",
+      "/profiles/{username}"
+    })
+    public String readArticles() {
+      return "read";
+    }
+
+    @PostMapping({
+      "/articles",
+      "/articles/{slug}/comments",
+      "/articles/{slug}/favorite",
+      "/profiles/{username}/follow",
+      "/graphql"
+    })
+    public String write() {
+      return "written";
+    }
+
+    @PutMapping("/articles/{slug}")
+    public String updateArticle() {
+      return "updated";
+    }
+
+    @DeleteMapping("/articles/{slug}")
+    public String deleteArticle() {
+      return "deleted";
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds 33 tests in 4 new test files for `io.spring.api.security` and `io.spring.api.exception`, which until now were only exercised incidentally by the `*ApiTest` classes (`InvalidRequestException`, `NoAuthorizationException` and the `ConstraintViolationException` handler had no coverage at all). No production code, existing test, or build file is touched.

| new file | class under test | tests |
| --- | --- | --- |
| `src/test/java/io/spring/api/security/JwtTokenFilterTest.java` | `JwtTokenFilter` | 8 |
| `src/test/java/io/spring/api/security/WebSecurityConfigTest.java` | `WebSecurityConfig` | 9 |
| `src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java` | `CustomizeExceptionHandler`, `InvalidRequestException` | 11 |
| `src/test/java/io/spring/api/exception/ErrorResourceSerializerTest.java` | `ErrorResourceSerializer`, `ErrorResource`, `FieldErrorResource` | 5 |

**`JwtTokenFilterTest`** — `doFilterInternal` called directly with `MockHttpServletRequest`/`MockHttpServletResponse` and a mock `FilterChain`; the two `@Autowired` collaborators are injected with `ReflectionTestUtils`. Covers: no header, header with no token part, `getSubFromToken` empty, user gone, happy path (principal is the `User`, no credentials, empty authorities, `WebAuthenticationDetails`), a pre-existing `Authentication` is not overwritten (and the repository is never hit), and the chain is continued in every case. `SecurityContextHolder.clearContext()` runs in `@AfterEach`.

**`WebSecurityConfigTest`** — `@WebMvcTest(controllers = RoutesController.class)` + `@Import(WebSecurityConfig.class)`, where `RoutesController` is a throwaway `@RestController` (supplied via a `@TestConfiguration` bean) that mirrors the real routes, so the assertions are about the access rules and not controller behaviour. Asserts the permitted set (`POST /users`, `POST /users/login`, `GET /articles/**`, `GET /profiles/**`, `GET /tags`, `/graphql`, `/graphiql`, `OPTIONS`), that `GET /articles/feed` is authenticated despite the broader `GET /articles/**` permit that follows it, that the write/current-user endpoints answer 401 anonymously, and that a real `Token <jwt>` header (mocked `JwtService` + `UserRepository`) turns those 401s into 200s.

**`CustomizeExceptionHandlerTest`** — handler methods invoked directly with a `ServletWebRequest`, plus a standalone `MockMvc` (`setControllerAdvice(new CustomizeExceptionHandler())`) over a test controller to check the wire format: `InvalidRequestException` → 422 + `{"errors":{"email":["should be an email"], ...}}`, `@Valid` body failure (`MethodArgumentNotValidException`) → 422 with the same shape, `InvalidAuthenticationException` → 422 `{"message":"invalid email or password"}`, `ResourceNotFoundException` → 404, `NoAuthorizationException` → 403. `handleConstraintViolation` is fed *real* violations from `Validator.validate(bean)` (single-segment path) and from `ExecutableValidator.validateParameters` for both a cascaded `@Valid` parameter (`validated.arg0.email` → `email`) and a constraint directly on a parameter (`directlyValidated.arg0` → `""`), pinning the `getParam` path-stripping behaviour including its degenerate case.

**`ErrorResourceSerializerTest`** — serializes through a real `ObjectMapper` registered with `JacksonCustomizations.RealWorldModules`, asserting exact JSON for the single-field and same-field-grouped cases (`{"errors":{"email":["can't be empty","should be an email"]}}`) and the empty case (`{"errors":{}}`); the multi-field case is asserted on the parsed tree because the serializer groups into a `HashMap`, so field order is not guaranteed.

## Production-code observations (deliberately not fixed)

- **The `Token ` prefix is not enforced.** `JwtTokenFilter.getTokenString` just does `header.split(" ")[1]`, so `Bearer <jwt>`, `Nonsense <jwt>` or any prefix authenticates identically, and a header like `Token a b` silently uses `a`. `should_accept_any_header_prefix_before_the_token` documents the current behaviour rather than the intended one; a fix would be to require the literal `Token ` prefix.
- **`InvalidAuthenticationException` maps to 422, not 401.** `handleInvalidAuthentication` returns `UNPROCESSABLE_ENTITY` with a bare `{"message": ...}` body — inconsistent with the `{"errors": {...}}` shape the RealWorld spec uses elsewhere. Tests assert the current 422.
- **`ErrorResourceSerializer` swallows `IOException`** inside the `forEach` (`e.printStackTrace()`), so a write failure mid-array would produce truncated JSON on an otherwise successful response.
- **`ErrorResource` field order is non-deterministic** because the serializer buffers into a `HashMap`; a `LinkedHashMap` would make responses stable (and let the multi-field test assert an exact string).
- **`CustomizeExceptionHandler.handleInvalidRequest` takes `RuntimeException` and downcasts** to `InvalidRequestException`; narrowing the parameter type would remove the unchecked cast.
- **`ConstraintViolationException` handling leaks internals and loses the field name**: `resource` is set to `violation.getRootBeanClass().getName()` (a fully-qualified application class name), and `getParam` returns `""` when the violation path has exactly two segments (a constraint directly on a method parameter, e.g. `method.arg0`) — covered by `should_lose_the_field_name_of_a_constraint_on_a_method_parameter`.

## Verification

- `./gradlew test` — 101 tests, 0 failures.
- `./gradlew spotlessApply` (with the JDK 17 `--add-exports` flags) run and `spotlessCheck` passes. Only the four new files are committed; the pre-existing formatting drift in `DefaultJwtServiceTest.java` that `spotlessApply` rewrites was intentionally left out of the commit.


Link to Devin session: https://app.devin.ai/sessions/0ca57ab89d9c4d44bbe502d4020ef01d
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/874?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->