### PR TITLE
test: cover the DGS GraphQL layer (io.spring.graphql)

### DIFF
--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,421 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.TestHelper;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, ArticleDatafetcher.class, ProfileDatafetcher.class})
+public class ArticleDatafetcherTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @Autowired private ArticleDatafetcher articleDatafetcher;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private User currentUser;
+  private User author;
+  private ArticleData articleData;
+
+  @BeforeEach
+  public void setUp() {
+    currentUser = new User("current@test.com", "current", "123", "", "");
+    author = new User("author@test.com", "author", "123", "author bio", "author image");
+    articleData = TestHelper.articleDataFixture("1", author);
+    authenticate(currentUser);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_return_feed_of_the_current_user_paging_forwards() {
+    ArticleData second = TestHelper.articleDataFixture("2", author);
+    when(articleQueryService.findUserFeedWithCursor(eq(currentUser), any()))
+        .thenReturn(new CursorPager<>(Arrays.asList(articleData, second), Direction.NEXT, true));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ feed(first: 2, after: \"1000\") { edges { cursor node { slug title body favorited"
+                + " favoritesCount createdAt } } pageInfo { hasNextPage hasPreviousPage startCursor"
+                + " endCursor } } }");
+
+    assertThat(result.<List<String>>read("data.feed.edges[*].node.slug"))
+        .containsExactly(articleData.getSlug(), second.getSlug());
+    assertThat(result.<String>read("data.feed.edges[0].cursor"))
+        .isEqualTo(articleData.getCursor().toString());
+    assertThat(result.<String>read("data.feed.edges[0].node.createdAt"))
+        .isEqualTo(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getCreatedAt()));
+    assertThat(result.<Boolean>read("data.feed.pageInfo.hasNextPage")).isTrue();
+    assertThat(result.<Boolean>read("data.feed.pageInfo.hasPreviousPage")).isFalse();
+    assertThat(result.<String>read("data.feed.pageInfo.startCursor"))
+        .isEqualTo(articleData.getCursor().toString());
+    assertThat(result.<String>read("data.feed.pageInfo.endCursor"))
+        .isEqualTo(second.getCursor().toString());
+
+    CursorPageParameter<DateTime> page = captureFeedPageParameter();
+    assertThat(page.getDirection()).isEqualTo(Direction.NEXT);
+    assertThat(page.getLimit()).isEqualTo(2);
+    assertThat(page.getCursor().getMillis()).isEqualTo(1000L);
+  }
+
+  @Test
+  public void should_return_feed_paging_backwards() {
+    when(articleQueryService.findUserFeedWithCursor(eq(currentUser), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.PREV, true));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ feed(last: 1, before: \"2000\") { edges { node { slug } } pageInfo { hasNextPage"
+                + " hasPreviousPage } } }");
+
+    assertThat(result.<Boolean>read("data.feed.pageInfo.hasPreviousPage")).isTrue();
+    assertThat(result.<Boolean>read("data.feed.pageInfo.hasNextPage")).isFalse();
+
+    CursorPageParameter<DateTime> page = captureFeedPageParameter();
+    assertThat(page.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(page.getLimit()).isEqualTo(1);
+    assertThat(page.getCursor().getMillis()).isEqualTo(2000L);
+  }
+
+  @Test
+  public void should_return_null_cursors_for_an_empty_feed() {
+    when(articleQueryService.findUserFeedWithCursor(eq(currentUser), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ feed(first: 10) { edges { cursor } pageInfo { startCursor endCursor hasNextPage } }"
+                + " }");
+
+    assertThat(result.<List<Object>>read("data.feed.edges")).isEmpty();
+    assertThat(result.<String>read("data.feed.pageInfo.startCursor")).isNull();
+    assertThat(result.<String>read("data.feed.pageInfo.endCursor")).isNull();
+    assertThat(result.<Boolean>read("data.feed.pageInfo.hasNextPage")).isFalse();
+  }
+
+  @Test
+  public void should_query_feed_without_current_user_when_anonymous() {
+    anonymous();
+    when(articleQueryService.findUserFeedWithCursor(isNull(), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.NEXT, false));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ feed(first: 1) { edges { node { slug } } } }");
+
+    assertThat(result.<String>read("data.feed.edges[0].node.slug"))
+        .isEqualTo(articleData.getSlug());
+  }
+
+  @Test
+  public void should_report_error_when_feed_has_neither_first_nor_last() {
+    ExecutionResult result = dgsQueryExecutor.execute("{ feed { edges { cursor } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("IllegalArgumentException");
+  }
+
+  @Test
+  public void should_return_articles_filtered_by_tag_author_and_favorited_by() {
+    when(articleQueryService.findRecentArticlesWithCursor(
+            eq("java"), eq("author"), eq("current"), any(), eq(currentUser)))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.NEXT, false));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ articles(first: 1, withTag: \"java\", authoredBy: \"author\", favoritedBy:"
+                + " \"current\") { edges { node { slug title } } pageInfo { hasNextPage } } }");
+
+    assertThat(result.<String>read("data.articles.edges[0].node.slug"))
+        .isEqualTo(articleData.getSlug());
+    assertThat(result.<String>read("data.articles.edges[0].node.title"))
+        .isEqualTo(articleData.getTitle());
+    assertThat(result.<Boolean>read("data.articles.pageInfo.hasNextPage")).isFalse();
+  }
+
+  @Test
+  public void should_return_articles_paging_backwards() {
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), isNull(), any(), eq(currentUser)))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.PREV, true));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ articles(last: 5, before: \"3000\") { edges { node { slug } } pageInfo {"
+                + " hasPreviousPage } } }");
+
+    assertThat(result.<Boolean>read("data.articles.pageInfo.hasPreviousPage")).isTrue();
+
+    CursorPageParameter<DateTime> page = captureRecentArticlesPageParameter();
+    assertThat(page.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(page.getLimit()).isEqualTo(5);
+    assertThat(page.getCursor().getMillis()).isEqualTo(3000L);
+  }
+
+  @Test
+  public void should_report_error_when_articles_has_neither_first_nor_last() {
+    ExecutionResult result = dgsQueryExecutor.execute("{ articles { edges { cursor } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("IllegalArgumentException");
+  }
+
+  @Test
+  public void should_find_article_by_slug() {
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(currentUser)))
+        .thenReturn(Optional.of(articleData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ article(slug: \"%s\") { slug title description body favorited favoritesCount"
+                    + " tagList createdAt updatedAt } }",
+                articleData.getSlug()));
+
+    assertThat(result.<String>read("data.article.title")).isEqualTo(articleData.getTitle());
+    assertThat(result.<String>read("data.article.description"))
+        .isEqualTo(articleData.getDescription());
+    assertThat(result.<String>read("data.article.body")).isEqualTo(articleData.getBody());
+    assertThat(result.<Boolean>read("data.article.favorited")).isFalse();
+    assertThat(result.<Integer>read("data.article.favoritesCount")).isZero();
+    assertThat(result.<String>read("data.article.updatedAt"))
+        .isEqualTo(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getUpdatedAt()));
+  }
+
+  @Test
+  public void should_report_error_when_article_is_not_found() {
+    when(articleQueryService.findBySlug(eq("missing"), any())).thenReturn(Optional.empty());
+
+    ExecutionResult result = dgsQueryExecutor.execute("{ article(slug: \"missing\") { slug } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  public void should_return_the_feed_of_a_profile() {
+    mockProfile();
+    when(userRepository.findByUsername(eq(author.getUsername()))).thenReturn(Optional.of(author));
+    when(articleQueryService.findUserFeedWithCursor(eq(author), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.NEXT, false));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ profile(username: \"%s\") { profile { username feed(first: 1) { edges { cursor"
+                    + " node { slug } } } } } }",
+                author.getUsername()));
+
+    assertThat(result.<String>read("data.profile.profile.username"))
+        .isEqualTo(author.getUsername());
+    assertThat(result.<String>read("data.profile.profile.feed.edges[0].node.slug"))
+        .isEqualTo(articleData.getSlug());
+  }
+
+  @Test
+  public void should_report_error_when_the_profile_of_a_feed_has_no_user() {
+    mockProfile();
+    when(userRepository.findByUsername(eq(author.getUsername()))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "{ profile(username: \"%s\") { profile { feed(first: 1) { edges { cursor } } } } }",
+                author.getUsername()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  public void should_return_the_articles_authored_by_a_profile() {
+    mockProfile();
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), eq(author.getUsername()), isNull(), any(), eq(currentUser)))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.NEXT, true));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ profile(username: \"%s\") { profile { articles(first: 1) { edges { node { slug"
+                    + " } } pageInfo { hasNextPage } } } } }",
+                author.getUsername()));
+
+    assertThat(result.<String>read("data.profile.profile.articles.edges[0].node.slug"))
+        .isEqualTo(articleData.getSlug());
+    assertThat(result.<Boolean>read("data.profile.profile.articles.pageInfo.hasNextPage")).isTrue();
+  }
+
+  @Test
+  public void should_return_the_articles_favorited_by_a_profile_paging_backwards() {
+    mockProfile();
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), eq(author.getUsername()), any(), eq(currentUser)))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.PREV, true));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ profile(username: \"%s\") { profile { favorites(last: 3, before: \"4000\") {"
+                    + " edges { node { slug } } pageInfo { hasPreviousPage } } } } }",
+                author.getUsername()));
+
+    assertThat(result.<String>read("data.profile.profile.favorites.edges[0].node.slug"))
+        .isEqualTo(articleData.getSlug());
+    assertThat(result.<Boolean>read("data.profile.profile.favorites.pageInfo.hasPreviousPage"))
+        .isTrue();
+
+    CursorPageParameter<DateTime> page = captureRecentArticlesPageParameter();
+    assertThat(page.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(page.getLimit()).isEqualTo(3);
+    assertThat(page.getCursor().getMillis()).isEqualTo(4000L);
+  }
+
+  @Test
+  public void should_report_error_when_profile_articles_have_neither_first_nor_last() {
+    mockProfile();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "{ profile(username: \"%s\") { profile { articles { edges { cursor } } } } }",
+                author.getUsername()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("IllegalArgumentException");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void should_resolve_the_article_of_a_comment_from_its_local_context() {
+    when(articleQueryService.findById(eq(articleData.getId()), eq(currentUser)))
+        .thenReturn(Optional.of(articleData));
+
+    DataFetcherResult<io.spring.graphql.types.Article> result =
+        articleDatafetcher.getCommentArticle(commentEnvironment());
+
+    assertThat(result.getData().getSlug()).isEqualTo(articleData.getSlug());
+    assertThat(result.getData().getTitle()).isEqualTo(articleData.getTitle());
+    Map<String, Object> localContext = (Map<String, Object>) result.getLocalContext();
+    assertThat(localContext).containsEntry(articleData.getSlug(), articleData);
+  }
+
+  @Test
+  public void should_fail_to_resolve_the_article_of_a_comment_when_it_is_gone() {
+    when(articleQueryService.findById(eq(articleData.getId()), eq(currentUser)))
+        .thenReturn(Optional.empty());
+
+    DataFetchingEnvironment environment = commentEnvironment();
+
+    assertThatThrownBy(() -> articleDatafetcher.getCommentArticle(environment))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  private DataFetchingEnvironment commentEnvironment() {
+    DateTime now = new DateTime();
+    CommentData commentData =
+        new CommentData("comment-1", "a comment", articleData.getId(), now, now, null);
+    DataFetchingEnvironment environment = mock(DataFetchingEnvironment.class);
+    when(environment.<CommentData>getLocalContext()).thenReturn(commentData);
+    return environment;
+  }
+
+  private void mockProfile() {
+    when(profileQueryService.findByUsername(eq(author.getUsername()), eq(currentUser)))
+        .thenReturn(
+            Optional.of(
+                new ProfileData(
+                    author.getId(),
+                    author.getUsername(),
+                    author.getBio(),
+                    author.getImage(),
+                    true)));
+  }
+
+  @SuppressWarnings("unchecked")
+  private CursorPageParameter<DateTime> captureFeedPageParameter() {
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(articleQueryService).findUserFeedWithCursor(any(), captor.capture());
+    return captor.getValue();
+  }
+
+  @SuppressWarnings("unchecked")
+  private CursorPageParameter<DateTime> captureRecentArticlesPageParameter() {
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(articleQueryService)
+        .findRecentArticlesWithCursor(any(), any(), any(), captor.capture(), any());
+    return captor.getValue();
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  private void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,313 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.article.UpdateArticleParam;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, ArticleMutation.class, ArticleDatafetcher.class})
+public class ArticleMutationTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ArticleCommandService articleCommandService;
+
+  @MockBean private ArticleFavoriteRepository articleFavoriteRepository;
+
+  @MockBean private ArticleRepository articleRepository;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  private User author;
+  private Article article;
+  private ArticleData articleData;
+
+  @BeforeEach
+  public void setUp() {
+    author = new User("author@test.com", "author", "123", "bio", "image");
+    article = new Article("Test Article", "desc", "body", Arrays.asList("java"), author.getId());
+    articleData = TestHelper.getArticleDataFromArticleAndUser(article, author);
+    authenticate(author);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_create_an_article() {
+    when(articleCommandService.createArticle(any(), eq(author))).thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), eq(author)))
+        .thenReturn(Optional.of(articleData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { createArticle(input: {title: \"Test Article\", description: \"desc\", body:"
+                + " \"body\", tagList: [\"java\"]}) { article { slug title description body } } }");
+
+    assertThat(result.<String>read("data.createArticle.article.slug")).isEqualTo(article.getSlug());
+    assertThat(result.<String>read("data.createArticle.article.title"))
+        .isEqualTo(article.getTitle());
+
+    ArgumentCaptor<NewArticleParam> captor = ArgumentCaptor.forClass(NewArticleParam.class);
+    verify(articleCommandService).createArticle(captor.capture(), eq(author));
+    assertThat(captor.getValue().getTitle()).isEqualTo("Test Article");
+    assertThat(captor.getValue().getDescription()).isEqualTo("desc");
+    assertThat(captor.getValue().getBody()).isEqualTo("body");
+    assertThat(captor.getValue().getTagList()).containsExactly("java");
+  }
+
+  @Test
+  public void should_default_the_tag_list_to_an_empty_list() {
+    when(articleCommandService.createArticle(any(), eq(author))).thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), eq(author)))
+        .thenReturn(Optional.of(articleData));
+
+    dgsQueryExecutor.executeAndGetDocumentContext(
+        "mutation { createArticle(input: {title: \"Test Article\", description: \"desc\", body:"
+            + " \"body\"}) { article { slug } } }");
+
+    ArgumentCaptor<NewArticleParam> captor = ArgumentCaptor.forClass(NewArticleParam.class);
+    verify(articleCommandService).createArticle(captor.capture(), eq(author));
+    assertThat(captor.getValue().getTagList()).isEmpty();
+  }
+
+  @Test
+  public void should_reject_article_creation_without_a_current_user() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { createArticle(input: {title: \"t\", description: \"d\", body: \"b\"}) {"
+                + " article { slug } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(articleCommandService, never()).createArticle(any(), any());
+  }
+
+  @Test
+  public void should_update_an_article() {
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any())).thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), eq(author)))
+        .thenReturn(Optional.of(articleData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { updateArticle(slug: \"%s\", changes: {title: \"new title\", body: \"new"
+                    + " body\", description: \"new desc\"}) { article { slug } } }",
+                article.getSlug()));
+
+    assertThat(result.<String>read("data.updateArticle.article.slug")).isEqualTo(article.getSlug());
+
+    ArgumentCaptor<UpdateArticleParam> captor = ArgumentCaptor.forClass(UpdateArticleParam.class);
+    verify(articleCommandService).updateArticle(eq(article), captor.capture());
+    assertThat(captor.getValue().getTitle()).isEqualTo("new title");
+    assertThat(captor.getValue().getBody()).isEqualTo("new body");
+    assertThat(captor.getValue().getDescription()).isEqualTo("new desc");
+  }
+
+  @Test
+  public void should_reject_updating_an_article_of_another_user() {
+    User other = new User("other@test.com", "other", "123", "", "");
+    authenticate(other);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "mutation { updateArticle(slug: \"%s\", changes: {title: \"new title\"}) { article {"
+                    + " slug } } }",
+                article.getSlug()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("NoAuthorizationException");
+    verify(articleCommandService, never()).updateArticle(any(), any());
+  }
+
+  @Test
+  public void should_report_error_when_updating_an_unknown_article() {
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { updateArticle(slug: \"missing\", changes: {title: \"t\"}) { article { slug }"
+                + " } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  public void should_favorite_an_article() {
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleQueryService.findById(eq(article.getId()), eq(author)))
+        .thenReturn(Optional.of(articleData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { favoriteArticle(slug: \"%s\") { article { slug } } }",
+                article.getSlug()));
+
+    assertThat(result.<String>read("data.favoriteArticle.article.slug"))
+        .isEqualTo(article.getSlug());
+    verify(articleFavoriteRepository)
+        .save(eq(new ArticleFavorite(article.getId(), author.getId())));
+  }
+
+  @Test
+  public void should_report_error_when_favoriting_an_unknown_article() {
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { favoriteArticle(slug: \"missing\") { article { slug } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(articleFavoriteRepository, never()).save(any());
+  }
+
+  @Test
+  public void should_unfavorite_an_article() {
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), author.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(author.getId())))
+        .thenReturn(Optional.of(favorite));
+    when(articleQueryService.findById(eq(article.getId()), eq(author)))
+        .thenReturn(Optional.of(articleData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { unfavoriteArticle(slug: \"%s\") { article { slug } } }",
+                article.getSlug()));
+
+    assertThat(result.<String>read("data.unfavoriteArticle.article.slug"))
+        .isEqualTo(article.getSlug());
+    verify(articleFavoriteRepository).remove(eq(favorite));
+  }
+
+  @Test
+  public void should_ignore_unfavorite_when_there_is_no_favorite() {
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(author.getId())))
+        .thenReturn(Optional.empty());
+    when(articleQueryService.findById(eq(article.getId()), eq(author)))
+        .thenReturn(Optional.of(articleData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { unfavoriteArticle(slug: \"%s\") { article { slug } } }",
+                article.getSlug()));
+
+    assertThat(result.<String>read("data.unfavoriteArticle.article.slug"))
+        .isEqualTo(article.getSlug());
+    verify(articleFavoriteRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_delete_an_article() {
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { deleteArticle(slug: \"%s\") { success } }", article.getSlug()));
+
+    assertThat(result.<Boolean>read("data.deleteArticle.success")).isTrue();
+    verify(articleRepository).remove(eq(article));
+  }
+
+  @Test
+  public void should_reject_deleting_an_article_of_another_user() {
+    authenticate(new User("other@test.com", "other", "123", "", ""));
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "mutation { deleteArticle(slug: \"%s\") { success } }", article.getSlug()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("NoAuthorizationException");
+    verify(articleRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_reject_deleting_an_article_without_a_current_user() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute("mutation { deleteArticle(slug: \"whatever\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(articleRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_report_error_when_deleting_an_unknown_article() {
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute("mutation { deleteArticle(slug: \"missing\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  private void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,208 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, CommentDatafetcher.class, ArticleDatafetcher.class})
+public class CommentDatafetcherTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private CommentQueryService commentQueryService;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  private User currentUser;
+  private User author;
+  private ArticleData articleData;
+  private CommentData commentData;
+
+  @BeforeEach
+  public void setUp() {
+    currentUser = new User("current@test.com", "current", "123", "", "");
+    author = new User("author@test.com", "author", "123", "author bio", "author image");
+    articleData = TestHelper.articleDataFixture("1", author);
+    commentData = commentDataFixture("comment-1", "first comment");
+    authenticate(currentUser);
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), any()))
+        .thenReturn(Optional.of(articleData));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_return_article_comments_paging_forwards() {
+    CommentData second = commentDataFixture("comment-2", "second comment");
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq(articleData.getId()), eq(currentUser), any()))
+        .thenReturn(new CursorPager<>(Arrays.asList(commentData, second), Direction.NEXT, true));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(commentsQuery("first: 2, after: \"1000\""));
+
+    assertThat(result.<List<String>>read("data.article.comments.edges[*].node.id"))
+        .containsExactly(commentData.getId(), second.getId());
+    assertThat(result.<String>read("data.article.comments.edges[0].node.body"))
+        .isEqualTo(commentData.getBody());
+    assertThat(result.<String>read("data.article.comments.edges[0].cursor"))
+        .isEqualTo(commentData.getCursor().toString());
+    assertThat(result.<String>read("data.article.comments.edges[0].node.createdAt"))
+        .isEqualTo(ISODateTimeFormat.dateTime().withZoneUTC().print(commentData.getCreatedAt()));
+    // the datafetcher maps updatedAt from createdAt, so it never reflects the real updatedAt
+    assertThat(result.<String>read("data.article.comments.edges[0].node.updatedAt"))
+        .isEqualTo(ISODateTimeFormat.dateTime().withZoneUTC().print(commentData.getCreatedAt()));
+    assertThat(result.<Boolean>read("data.article.comments.pageInfo.hasNextPage")).isTrue();
+    assertThat(result.<Boolean>read("data.article.comments.pageInfo.hasPreviousPage")).isFalse();
+    assertThat(result.<String>read("data.article.comments.pageInfo.startCursor"))
+        .isEqualTo(commentData.getCursor().toString());
+    assertThat(result.<String>read("data.article.comments.pageInfo.endCursor"))
+        .isEqualTo(second.getCursor().toString());
+
+    CursorPageParameter<DateTime> page = capturePageParameter();
+    assertThat(page.getDirection()).isEqualTo(Direction.NEXT);
+    assertThat(page.getLimit()).isEqualTo(2);
+    assertThat(page.getCursor().getMillis()).isEqualTo(1000L);
+  }
+
+  @Test
+  public void should_return_article_comments_paging_backwards() {
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq(articleData.getId()), eq(currentUser), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(commentData), Direction.PREV, true));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(commentsQuery("last: 1, before: \"2000\""));
+
+    assertThat(result.<Boolean>read("data.article.comments.pageInfo.hasPreviousPage")).isTrue();
+    assertThat(result.<Boolean>read("data.article.comments.pageInfo.hasNextPage")).isFalse();
+
+    CursorPageParameter<DateTime> page = capturePageParameter();
+    assertThat(page.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(page.getLimit()).isEqualTo(1);
+    assertThat(page.getCursor().getMillis()).isEqualTo(2000L);
+  }
+
+  @Test
+  public void should_return_empty_comments_connection() {
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq(articleData.getId()), eq(currentUser), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(commentsQuery("first: 10"));
+
+    assertThat(result.<List<Object>>read("data.article.comments.edges")).isEmpty();
+    assertThat(result.<String>read("data.article.comments.pageInfo.startCursor")).isNull();
+    assertThat(result.<String>read("data.article.comments.pageInfo.endCursor")).isNull();
+  }
+
+  @Test
+  public void should_load_comments_without_current_user_when_anonymous() {
+    anonymous();
+    when(commentQueryService.findByArticleIdWithCursor(eq(articleData.getId()), isNull(), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(commentData), Direction.NEXT, false));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(commentsQuery("first: 1"));
+
+    assertThat(result.<String>read("data.article.comments.edges[0].node.id"))
+        .isEqualTo(commentData.getId());
+  }
+
+  @Test
+  public void should_report_error_when_comments_have_neither_first_nor_last() {
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "{ article(slug: \"%s\") { comments { edges { cursor } } } }",
+                articleData.getSlug()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("IllegalArgumentException");
+  }
+
+  private String commentsQuery(String pagingArguments) {
+    return String.format(
+        "{ article(slug: \"%s\") { slug comments(%s) { edges { cursor node { id body createdAt"
+            + " updatedAt } } pageInfo { hasNextPage hasPreviousPage startCursor endCursor } } } }",
+        articleData.getSlug(), pagingArguments);
+  }
+
+  @SuppressWarnings("unchecked")
+  private CursorPageParameter<DateTime> capturePageParameter() {
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(commentQueryService).findByArticleIdWithCursor(any(), any(), captor.capture());
+    return captor.getValue();
+  }
+
+  private CommentData commentDataFixture(String id, String body) {
+    DateTime createdAt = new DateTime();
+    return new CommentData(
+        id,
+        body,
+        articleData.getId(),
+        createdAt,
+        createdAt.plusDays(1),
+        new ProfileData(
+            author.getId(), author.getUsername(), author.getBio(), author.getImage(), false));
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  private void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,290 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      CommentMutation.class,
+      CommentDatafetcher.class,
+      ArticleDatafetcher.class
+    })
+public class CommentMutationTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ArticleRepository articleRepository;
+
+  @MockBean private CommentRepository commentRepository;
+
+  @MockBean private CommentQueryService commentQueryService;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  private User author;
+  private User commenter;
+  private Article article;
+  private ArticleData articleData;
+  private CommentData commentData;
+
+  @BeforeEach
+  public void setUp() {
+    author = new User("author@test.com", "author", "123", "bio", "image");
+    commenter = new User("commenter@test.com", "commenter", "123", "", "");
+    article = new Article("Test Article", "desc", "body", Arrays.asList("java"), author.getId());
+    articleData = TestHelper.getArticleDataFromArticleAndUser(article, author);
+    DateTime now = new DateTime();
+    commentData =
+        new CommentData(
+            "comment-1",
+            "nice article",
+            article.getId(),
+            now,
+            now,
+            new ProfileData(commenter.getId(), commenter.getUsername(), "", "", false));
+    authenticate(commenter);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_add_a_comment_to_an_article() {
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(commenter))).thenReturn(Optional.of(commentData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { addComment(slug: \"%s\", body: \"nice article\") { comment { id body"
+                    + " createdAt } } }",
+                article.getSlug()));
+
+    assertThat(result.<String>read("data.addComment.comment.id")).isEqualTo(commentData.getId());
+    assertThat(result.<String>read("data.addComment.comment.body"))
+        .isEqualTo(commentData.getBody());
+    assertThat(result.<String>read("data.addComment.comment.createdAt"))
+        .isEqualTo(ISODateTimeFormat.dateTime().withZoneUTC().print(commentData.getCreatedAt()));
+
+    ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+    verify(commentRepository).save(captor.capture());
+    assertThat(captor.getValue().getBody()).isEqualTo("nice article");
+    assertThat(captor.getValue().getUserId()).isEqualTo(commenter.getId());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+  }
+
+  @Test
+  public void should_reject_adding_a_comment_without_a_current_user() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { addComment(slug: \"whatever\", body: \"hi\") { comment { id } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(commentRepository, never()).save(any());
+  }
+
+  @Test
+  public void should_report_error_when_commenting_on_an_unknown_article() {
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { addComment(slug: \"missing\", body: \"hi\") { comment { id } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(commentRepository, never()).save(any());
+  }
+
+  @Test
+  public void should_report_error_when_the_saved_comment_cannot_be_read_back() {
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(commenter))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "mutation { addComment(slug: \"%s\", body: \"hi\") { comment { id } } }",
+                article.getSlug()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(commentRepository).save(any());
+  }
+
+  @Test
+  public void should_delete_a_comment_written_by_the_current_user() {
+    Comment comment = new Comment("nice article", commenter.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { deleteComment(slug: \"%s\", id: \"%s\") { success } }",
+                article.getSlug(), comment.getId()));
+
+    assertThat(result.<Boolean>read("data.deleteComment.success")).isTrue();
+    verify(commentRepository).remove(eq(comment));
+  }
+
+  @Test
+  public void should_let_the_article_author_delete_any_comment() {
+    Comment comment = new Comment("nice article", commenter.getId(), article.getId());
+    authenticate(author);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { deleteComment(slug: \"%s\", id: \"%s\") { success } }",
+                article.getSlug(), comment.getId()));
+
+    assertThat(result.<Boolean>read("data.deleteComment.success")).isTrue();
+    verify(commentRepository).remove(eq(comment));
+  }
+
+  @Test
+  public void should_reject_deleting_a_comment_of_somebody_else() {
+    Comment comment = new Comment("nice article", commenter.getId(), article.getId());
+    authenticate(new User("other@test.com", "other", "123", "", ""));
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "mutation { deleteComment(slug: \"%s\", id: \"%s\") { success } }",
+                article.getSlug(), comment.getId()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("NoAuthorizationException");
+    verify(commentRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_report_error_when_deleting_an_unknown_comment() {
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq("missing")))
+        .thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "mutation { deleteComment(slug: \"%s\", id: \"missing\") { success } }",
+                article.getSlug()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  public void should_report_error_when_deleting_a_comment_of_an_unknown_article() {
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteComment(slug: \"missing\", id: \"comment-1\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  public void should_reject_deleting_a_comment_without_a_current_user() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteComment(slug: \"whatever\", id: \"comment-1\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(commentRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_fail_to_resolve_the_article_of_a_comment() {
+    // known bug: CommentDatafetcher publishes a Map<String, CommentData> as local context while
+    // ArticleDatafetcher#getCommentArticle expects a bare CommentData, so Comment.article always
+    // blows up with a ClassCastException
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(commenter))).thenReturn(Optional.of(commentData));
+    when(articleQueryService.findById(eq(article.getId()), eq(commenter)))
+        .thenReturn(Optional.of(articleData));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "mutation { addComment(slug: \"%s\", body: \"nice article\") { comment { id"
+                    + " article { slug } } } }",
+                article.getSlug()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ClassCastException");
+    assertThat(result.getErrors().get(0).getPath())
+        .containsExactly("addComment", "comment", "article");
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  private void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,163 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, MeDatafetcher.class})
+public class MeDatafetcherTest {
+
+  private static final String ME_QUERY = "{ me { email username token } }";
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @Autowired private MeDatafetcher meDatafetcher;
+
+  @MockBean private UserQueryService userQueryService;
+
+  @MockBean private JwtService jwtService;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("john@test.com", "john", "123", "bio", "image");
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_return_the_current_user_with_the_token_of_the_authorization_header() {
+    authenticate(user);
+    when(userQueryService.findById(eq(user.getId())))
+        .thenReturn(
+            Optional.of(
+                new UserData(user.getId(), user.getEmail(), user.getUsername(), "bio", "image")));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            ME_QUERY, Collections.emptyMap(), authorizationHeader("Token jwt-token"));
+
+    assertThat(result.<String>read("data.me.email")).isEqualTo(user.getEmail());
+    assertThat(result.<String>read("data.me.username")).isEqualTo(user.getUsername());
+    assertThat(result.<String>read("data.me.token")).isEqualTo("jwt-token");
+  }
+
+  @Test
+  public void should_return_null_me_for_anonymous_user() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            ME_QUERY,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            authorizationHeader("Token jwt-token"));
+
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.<java.util.Map<String, Object>>getData()).containsEntry("me", null);
+  }
+
+  @Test
+  public void should_return_null_me_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            ME_QUERY,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            authorizationHeader("Token jwt-token"));
+
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.<java.util.Map<String, Object>>getData()).containsEntry("me", null);
+  }
+
+  @Test
+  public void should_report_error_when_the_authenticated_user_no_longer_exists() {
+    authenticate(user);
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            ME_QUERY,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            authorizationHeader("Token jwt-token"));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  public void should_report_error_when_the_authorization_header_is_missing() {
+    authenticate(user);
+    when(userQueryService.findById(eq(user.getId())))
+        .thenReturn(
+            Optional.of(
+                new UserData(user.getId(), user.getEmail(), user.getUsername(), "bio", "image")));
+
+    ExecutionResult result = dgsQueryExecutor.execute(ME_QUERY);
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  public void should_build_user_payload_user_with_a_freshly_generated_token() {
+    when(jwtService.toToken(eq(user))).thenReturn("generated-token");
+    DataFetchingEnvironment dataFetchingEnvironment = mock(DataFetchingEnvironment.class);
+    when(dataFetchingEnvironment.<User>getLocalContext()).thenReturn(user);
+
+    DataFetcherResult<io.spring.graphql.types.User> result =
+        meDatafetcher.getUserPayloadUser(dataFetchingEnvironment);
+
+    assertThat(result.getData().getEmail()).isEqualTo(user.getEmail());
+    assertThat(result.getData().getUsername()).isEqualTo(user.getUsername());
+    assertThat(result.getData().getToken()).isEqualTo("generated-token");
+    assertThat(result.getLocalContext()).isSameAs(user);
+  }
+
+  private HttpHeaders authorizationHeader(String value) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", value);
+    return headers;
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,233 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Collections;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      ProfileDatafetcher.class,
+      ArticleDatafetcher.class,
+      CommentDatafetcher.class,
+      MeDatafetcher.class
+    })
+public class ProfileDatafetcherTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ProfileQueryService profileQueryService;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private CommentQueryService commentQueryService;
+
+  @MockBean private UserQueryService userQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private JwtService jwtService;
+
+  private User currentUser;
+  private User author;
+  private ArticleData articleData;
+
+  @BeforeEach
+  public void setUp() {
+    currentUser = new User("current@test.com", "current", "123", "", "");
+    author = new User("author@test.com", "author", "123", "author bio", "author image");
+    articleData = TestHelper.articleDataFixture("1", author);
+    authenticate(currentUser);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_query_a_profile_by_username() {
+    mockAuthorProfile(currentUser, true);
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ profile(username: \"%s\") { profile { username bio image following } } }",
+                author.getUsername()));
+
+    assertThat(result.<String>read("data.profile.profile.username"))
+        .isEqualTo(author.getUsername());
+    assertThat(result.<String>read("data.profile.profile.bio")).isEqualTo(author.getBio());
+    assertThat(result.<String>read("data.profile.profile.image")).isEqualTo(author.getImage());
+    assertThat(result.<Boolean>read("data.profile.profile.following")).isTrue();
+  }
+
+  @Test
+  public void should_query_a_profile_without_current_user_when_anonymous() {
+    anonymous();
+    mockAuthorProfile(null, false);
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ profile(username: \"%s\") { profile { username following } } }",
+                author.getUsername()));
+
+    assertThat(result.<String>read("data.profile.profile.username"))
+        .isEqualTo(author.getUsername());
+    assertThat(result.<Boolean>read("data.profile.profile.following")).isFalse();
+  }
+
+  @Test
+  public void should_report_error_when_the_profile_does_not_exist() {
+    when(profileQueryService.findByUsername(eq("ghost"), any())).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute("{ profile(username: \"ghost\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  public void should_resolve_the_profile_of_the_current_user() {
+    when(userQueryService.findById(eq(currentUser.getId())))
+        .thenReturn(
+            Optional.of(
+                new UserData(
+                    currentUser.getId(),
+                    currentUser.getEmail(),
+                    currentUser.getUsername(),
+                    "",
+                    "")));
+    when(profileQueryService.findByUsername(eq(currentUser.getUsername()), eq(currentUser)))
+        .thenReturn(
+            Optional.of(
+                new ProfileData(
+                    currentUser.getId(), currentUser.getUsername(), "my bio", "my image", false)));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token");
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ me { username profile { username bio image following } } }",
+            Collections.emptyMap(),
+            headers);
+
+    assertThat(result.<String>read("data.me.profile.username"))
+        .isEqualTo(currentUser.getUsername());
+    assertThat(result.<String>read("data.me.profile.bio")).isEqualTo("my bio");
+    assertThat(result.<Boolean>read("data.me.profile.following")).isFalse();
+  }
+
+  @Test
+  public void should_resolve_the_author_of_an_article() {
+    mockAuthorProfile(currentUser, true);
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(currentUser)))
+        .thenReturn(Optional.of(articleData));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ article(slug: \"%s\") { slug author { username bio following } } }",
+                articleData.getSlug()));
+
+    assertThat(result.<String>read("data.article.author.username")).isEqualTo(author.getUsername());
+    assertThat(result.<String>read("data.article.author.bio")).isEqualTo(author.getBio());
+    assertThat(result.<Boolean>read("data.article.author.following")).isTrue();
+  }
+
+  @Test
+  public void should_resolve_the_author_of_a_comment() {
+    mockAuthorProfile(currentUser, false);
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(currentUser)))
+        .thenReturn(Optional.of(articleData));
+    DateTime now = new DateTime();
+    CommentData commentData =
+        new CommentData(
+            "comment-1",
+            "a comment",
+            articleData.getId(),
+            now,
+            now,
+            new ProfileData(
+                author.getId(), author.getUsername(), author.getBio(), author.getImage(), false));
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq(articleData.getId()), eq(currentUser), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(commentData), Direction.NEXT, false));
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "{ article(slug: \"%s\") { comments(first: 1) { edges { node { id author { username"
+                    + " bio } } } } } }",
+                articleData.getSlug()));
+
+    assertThat(result.<String>read("data.article.comments.edges[0].node.author.username"))
+        .isEqualTo(author.getUsername());
+    assertThat(result.<String>read("data.article.comments.edges[0].node.author.bio"))
+        .isEqualTo(author.getBio());
+  }
+
+  private void mockAuthorProfile(User expectedCurrentUser, boolean following) {
+    ProfileData profileData =
+        new ProfileData(
+            author.getId(), author.getUsername(), author.getBio(), author.getImage(), following);
+    if (expectedCurrentUser == null) {
+      when(profileQueryService.findByUsername(eq(author.getUsername()), isNull()))
+          .thenReturn(Optional.of(profileData));
+    } else {
+      when(profileQueryService.findByUsername(eq(author.getUsername()), eq(expectedCurrentUser)))
+          .thenReturn(Optional.of(profileData));
+    }
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  private void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,189 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, RelationMutation.class})
+public class RelationMutationTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private User currentUser;
+  private User target;
+
+  @BeforeEach
+  public void setUp() {
+    currentUser = new User("current@test.com", "current", "123", "", "");
+    target = new User("target@test.com", "target", "123", "target bio", "target image");
+    authenticate(currentUser);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_follow_a_user() {
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    mockProfile(true);
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { followUser(username: \"%s\") { profile { username bio image following }"
+                    + " } }",
+                target.getUsername()));
+
+    assertThat(result.<String>read("data.followUser.profile.username"))
+        .isEqualTo(target.getUsername());
+    assertThat(result.<String>read("data.followUser.profile.bio")).isEqualTo(target.getBio());
+    assertThat(result.<Boolean>read("data.followUser.profile.following")).isTrue();
+    verify(userRepository)
+        .saveRelation(eq(new FollowRelation(currentUser.getId(), target.getId())));
+  }
+
+  @Test
+  public void should_report_error_when_following_an_unknown_user() {
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { followUser(username: \"ghost\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  public void should_reject_following_without_a_current_user() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { followUser(username: \"target\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  public void should_unfollow_a_user() {
+    FollowRelation relation = new FollowRelation(currentUser.getId(), target.getId());
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(currentUser.getId()), eq(target.getId())))
+        .thenReturn(Optional.of(relation));
+    mockProfile(false);
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            String.format(
+                "mutation { unfollowUser(username: \"%s\") { profile { username following } } }",
+                target.getUsername()));
+
+    assertThat(result.<String>read("data.unfollowUser.profile.username"))
+        .isEqualTo(target.getUsername());
+    assertThat(result.<Boolean>read("data.unfollowUser.profile.following")).isFalse();
+    verify(userRepository).removeRelation(eq(relation));
+  }
+
+  @Test
+  public void should_report_error_when_unfollowing_an_unknown_user() {
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfollowUser(username: \"ghost\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(userRepository, never()).removeRelation(any());
+  }
+
+  @Test
+  public void should_report_error_when_there_is_no_relation_to_remove() {
+    when(userRepository.findByUsername(eq(target.getUsername()))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(currentUser.getId()), eq(target.getId())))
+        .thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            String.format(
+                "mutation { unfollowUser(username: \"%s\") { profile { username } } }",
+                target.getUsername()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(userRepository, never()).removeRelation(any());
+  }
+
+  @Test
+  public void should_reject_unfollowing_without_a_current_user() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfollowUser(username: \"target\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(userRepository, never()).removeRelation(any());
+  }
+
+  private void mockProfile(boolean following) {
+    when(profileQueryService.findByUsername(eq(target.getUsername()), eq(currentUser)))
+        .thenReturn(
+            Optional.of(
+                new ProfileData(
+                    target.getId(),
+                    target.getUsername(),
+                    target.getBio(),
+                    target.getImage(),
+                    following)));
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  private void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,62 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtilTest {
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_return_current_user_from_authentication_principal() {
+    User user = new User("john@test.com", "john", "123", "bio", "image");
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+
+    Optional<User> currentUser = SecurityUtil.getCurrentUser();
+
+    assertThat(currentUser).isPresent();
+    assertThat(currentUser.get()).isSameAs(user);
+  }
+
+  @Test
+  public void should_return_empty_for_anonymous_authentication() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  public void should_return_empty_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  public void should_throw_npe_when_there_is_no_authentication() {
+    // documents current behaviour: an empty security context (authentication == null) is not
+    // handled by getCurrentUser and blows up instead of returning Optional.empty()
+    SecurityContextHolder.clearContext();
+
+    assertThatThrownBy(SecurityUtil::getCurrentUser).isInstanceOf(NullPointerException.class);
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,41 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, TagDatafetcher.class})
+public class TagDatafetcherTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @Test
+  public void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertThat(tags).containsExactly("java", "spring");
+  }
+
+  @Test
+  public void should_return_empty_list_when_no_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertThat(tags).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,222 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.application.user.UserService;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      UserMutation.class,
+      MeDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
+public class UserMutationTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private PasswordEncoder passwordEncoder;
+
+  @MockBean private UserService userService;
+
+  @MockBean private io.spring.application.UserQueryService userQueryService;
+
+  @MockBean private JwtService jwtService;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("john@test.com", "john", "encoded-password", "bio", "image");
+    when(jwtService.toToken(eq(user))).thenReturn("jwt-token");
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_create_a_user() {
+    when(userService.createUser(any())).thenReturn(user);
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { createUser(input: {email: \"john@test.com\", username: \"john\", password:"
+                + " \"secret\"}) { ... on UserPayload { user { email username token } } } }");
+
+    assertThat(result.<String>read("data.createUser.user.email")).isEqualTo(user.getEmail());
+    assertThat(result.<String>read("data.createUser.user.username")).isEqualTo(user.getUsername());
+    assertThat(result.<String>read("data.createUser.user.token")).isEqualTo("jwt-token");
+
+    ArgumentCaptor<RegisterParam> captor = ArgumentCaptor.forClass(RegisterParam.class);
+    verify(userService).createUser(captor.capture());
+    assertThat(captor.getValue().getEmail()).isEqualTo("john@test.com");
+    assertThat(captor.getValue().getUsername()).isEqualTo("john");
+    assertThat(captor.getValue().getPassword()).isEqualTo("secret");
+  }
+
+  @Test
+  public void should_return_an_error_payload_when_registration_is_invalid() {
+    when(userService.createUser(any())).thenThrow(constraintViolationException());
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { createUser(input: {email: \"not-an-email\", username: \"\", password:"
+                + " \"secret\"}) { ... on Error { message errors { key value } } } }");
+
+    assertThat(result.<String>read("data.createUser.message")).isEqualTo("BAD_REQUEST");
+    assertThat(result.<List<String>>read("data.createUser.errors[*].key"))
+        .containsExactlyInAnyOrder("email", "username");
+    assertThat(result.<List<String>>read("data.createUser.errors[?(@.key == 'email')].value[0]"))
+        .containsExactly("should be an email");
+  }
+
+  @Test
+  public void should_log_a_user_in() {
+    when(userRepository.findByEmail(eq(user.getEmail()))).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(eq("secret"), eq(user.getPassword()))).thenReturn(true);
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { login(email: \"john@test.com\", password: \"secret\") { user { email"
+                + " username token } } }");
+
+    assertThat(result.<String>read("data.login.user.email")).isEqualTo(user.getEmail());
+    assertThat(result.<String>read("data.login.user.token")).isEqualTo("jwt-token");
+  }
+
+  @Test
+  public void should_reject_a_login_with_a_wrong_password() {
+    when(userRepository.findByEmail(eq(user.getEmail()))).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(eq("wrong"), eq(user.getPassword()))).thenReturn(false);
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { login(email: \"john@test.com\", password: \"wrong\") { user { email } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("invalid email or password");
+    assertThat(result.getErrors().get(0).getExtensions())
+        .containsEntry("errorType", "UNAUTHENTICATED");
+  }
+
+  @Test
+  public void should_reject_a_login_of_an_unknown_email() {
+    when(userRepository.findByEmail(eq("ghost@test.com"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { login(email: \"ghost@test.com\", password: \"secret\") { user { email } }"
+                + " }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getExtensions())
+        .containsEntry("errorType", "UNAUTHENTICATED");
+    verify(passwordEncoder, never()).matches(any(), any());
+  }
+
+  @Test
+  public void should_update_the_current_user() {
+    authenticate(user);
+
+    DocumentContext result =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { updateUser(changes: {email: \"new@test.com\", username: \"new\", bio: \"new"
+                + " bio\", image: \"new image\", password: \"new password\"}) { user { email token }"
+                + " } }");
+
+    assertThat(result.<String>read("data.updateUser.user.email")).isEqualTo(user.getEmail());
+    assertThat(result.<String>read("data.updateUser.user.token")).isEqualTo("jwt-token");
+
+    ArgumentCaptor<UpdateUserCommand> captor = ArgumentCaptor.forClass(UpdateUserCommand.class);
+    verify(userService).updateUser(captor.capture());
+    assertThat(captor.getValue().getTargetUser()).isSameAs(user);
+    assertThat(captor.getValue().getParam().getEmail()).isEqualTo("new@test.com");
+    assertThat(captor.getValue().getParam().getUsername()).isEqualTo("new");
+    assertThat(captor.getValue().getParam().getBio()).isEqualTo("new bio");
+    assertThat(captor.getValue().getParam().getImage()).isEqualTo("new image");
+    assertThat(captor.getValue().getParam().getPassword()).isEqualTo("new password");
+  }
+
+  @Test
+  public void should_return_null_when_updating_a_user_anonymously() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { updateUser(changes: {email: \"new@test.com\"}) { user { email } } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.<java.util.Map<String, Object>>getData()).containsEntry("updateUser", null);
+    verify(userService, never()).updateUser(any());
+  }
+
+  private ConstraintViolationException constraintViolationException() {
+    Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    Set<ConstraintViolation<Registration>> violations =
+        validator.validate(new Registration("not-an-email", ""));
+    return new ConstraintViolationException(violations);
+  }
+
+  private void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  private static class Registration {
+    @Email(message = "should be an email")
+    private final String email;
+
+    @NotBlank(message = "can't be empty")
+    private final String username;
+
+    Registration(String email, String username) {
+      this.email = email;
+      this.username = username;
+    }
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -1,0 +1,197 @@
+package io.spring.graphql.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import graphql.GraphQLError;
+import graphql.Scalars;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.MergedField;
+import graphql.execution.ResultPath;
+import graphql.language.Field;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.ErrorItem;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GraphQLCustomizeExceptionHandlerTest {
+
+  private GraphQLCustomizeExceptionHandler handler;
+  private Validator validator;
+
+  @BeforeEach
+  public void setUp() {
+    handler = new GraphQLCustomizeExceptionHandler();
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  public void should_map_invalid_authentication_to_unauthenticated_error() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new InvalidAuthenticationException(), "/login"));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("invalid email or password");
+    assertThat(error.getPath()).containsExactly("login");
+    assertThat(error.getExtensions()).containsEntry("errorType", "UNAUTHENTICATED");
+  }
+
+  @Test
+  public void should_map_constraint_violation_to_bad_request_error_with_field_extensions() {
+    ConstraintViolationException cve = registerViolations();
+
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(cve, "/createUser"));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getPath()).containsExactly("createUser");
+    assertThat(error.getExtensions()).containsEntry("errorType", "BAD_REQUEST");
+    assertThat(error.getExtensions().get("email")).isEqualTo(List.of("should be an email"));
+    assertThat(error.getExtensions().get("username")).isEqualTo(List.of("can't be empty"));
+  }
+
+  @Test
+  public void should_delegate_unknown_exceptions_to_the_default_handler() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new RuntimeException("boom"), "/article"));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("java.lang.RuntimeException: boom");
+    assertThat(error.getExtensions()).containsEntry("errorType", "INTERNAL");
+  }
+
+  @Test
+  public void should_convert_constraint_violations_into_error_payload() {
+    Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(registerViolations());
+
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).hasSize(2);
+    assertThat(error.getErrors().stream().map(ErrorItem::getKey))
+        .containsExactlyInAnyOrder("email", "username");
+    ErrorItem emailItem =
+        error.getErrors().stream()
+            .filter(item -> item.getKey().equals("email"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(emailItem.getValue()).containsExactly("should be an email");
+  }
+
+  @Test
+  public void should_group_multiple_messages_of_the_same_field_together() {
+    Set<ConstraintViolation<RegistrationForm>> violations =
+        validator.validate(new RegistrationForm("not-an-email", "someone"));
+    // a whitespace-only email violates both @NotBlank and @Email
+    Set<ConstraintViolation<RegistrationForm>> blankEmail =
+        validator.validate(new RegistrationForm("   ", "someone"));
+    assertThat(violations).hasSize(1);
+    assertThat(blankEmail).hasSize(2);
+
+    Error error =
+        GraphQLCustomizeExceptionHandler.getErrorsAsData(
+            new ConstraintViolationException(blankEmail));
+
+    assertThat(error.getErrors()).hasSize(1);
+    assertThat(error.getErrors().get(0).getKey()).isEqualTo("email");
+    assertThat(error.getErrors().get(0).getValue())
+        .containsExactlyInAnyOrder("can't be empty", "should be an email");
+  }
+
+  @Test
+  public void should_strip_method_and_parameter_prefix_from_nested_property_paths()
+      throws Exception {
+    Method method = RegistrationService.class.getMethod("createUser", RegistrationForm.class);
+    Set<ConstraintViolation<RegistrationService>> violations =
+        validator
+            .forExecutables()
+            .validateParameters(
+                new RegistrationService(),
+                method,
+                new Object[] {new RegistrationForm("not-an-email", "someone", new Address(""))});
+    assertThat(violations.stream().map(v -> v.getPropertyPath().toString()))
+        .containsExactlyInAnyOrder("createUser.form.email", "createUser.form.address.city");
+
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(
+            parametersFor(new ConstraintViolationException(violations), "/createUser"));
+
+    Map<String, Object> extensions = result.getErrors().get(0).getExtensions();
+    assertThat(extensions.get("email")).isEqualTo(List.of("should be an email"));
+    assertThat(extensions.get("address.city")).isEqualTo(List.of("can't be empty"));
+  }
+
+  private ConstraintViolationException registerViolations() {
+    Set<ConstraintViolation<RegistrationForm>> violations =
+        validator.validate(new RegistrationForm("not-an-email", ""));
+    assertThat(violations).hasSize(2);
+    return new ConstraintViolationException(violations);
+  }
+
+  private DataFetcherExceptionHandlerParameters parametersFor(Throwable exception, String path) {
+    DataFetchingEnvironment dataFetchingEnvironment =
+        DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+            .executionStepInfo(
+                ExecutionStepInfo.newExecutionStepInfo()
+                    .type(Scalars.GraphQLString)
+                    .path(ResultPath.parse(path))
+                    .build())
+            .mergedField(
+                MergedField.newMergedField(Field.newField(path.substring(1)).build()).build())
+            .build();
+    return DataFetcherExceptionHandlerParameters.newExceptionParameters()
+        .exception(exception)
+        .dataFetchingEnvironment(dataFetchingEnvironment)
+        .build();
+  }
+
+  static class RegistrationForm {
+    @NotBlank(message = "can't be empty")
+    @Email(message = "should be an email")
+    private final String email;
+
+    @NotBlank(message = "can't be empty")
+    private final String username;
+
+    @Valid private final Address address;
+
+    RegistrationForm(String email, String username) {
+      this(email, username, null);
+    }
+
+    RegistrationForm(String email, String username, Address address) {
+      this.email = email;
+      this.username = username;
+      this.address = address;
+    }
+  }
+
+  static class Address {
+    @NotBlank(message = "can't be empty")
+    private final String city;
+
+    Address(String city) {
+      this.city = city;
+    }
+  }
+
+  static class RegistrationService {
+    public void createUser(@Valid RegistrationForm form) {}
+  }
+}


### PR DESCRIPTION
## Summary

85 new tests under `src/test/java/io/spring/graphql/`, closing the repo's largest coverage gap (`io.spring.graphql` was 4.9% instruction / 2.0% line, `io.spring.graphql.exception` 3.0% / 3.2%, zero tests). No production code, build files or existing tests were touched.

Most datafetchers/mutations are exercised through the real schema with the DGS test framework, which requires no new dependencies:

```java
@SpringBootTest(classes = {DgsAutoConfiguration.class, ArticleDatafetcher.class, ProfileDatafetcher.class})
// @MockBean the query services / repositories, authenticate via SecurityContextHolder,
// then dgsQueryExecutor.executeAndGetDocumentContext("{ feed(first: 2, after: \"1000\") { ... } }")
```

Registering *several* datafetchers in one context is what makes the nested/lazy `@DgsData` child resolvers reachable (e.g. `Article.author`, `Comment.author`, `Article.comments`, `Profile.feed/articles/favorites`, `UserPayload.user`), which is where most of the untested lines were. Two child resolvers that can only be reached via a local context the schema never produces are covered by calling them directly with a mocked `DataFetchingEnvironment`.

Cursor pagination is asserted both on the response shape (`edges[*].cursor`, `pageInfo.{hasNextPage,hasPreviousPage,startCursor,endCursor}`) and on what the datafetcher actually passes down, by capturing the `CursorPageParameter` and checking `direction` / `limit` / parsed cursor for `first`/`after` vs `last`/`before`, plus the `IllegalArgumentException` when neither is given.

### Classes covered

| Class | Tests |
| --- | --- |
| `ArticleDatafetcher` | 17 |
| `ArticleMutation` | 14 |
| `CommentDatafetcher` | 5 |
| `CommentMutation` | 11 |
| `MeDatafetcher` | 6 |
| `ProfileDatafetcher` | 6 |
| `RelationMutation` | 7 |
| `SecurityUtil` | 4 |
| `TagDatafetcher` | 2 |
| `UserMutation` | 7 |
| `exception/GraphQLCustomizeExceptionHandler` | 6 |

Beyond happy paths: anonymous access (`AuthenticationException` on every mutation that needs a user), `ResourceNotFoundException` paths, `NoAuthorizationException` when editing/deleting somebody else's article or comment, `login` failures mapped to `errorType: UNAUTHENTICATED`, and `createUser` validation failures returned as the `Error` member of the `UserResult` union with per-field `ErrorItem`s.

### Production smells / bugs found, deliberately not fixed

1. **`Comment.article` is unresolvable — `ClassCastException` at runtime.** `CommentDatafetcher` publishes a `Map<String, CommentData>` as local context, but `ArticleDatafetcher#getCommentArticle` does `CommentData comment = dfe.getLocalContext()`. Any query selecting `article` under a comment fails:
   ```
   java.lang.ClassCastException: class io.spring.graphql.CommentDatafetcher$1 cannot be cast to
   class io.spring.application.data.CommentData
   ```
   `CommentMutationTest#should_fail_to_resolve_the_article_of_a_comment` pins this current (broken) behaviour and is labelled as a known bug; `ArticleDatafetcherTest#should_resolve_the_article_of_a_comment_from_its_local_context` covers the intended behaviour by passing a bare `CommentData` directly.
2. **`SecurityUtil.getCurrentUser()` NPEs on an empty security context** — it handles `AnonymousAuthenticationToken` and a null principal, but dereferences `authentication` without a null check, so `SecurityContextHolder.clearContext()` + a call throws NPE instead of returning `Optional.empty()`. Pinned by `SecurityUtilTest`.
3. **`CommentDatafetcher` maps `updatedAt` from `createdAt`**, so a comment's `updatedAt` never reflects the real value. Pinned by `CommentDatafetcherTest`.
4. `UserMutation#updateUser` duplicates the `SecurityUtil.getCurrentUser()` logic inline (and returns `null` instead of raising an authentication error when anonymous, unlike every sibling mutation).
5. `RelationMutation#buildProfile` calls `.get()` on the `Optional` from `profileQueryService.findByUsername(...)` — a missing profile becomes a `NoSuchElementException`, not a 404-ish error. It also carries a stray `@InputArgument` annotation on a private helper parameter.

### Notes

- Everything is a new file; `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java` (the pre-existing `spotlessApply` violation) is intentionally left uncommitted.
- `./gradlew test` passes fully; `spotlessCheck` passes for the committed files.


Link to Devin session: https://app.devin.ai/sessions/876ee93e540c4a8f97b0d71e0b37feff
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/875?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->