### PR TITLE
test: add security layer tests for JwtTokenFilter and WebSecurityConfig

### DIFF
--- a/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
+++ b/src/test/java/io/spring/api/security/JwtTokenFilterTest.java
@@ -1,0 +1,146 @@
+package io.spring.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtTokenFilterTest {
+  private static final String TOKEN = "valid.jwt.token";
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private JwtService jwtService;
+
+  private JwtTokenFilter filter;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+  private MockFilterChain filterChain;
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    filter = new JwtTokenFilter();
+    ReflectionTestUtils.setField(filter, "userRepository", userRepository);
+    ReflectionTestUtils.setField(filter, "jwtService", jwtService);
+
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+    filterChain = new MockFilterChain();
+
+    user =
+        new User(
+            "john@jacob.com",
+            "johnjacob",
+            "123",
+            "",
+            "https://static.productionready.io/images/smiley-cyrus.jpg");
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void should_not_authenticate_without_authorization_header() throws Exception {
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(filterChain.getRequest()).isSameAs(request);
+    verifyNoInteractions(jwtService, userRepository);
+  }
+
+  @Test
+  public void should_not_authenticate_with_malformed_authorization_header() throws Exception {
+    request.addHeader("Authorization", TOKEN);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(filterChain.getRequest()).isSameAs(request);
+    verify(jwtService, never()).getSubFromToken(anyString());
+    verifyNoInteractions(userRepository);
+  }
+
+  @Test
+  public void should_not_authenticate_with_invalid_token() throws Exception {
+    request.addHeader("Authorization", "Token " + TOKEN);
+    when(jwtService.getSubFromToken(eq(TOKEN))).thenReturn(Optional.empty());
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(filterChain.getRequest()).isSameAs(request);
+    verifyNoInteractions(userRepository);
+  }
+
+  @Test
+  public void should_authenticate_with_valid_token_of_existing_user() throws Exception {
+    request.addHeader("Authorization", "Token " + TOKEN);
+    when(jwtService.getSubFromToken(eq(TOKEN))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isInstanceOf(UsernamePasswordAuthenticationToken.class);
+    assertThat(authentication.getPrincipal()).isSameAs(user);
+    assertThat(authentication.getCredentials()).isNull();
+    assertThat(authentication.getAuthorities()).isEmpty();
+    assertThat(authentication.getDetails()).isInstanceOf(WebAuthenticationDetails.class);
+    assertThat(filterChain.getRequest()).isSameAs(request);
+  }
+
+  @Test
+  public void should_not_authenticate_with_valid_token_of_unknown_user() throws Exception {
+    request.addHeader("Authorization", "Token " + TOKEN);
+    when(jwtService.getSubFromToken(eq(TOKEN))).thenReturn(Optional.of("unknown-user-id"));
+    when(userRepository.findById(eq("unknown-user-id"))).thenReturn(Optional.empty());
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(filterChain.getRequest()).isSameAs(request);
+  }
+
+  @Test
+  public void should_keep_existing_authentication_untouched() throws Exception {
+    Authentication existing =
+        new UsernamePasswordAuthenticationToken("existing", null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(existing);
+
+    request.addHeader("Authorization", "Token " + TOKEN);
+    when(jwtService.getSubFromToken(eq(TOKEN))).thenReturn(Optional.of(user.getId()));
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(existing);
+    assertThat(filterChain.getRequest()).isSameAs(request);
+    verifyNoInteractions(userRepository);
+  }
+}

--- a/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
+++ b/src/test/java/io/spring/api/security/WebSecurityConfigTest.java
@@ -1,0 +1,141 @@
+package io.spring.api.security;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.JacksonCustomizations;
+import io.spring.api.ArticlesApi;
+import io.spring.api.UsersApi;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.Page;
+import io.spring.application.UserQueryService;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.data.ArticleDataList;
+import io.spring.application.data.UserData;
+import io.spring.application.user.UserService;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest({ArticlesApi.class, UsersApi.class})
+@Import({WebSecurityConfig.class, JacksonCustomizations.class})
+public class WebSecurityConfigTest {
+  private static final String TOKEN = "token";
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private ArticleCommandService articleCommandService;
+
+  @MockBean private UserQueryService userQueryService;
+
+  @MockBean private UserService userService;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private JwtService jwtService;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    RestAssuredMockMvc.mockMvc(mvc);
+    user =
+        new User(
+            "john@jacob.com",
+            "johnjacob",
+            "123",
+            "",
+            "https://static.productionready.io/images/smiley-cyrus.jpg");
+  }
+
+  @Test
+  public void should_reject_anonymous_feed_request() {
+    given().when().get("/articles/feed").then().statusCode(401);
+  }
+
+  @Test
+  public void should_allow_feed_request_with_valid_token() {
+    when(jwtService.getSubFromToken(eq(TOKEN))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+    when(articleQueryService.findUserFeed(eq(user), any(Page.class)))
+        .thenReturn(new ArticleDataList(Collections.emptyList(), 0));
+
+    given()
+        .header("Authorization", "Token " + TOKEN)
+        .when()
+        .get("/articles/feed")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  public void should_allow_anonymous_article_listing() {
+    when(articleQueryService.findRecentArticles(
+            eq(null), eq(null), eq(null), any(Page.class), eq(null)))
+        .thenReturn(new ArticleDataList(Collections.emptyList(), 0));
+
+    given().when().get("/articles").then().statusCode(200);
+  }
+
+  @Test
+  public void should_reject_anonymous_article_creation() {
+    Map<String, Object> article = new HashMap<>();
+    article.put("title", "a title");
+    article.put("description", "a description");
+    article.put("body", "a body");
+
+    given()
+        .contentType("application/json")
+        .body(Collections.singletonMap("article", article))
+        .when()
+        .post("/articles")
+        .then()
+        .statusCode(401);
+  }
+
+  @Test
+  public void should_allow_anonymous_user_registration() {
+    Map<String, Object> registration = new HashMap<>();
+    registration.put("email", user.getEmail());
+    registration.put("username", user.getUsername());
+    registration.put("password", "johnjacobpassword");
+
+    when(userRepository.findByEmail(eq(user.getEmail()))).thenReturn(Optional.empty());
+    when(userRepository.findByUsername(eq(user.getUsername()))).thenReturn(Optional.empty());
+    when(userService.createUser(any())).thenReturn(user);
+    when(userQueryService.findById(eq(user.getId())))
+        .thenReturn(
+            Optional.of(
+                new UserData(
+                    user.getId(),
+                    user.getEmail(),
+                    user.getUsername(),
+                    user.getBio(),
+                    user.getImage())));
+    when(jwtService.toToken(eq(user))).thenReturn(TOKEN);
+
+    given()
+        .contentType("application/json")
+        .body(Collections.singletonMap("user", registration))
+        .when()
+        .post("/users")
+        .then()
+        .statusCode(201);
+  }
+}


### PR DESCRIPTION
## Summary

Test-only PR (no `src/main` or build-config changes). `JwtTokenFilter` and `WebSecurityConfig` were only covered incidentally by the API tests, so the filter's "no header" / "malformed header" / "unknown user" / "already authenticated" branches were never exercised directly. Adds two focused tests under `src/test/java/io/spring/api/security`.

`JwtTokenFilterTest` — plain Mockito unit test (no Spring context). The filter uses field injection, so the collaborators are wired with `ReflectionTestUtils`:

```java
filter = new JwtTokenFilter();
ReflectionTestUtils.setField(filter, "userRepository", userRepository);
ReflectionTestUtils.setField(filter, "jwtService", jwtService);
filter.doFilterInternal(request, response, filterChain); // protected, same package
```

Six cases, each asserting the chain is always invoked (`filterChain.getRequest()` is the request) and `SecurityContextHolder` is cleared in `@AfterEach`:

| case | expectation |
| --- | --- |
| no `Authorization` header | no auth; `jwtService`/`userRepository` untouched |
| header without a space (`"valid.jwt.token"`) | no auth; `getSubFromToken` never called |
| valid header, token resolves to nothing | no auth; repository untouched |
| valid token → existing user | auth set, principal is that `User`, null credentials, empty authorities, `WebAuthenticationDetails` |
| valid token → unknown user id | no auth |
| context already authenticated | pre-existing `Authentication` left in place, repository untouched |

`WebSecurityConfigTest` — `@WebMvcTest({ArticlesApi.class, UsersApi.class})` + `@Import({WebSecurityConfig.class, JacksonCustomizations.class})` with REST-Assured MockMvc, pinning the route rules: `GET /articles/feed` → 401 anonymous / 200 with a valid token, `GET /articles` → 200 anonymous, `POST /articles` → 401 anonymous, `POST /users` → 201 anonymous.

## Coverage

`./gradlew test jacocoTestReport -x spotlessJava -x spotlessJavaCheck` — full suite green (79 tests, 0 failures; 68 → 79).

Branch coverage (the point of this PR):

| target | metric | before | after |
| --- | --- | --- | --- |
| `io/spring/api/security/JwtTokenFilter` | branch | 66.7% (4/6) | **100.0% (6/6)** |
| `io/spring/api/security` (pkg) | branch | 66.7% (4/6) | **100.0% (6/6)** |
| project total | branch | 16.4% (146/890) | 16.6% (148/890) |

Instruction coverage:

| target | before | after |
| --- | --- | --- |
| `io/spring/api/security/JwtTokenFilter` | 97.4% (74/76) | **100.0% (76/76)** |
| `io/spring/api/security/WebSecurityConfig` | 100.0% (180/180) | 100.0% (180/180) |
| `io/spring/api/security` (pkg) | 99.2% (254/256) | **100.0% (256/256)** |
| project total | 33.3% (3477/10456) | 33.3% (3479/10456) |

As expected for this area the instruction delta is ~0 — the value is the branch coverage and the behaviour pinning.

Formatting was verified by running `spotlessJavaCheck` with `--add-exports jdk.compiler/...=ALL-UNNAMED` gradle JVM args (the usual JDK 17 failure mode); the only violation reported is the pre-existing one in `DefaultJwtServiceTest.java`, none in the new files.

Base branch is `devin/1785307367-add-jacoco` (PR #876) since the JaCoCo setup isn't on master yet.


Link to Devin session: https://app.devin.ai/sessions/70b0634f796e4041a8ec068071c24973
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/877?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->