### PR TITLE
build: add JaCoCo coverage reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'jacoco'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
 }
@@ -58,6 +59,31 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn tasks.named('test')
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    dependsOn tasks.named('jacocoTestReport')
+    violationRules {
+        failOnViolation = false
+        rule {
+            limit {
+                counter = 'INSTRUCTION'
+                minimum = 0.70
+            }
+        }
+    }
 }
 
 tasks.named('clean') {


### PR DESCRIPTION
## Summary

Adds the `jacoco` Gradle plugin so test coverage is measurable. Prerequisite for three follow-up test-only PRs (GraphQL layer, application command services/validators, security layer).

```groovy
plugins { ... id 'jacoco' ... }

jacoco { toolVersion = '0.8.8' }              // 0.8.7 (Gradle 7.4 default) does not support JDK 17 class files

jacocoTestReport { dependsOn test; reports { xml.required = true; html.required = true } }

jacocoTestCoverageVerification {              // informational only
    violationRules { failOnViolation = false; rule { limit { counter='INSTRUCTION'; minimum=0.70 } } }
}
```

`failOnViolation = false` keeps the 70% instruction threshold advisory — `./gradlew jacocoTestCoverageVerification` reports violations without breaking the build.

Verified with `./gradlew test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` (spotless/google-java-format is broken under JDK 17); reports land in `build/reports/jacoco/test/{html,jacocoTestReport.xml}`.

## Baseline coverage

**33.3% instruction** (3477/10456), 16.4% branch, 34.1% line, 39.5% method.

Least-covered packages, i.e. the targets of the follow-up PRs:

| package | instruction |
|---|---|
| `io/spring/graphql` | 4.7% |
| `io/spring/graphql/exception` | 3.0% |
| `io/spring/application/article` | 20.5% |
| `io/spring/application/data` | 25.7% |
| `io/spring/application/user` | 52.2% |
| `io/spring/core/favorite` | 54.5% |

Caveat on the headline number: `io/spring/graphql/types` is DGS-codegen output (2952 instructions ≈ 28% of the total, 0% covered) and drags the project figure down. It is left in the report for now rather than excluded, so the baseline is comparable to whatever the follow-up PRs produce.


Link to Devin session: https://app.devin.ai/sessions/f6404bf9b94047b1881b27b9041a5340
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/876?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->