### PR TITLE
test: cover ArticleCommandService, UserService and user validators

### DIFF
--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,153 @@
+package io.spring.application.article;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.article.Tag;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisArticleRepository;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import({ArticleCommandService.class, MyBatisArticleRepository.class, MyBatisUserRepository.class})
+public class ArticleCommandServiceTest extends DbTestBase {
+  @Autowired private ArticleCommandService articleCommandService;
+
+  @Autowired private ArticleRepository articleRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("aisensiy@gmail.com", "aisensiy", "123", "bio", "default");
+    userRepository.save(user);
+  }
+
+  @Test
+  public void should_create_article_with_slug_and_tags() {
+    NewArticleParam newArticleParam =
+        NewArticleParam.builder()
+            .title("How to train your dragon")
+            .description("Ever wonder how?")
+            .body("You have to believe")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(newArticleParam, user);
+
+    Assertions.assertEquals("how-to-train-your-dragon", article.getSlug());
+    Assertions.assertEquals(user.getId(), article.getUserId());
+    Assertions.assertEquals("Ever wonder how?", article.getDescription());
+    Assertions.assertEquals("You have to believe", article.getBody());
+
+    Optional<Article> saved = articleRepository.findBySlug("how-to-train-your-dragon");
+    Assertions.assertTrue(saved.isPresent());
+    Assertions.assertEquals(article.getId(), saved.get().getId());
+    Assertions.assertEquals(Arrays.asList("java", "spring"), sortedTagNames(saved.get().getTags()));
+  }
+
+  @Test
+  public void should_create_article_with_deduplicated_tags() {
+    NewArticleParam newArticleParam =
+        NewArticleParam.builder()
+            .title("tags")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(newArticleParam, user);
+
+    Assertions.assertEquals(Arrays.asList("java", "spring"), sortedTagNames(article.getTags()));
+  }
+
+  @Test
+  public void should_create_article_without_tags() {
+    NewArticleParam newArticleParam =
+        NewArticleParam.builder()
+            .title("no tags here")
+            .description("desc")
+            .body("body")
+            .tagList(Collections.emptyList())
+            .build();
+
+    Article article = articleCommandService.createArticle(newArticleParam, user);
+
+    Assertions.assertTrue(article.getTags().isEmpty());
+    Assertions.assertTrue(articleRepository.findBySlug("no-tags-here").isPresent());
+  }
+
+  @Test
+  public void should_update_article_and_regenerate_slug() {
+    Article article = createArticle("old title");
+
+    Article updated =
+        articleCommandService.updateArticle(
+            article, new UpdateArticleParam("new title", "new body", "new desc"));
+
+    Assertions.assertEquals(article.getId(), updated.getId());
+    Assertions.assertEquals("new-title", updated.getSlug());
+
+    Optional<Article> saved = articleRepository.findBySlug("new-title");
+    Assertions.assertTrue(saved.isPresent());
+    Assertions.assertEquals("new title", saved.get().getTitle());
+    Assertions.assertEquals("new desc", saved.get().getDescription());
+    Assertions.assertEquals("new body", saved.get().getBody());
+    Assertions.assertFalse(articleRepository.findBySlug("old-title").isPresent());
+  }
+
+  @Test
+  public void should_keep_slug_and_fields_when_update_param_is_empty() {
+    Article article = createArticle("keep me");
+
+    Article updated =
+        articleCommandService.updateArticle(article, new UpdateArticleParam("", "", ""));
+
+    Assertions.assertEquals("keep-me", updated.getSlug());
+    Assertions.assertEquals("keep me", updated.getTitle());
+    Assertions.assertEquals("desc", updated.getDescription());
+    Assertions.assertEquals("body", updated.getBody());
+
+    Optional<Article> saved = articleRepository.findBySlug("keep-me");
+    Assertions.assertTrue(saved.isPresent());
+    Assertions.assertEquals("keep me", saved.get().getTitle());
+  }
+
+  @Test
+  public void should_keep_tags_when_article_updated() {
+    Article article = createArticle("tagged article");
+
+    articleCommandService.updateArticle(article, new UpdateArticleParam("renamed article", "", ""));
+
+    Optional<Article> saved = articleRepository.findBySlug("renamed-article");
+    Assertions.assertTrue(saved.isPresent());
+    Assertions.assertEquals(Arrays.asList("java", "spring"), sortedTagNames(saved.get().getTags()));
+  }
+
+  private Article createArticle(String title) {
+    return articleCommandService.createArticle(
+        NewArticleParam.builder()
+            .title(title)
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build(),
+        user);
+  }
+
+  private List<String> sortedTagNames(List<Tag> tags) {
+    return tags.stream().map(Tag::getName).sorted().collect(Collectors.toList());
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
@@ -1,0 +1,54 @@
+package io.spring.application.user;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedEmailValidatorTest {
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedEmailValidator duplicatedEmailValidator;
+
+  private ConstraintValidatorContext context;
+
+  @BeforeEach
+  public void setUp() {
+    context = mock(ConstraintValidatorContext.class);
+  }
+
+  @Test
+  public void should_be_valid_when_email_is_not_used() {
+    when(userRepository.findByEmail("new@test.com")).thenReturn(Optional.empty());
+
+    Assertions.assertTrue(duplicatedEmailValidator.isValid("new@test.com", context));
+  }
+
+  @Test
+  public void should_be_invalid_when_email_is_already_used() {
+    when(userRepository.findByEmail("used@test.com"))
+        .thenReturn(Optional.of(new User("used@test.com", "user", "123", "", "")));
+
+    Assertions.assertFalse(duplicatedEmailValidator.isValid("used@test.com", context));
+  }
+
+  @Test
+  public void should_be_valid_when_email_is_null_or_empty() {
+    Assertions.assertTrue(duplicatedEmailValidator.isValid(null, context));
+    Assertions.assertTrue(duplicatedEmailValidator.isValid("", context));
+
+    verifyNoInteractions(userRepository);
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
@@ -1,0 +1,54 @@
+package io.spring.application.user;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedUsernameValidatorTest {
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private DuplicatedUsernameValidator duplicatedUsernameValidator;
+
+  private ConstraintValidatorContext context;
+
+  @BeforeEach
+  public void setUp() {
+    context = mock(ConstraintValidatorContext.class);
+  }
+
+  @Test
+  public void should_be_valid_when_username_is_not_used() {
+    when(userRepository.findByUsername("new")).thenReturn(Optional.empty());
+
+    Assertions.assertTrue(duplicatedUsernameValidator.isValid("new", context));
+  }
+
+  @Test
+  public void should_be_invalid_when_username_is_already_used() {
+    when(userRepository.findByUsername("used"))
+        .thenReturn(Optional.of(new User("used@test.com", "used", "123", "", "")));
+
+    Assertions.assertFalse(duplicatedUsernameValidator.isValid("used", context));
+  }
+
+  @Test
+  public void should_be_valid_when_username_is_null_or_empty() {
+    Assertions.assertTrue(duplicatedUsernameValidator.isValid(null, context));
+    Assertions.assertTrue(duplicatedUsernameValidator.isValid("", context));
+
+    verifyNoInteractions(userRepository);
+  }
+}

--- a/src/test/java/io/spring/application/user/UpdateUserValidatorTest.java
+++ b/src/test/java/io/spring/application/user/UpdateUserValidatorTest.java
@@ -1,0 +1,92 @@
+package io.spring.application.user;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateUserValidatorTest {
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private UpdateUserValidator updateUserValidator;
+
+  private User targetUser;
+  private ConstraintValidatorContext context;
+
+  @BeforeEach
+  public void setUp() {
+    targetUser = new User("old@test.com", "old", "123", "bio", "image");
+    context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+  }
+
+  @Test
+  public void should_be_valid_when_email_and_username_are_not_taken() {
+    when(userRepository.findByEmail("new@test.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("new")).thenReturn(Optional.empty());
+
+    Assertions.assertTrue(updateUserValidator.isValid(command("new@test.com", "new"), context));
+  }
+
+  @Test
+  public void should_be_valid_when_email_and_username_belong_to_the_same_user() {
+    when(userRepository.findByEmail("old@test.com")).thenReturn(Optional.of(targetUser));
+    when(userRepository.findByUsername("old")).thenReturn(Optional.of(targetUser));
+
+    Assertions.assertTrue(updateUserValidator.isValid(command("old@test.com", "old"), context));
+  }
+
+  @Test
+  public void should_be_invalid_when_email_is_taken_by_another_user() {
+    User anotherUser = new User("taken@test.com", "another", "123", "", "");
+    when(userRepository.findByEmail("taken@test.com")).thenReturn(Optional.of(anotherUser));
+    when(userRepository.findByUsername("new")).thenReturn(Optional.empty());
+
+    Assertions.assertFalse(updateUserValidator.isValid(command("taken@test.com", "new"), context));
+
+    verify(context).disableDefaultConstraintViolation();
+    verify(context).buildConstraintViolationWithTemplate("email already exist");
+  }
+
+  @Test
+  public void should_be_invalid_when_username_is_taken_by_another_user() {
+    User anotherUser = new User("another@test.com", "taken", "123", "", "");
+    when(userRepository.findByEmail("new@test.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("taken")).thenReturn(Optional.of(anotherUser));
+
+    Assertions.assertFalse(updateUserValidator.isValid(command("new@test.com", "taken"), context));
+
+    verify(context).disableDefaultConstraintViolation();
+    verify(context).buildConstraintViolationWithTemplate("username already exist");
+  }
+
+  @Test
+  public void should_be_invalid_when_both_email_and_username_are_taken() {
+    User anotherUser = new User("taken@test.com", "taken", "123", "", "");
+    when(userRepository.findByEmail("taken@test.com")).thenReturn(Optional.of(anotherUser));
+    when(userRepository.findByUsername("taken")).thenReturn(Optional.of(anotherUser));
+
+    Assertions.assertFalse(
+        updateUserValidator.isValid(command("taken@test.com", "taken"), context));
+
+    verify(context).buildConstraintViolationWithTemplate("email already exist");
+    verify(context).buildConstraintViolationWithTemplate("username already exist");
+  }
+
+  private UpdateUserCommand command(String email, String username) {
+    return new UpdateUserCommand(
+        targetUser, UpdateUserParam.builder().email(email).username(username).build());
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,95 @@
+package io.spring.application.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+  private static final String DEFAULT_IMAGE = "https://static.productionready.io/images/user.jpg";
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private PasswordEncoder passwordEncoder;
+
+  @Captor private ArgumentCaptor<User> userCaptor;
+
+  private UserService userService;
+
+  @BeforeEach
+  public void setUp() {
+    userService = new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder);
+  }
+
+  @Test
+  public void should_create_user_with_encoded_password_and_default_image() {
+    when(passwordEncoder.encode("123")).thenReturn("encoded-123");
+
+    User user = userService.createUser(new RegisterParam("aisensiy@test.com", "aisensiy", "123"));
+
+    Assertions.assertEquals("aisensiy@test.com", user.getEmail());
+    Assertions.assertEquals("aisensiy", user.getUsername());
+    Assertions.assertEquals("encoded-123", user.getPassword());
+    Assertions.assertEquals("", user.getBio());
+    Assertions.assertEquals(DEFAULT_IMAGE, user.getImage());
+    Assertions.assertNotNull(user.getId());
+
+    verify(passwordEncoder).encode("123");
+    verify(userRepository).save(userCaptor.capture());
+    Assertions.assertEquals(user, userCaptor.getValue());
+    Assertions.assertEquals("encoded-123", userCaptor.getValue().getPassword());
+  }
+
+  @Test
+  public void should_update_user_with_all_command_fields() {
+    User user = new User("old@test.com", "old", "123", "old bio", "old image");
+
+    userService.updateUser(
+        new UpdateUserCommand(
+            user,
+            UpdateUserParam.builder()
+                .email("new@test.com")
+                .username("new")
+                .password("new password")
+                .bio("new bio")
+                .image("new image")
+                .build()));
+
+    Assertions.assertEquals("new@test.com", user.getEmail());
+    Assertions.assertEquals("new", user.getUsername());
+    Assertions.assertEquals("new password", user.getPassword());
+    Assertions.assertEquals("new bio", user.getBio());
+    Assertions.assertEquals("new image", user.getImage());
+
+    verify(userRepository).save(userCaptor.capture());
+    Assertions.assertEquals(user, userCaptor.getValue());
+  }
+
+  @Test
+  public void should_only_update_provided_fields() {
+    User user = new User("old@test.com", "old", "123", "old bio", "old image");
+
+    userService.updateUser(
+        new UpdateUserCommand(user, UpdateUserParam.builder().email("new@test.com").build()));
+
+    Assertions.assertEquals("new@test.com", user.getEmail());
+    Assertions.assertEquals("old", user.getUsername());
+    Assertions.assertEquals("123", user.getPassword());
+    Assertions.assertEquals("old bio", user.getBio());
+    Assertions.assertEquals("old image", user.getImage());
+
+    verify(userRepository).save(any(User.class));
+  }
+}


### PR DESCRIPTION
## Summary

Test-only PR: the application command services and the user constraint validators were previously only exercised indirectly through the API tests. Adds direct tests for them.

New files (all under `src/test/java`, no production/build changes):

- `application/article/ArticleCommandServiceTest` — `DbTestBase` + `@Import({ArticleCommandService, MyBatisArticleRepository, MyBatisUserRepository})`, same shape as `ArticleQueryServiceTest`. Covers slug generation on create (`"How to train your dragon"` → `how-to-train-your-dragon`), tag de-duplication and the empty-tag-list case, slug regeneration on title update (old slug no longer resolvable), the no-op path when `UpdateArticleParam` fields are empty, and that tags survive an update.
- `application/user/UserServiceTest` — Mockito, `new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder)`. Asserts the saved `User` (captured via `ArgumentCaptor`) carries the *encoded* password and the default image, and that `updateUser` applies the `UpdateUserCommand` fields — including that empty `UpdateUserParam` fields leave the existing values untouched.
- `application/user/UpdateUserValidatorTest` — drives the package-private `UpdateUserValidator` directly with a mocked `UserRepository` and a `RETURNS_DEEP_STUBS` `ConstraintValidatorContext` (so the `buildConstraintViolationWithTemplate(...).addPropertyNode(...).addConstraintViolation()` chain works without hand-stubbing). Covers: nothing taken (valid), conflicting record is the *same* user (valid), email taken by another user, username taken by another user, both taken — asserting the right violation templates are built.
- `application/user/DuplicatedEmailValidatorTest` / `DuplicatedUsernameValidatorTest` — valid / duplicate / null-or-empty (short-circuits, `verifyNoInteractions(userRepository)`).

Full suite passes: 88 tests, 0 failures, 0 skipped (`./gradlew test jacocoTestReport -x spotlessJava -x spotlessJavaCheck`). Files were formatted with google-java-format 1.13 (the version spotless pins) run directly, since the spotless task itself fails on JDK 17.

## Coverage (instruction, from `build/reports/jacoco/test/jacocoTestReport.xml`)

**Project total: 33.3% (3477/10456) → 36.3% (3798/10456)**

| Package | Before | After |
| --- | --- | --- |
| `io/spring/application/article` | 20.5% (36/176) | **94.3% (166/176)** |
| `io/spring/application/user` | 52.2% (198/379) | **96.3% (365/379)** |
| `io/spring/core/article` | 70.8% (199/281) | 76.5% (215/281) |
| `io/spring/core/user` | 71.8% (186/259) | 74.9% (194/259) |

| Class | Before | After |
| --- | --- | --- |
| `ArticleCommandService` | 15.0% (6/40) | **100%** |
| `UserService` | 61.4% (35/57) | **100%** |
| `UpdateUserValidator` | 84.6% (66/78) | **100%** |
| `NewArticleParam` | 8.8% (3/34) | **100%** |
| `NewArticleParam$Builder` | 0.0% (0/45) | 77.8% (35/45) |
| `UpdateArticleParam` | 28.6% (12/42) | **100%** |
| `RegisterParam` | 12.5% (3/24) | **100%** |
| `UpdateUserParam` | 66.2% (43/65) | **100%** |
| `UpdateUserParam$Builder` | 0.0% (0/104) | 86.5% (90/104) |
| `Article` | 74.9% (140/187) | 83.4% (156/187) |
| `User` | 87.4% (118/135) | 93.3% (126/135) |

`DuplicatedEmailValidator` / `DuplicatedUsernameValidator` were already at 100% via the API tests; the new tests pin their behaviour directly (incl. the null/empty short-circuit) without changing the number.

Base branch is `devin/1785307367-add-jacoco` (PR #876), which carries the JaCoCo setup and is not yet merged into master.


Link to Devin session: https://app.devin.ai/sessions/0ecd0de0551e4ff4a78611e8757bd6b5
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/878?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->