### PR TITLE
test: cover DGS graphql datafetchers, mutations and exception handler

### DIFF
--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,410 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.ArticlesConnection;
+import io.spring.graphql.types.Profile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleDatafetcherTest {
+
+  private static final DateTime CREATED_AT = new DateTime(2021, 1, 1, 0, 0, DateTimeZone.UTC);
+  private static final DateTime UPDATED_AT = new DateTime(2021, 2, 2, 0, 0, DateTimeZone.UTC);
+
+  @Mock private ArticleQueryService articleQueryService;
+  @Mock private UserRepository userRepository;
+  @Mock private DataFetchingEnvironment delegateEnvironment;
+
+  @Captor private ArgumentCaptor<CursorPageParameter<DateTime>> pageParameterCaptor;
+
+  @InjectMocks private ArticleDatafetcher articleDatafetcher;
+
+  private final User currentUser = new User("jake@jake.jake", "jake", "123", "bio", "image");
+  private final User targetUser = new User("john@john.com", "john", "123", "", "");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_return_feed_forward_page_for_current_user() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleQueryService.findUserFeedWithCursor(eq(currentUser), pageParameterCaptor.capture()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.NEXT, true));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(10, "1000", null, null, dgsEnvironment());
+
+    CursorPageParameter<DateTime> pageParameter = pageParameterCaptor.getValue();
+    assertEquals(10, pageParameter.getLimit());
+    assertEquals(Direction.NEXT, pageParameter.getDirection());
+    assertEquals(1000L, pageParameter.getCursor().getMillis());
+
+    assertConnectionContainsArticle(result, "a-title");
+    assertTrue(result.getData().getPageInfo().isHasNextPage());
+    assertFalse(result.getData().getPageInfo().isHasPreviousPage());
+  }
+
+  @Test
+  public void should_return_feed_backward_page_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+    when(articleQueryService.findUserFeedWithCursor(isNull(), pageParameterCaptor.capture()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.PREV, true));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(null, null, 5, null, dgsEnvironment());
+
+    assertEquals(Direction.PREV, pageParameterCaptor.getValue().getDirection());
+    assertNull(pageParameterCaptor.getValue().getCursor());
+    assertTrue(result.getData().getPageInfo().isHasPreviousPage());
+  }
+
+  @Test
+  public void should_reject_feed_without_first_or_last() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> articleDatafetcher.getFeed(null, null, null, null, dgsEnvironment()));
+  }
+
+  @Test
+  public void should_return_empty_connection_with_null_cursors() {
+    SecurityContextHelper.anonymous();
+    when(articleQueryService.findUserFeedWithCursor(isNull(), pageParameterCaptor.capture()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(10, null, null, null, dgsEnvironment());
+
+    assertTrue(result.getData().getEdges().isEmpty());
+    assertNull(result.getData().getPageInfo().getStartCursor());
+    assertNull(result.getData().getPageInfo().getEndCursor());
+  }
+
+  @Test
+  public void should_return_user_feed_of_profile() {
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(targetUser));
+    when(articleQueryService.findUserFeedWithCursor(eq(targetUser), pageParameterCaptor.capture()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.NEXT, false));
+    when(delegateEnvironment.<Profile>getSource())
+        .thenReturn(Profile.newBuilder().username("john").build());
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userFeed(10, null, null, null, dgsEnvironment());
+
+    assertEquals(Direction.NEXT, pageParameterCaptor.getValue().getDirection());
+    assertConnectionContainsArticle(result, "a-title");
+  }
+
+  @Test
+  public void should_return_user_feed_backward_page() {
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(targetUser));
+    when(articleQueryService.findUserFeedWithCursor(eq(targetUser), pageParameterCaptor.capture()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.PREV, false));
+    when(delegateEnvironment.<Profile>getSource())
+        .thenReturn(Profile.newBuilder().username("john").build());
+
+    articleDatafetcher.userFeed(null, null, 3, "2000", dgsEnvironment());
+
+    assertEquals(Direction.PREV, pageParameterCaptor.getValue().getDirection());
+    assertEquals(2000L, pageParameterCaptor.getValue().getCursor().getMillis());
+  }
+
+  @Test
+  public void should_throw_when_user_feed_owner_is_missing() {
+    when(userRepository.findByUsername("john")).thenReturn(Optional.empty());
+    when(delegateEnvironment.<Profile>getSource())
+        .thenReturn(Profile.newBuilder().username("john").build());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> articleDatafetcher.userFeed(10, null, null, null, dgsEnvironment()));
+  }
+
+  @Test
+  public void should_reject_user_feed_without_first_or_last() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> articleDatafetcher.userFeed(null, null, null, null, dgsEnvironment()));
+  }
+
+  @Test
+  public void should_return_articles_favorited_by_profile() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(delegateEnvironment.<Profile>getSource())
+        .thenReturn(Profile.newBuilder().username("john").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), eq("john"), pageParameterCaptor.capture(), eq(currentUser)))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.NEXT, false));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userFavorites(10, null, null, null, dgsEnvironment());
+
+    assertEquals(Direction.NEXT, pageParameterCaptor.getValue().getDirection());
+    assertConnectionContainsArticle(result, "a-title");
+  }
+
+  @Test
+  public void should_return_articles_favorited_by_profile_backward() {
+    SecurityContextHelper.anonymous();
+    when(delegateEnvironment.<Profile>getSource())
+        .thenReturn(Profile.newBuilder().username("john").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), eq("john"), pageParameterCaptor.capture(), isNull()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.PREV, false));
+
+    articleDatafetcher.userFavorites(null, null, 4, null, dgsEnvironment());
+
+    assertEquals(Direction.PREV, pageParameterCaptor.getValue().getDirection());
+  }
+
+  @Test
+  public void should_reject_user_favorites_without_first_or_last() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> articleDatafetcher.userFavorites(null, null, null, null, dgsEnvironment()));
+  }
+
+  @Test
+  public void should_return_articles_authored_by_profile() {
+    SecurityContextHelper.anonymous();
+    when(delegateEnvironment.<Profile>getSource())
+        .thenReturn(Profile.newBuilder().username("john").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), eq("john"), isNull(), pageParameterCaptor.capture(), isNull()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.NEXT, false));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userArticles(10, null, null, null, dgsEnvironment());
+
+    assertConnectionContainsArticle(result, "a-title");
+  }
+
+  @Test
+  public void should_return_articles_authored_by_profile_backward() {
+    SecurityContextHelper.anonymous();
+    when(delegateEnvironment.<Profile>getSource())
+        .thenReturn(Profile.newBuilder().username("john").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), eq("john"), isNull(), pageParameterCaptor.capture(), isNull()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.PREV, false));
+
+    articleDatafetcher.userArticles(null, null, 2, null, dgsEnvironment());
+
+    assertEquals(Direction.PREV, pageParameterCaptor.getValue().getDirection());
+  }
+
+  @Test
+  public void should_reject_user_articles_without_first_or_last() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> articleDatafetcher.userArticles(null, null, null, null, dgsEnvironment()));
+  }
+
+  @Test
+  public void should_return_articles_filtered_by_tag_author_and_favorited_by() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            eq("java"), eq("john"), eq("jake"), pageParameterCaptor.capture(), eq(currentUser)))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.NEXT, false));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getArticles(
+            10, null, null, null, "john", "jake", "java", dgsEnvironment());
+
+    assertConnectionContainsArticle(result, "a-title");
+  }
+
+  @Test
+  public void should_return_articles_backward_page() {
+    SecurityContextHelper.anonymous();
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), isNull(), pageParameterCaptor.capture(), isNull()))
+        .thenReturn(pagerOf(articleData("a-title"), Direction.PREV, true));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getArticles(null, null, 7, "3000", null, null, null, dgsEnvironment());
+
+    assertEquals(Direction.PREV, pageParameterCaptor.getValue().getDirection());
+    assertEquals(3000L, pageParameterCaptor.getValue().getCursor().getMillis());
+    assertTrue(result.getData().getPageInfo().isHasPreviousPage());
+  }
+
+  @Test
+  public void should_reject_articles_without_first_or_last() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            articleDatafetcher.getArticles(
+                null, null, null, null, null, null, null, dgsEnvironment()));
+  }
+
+  @Test
+  public void should_resolve_article_payload_article_from_local_context() {
+    SecurityContextHelper.authenticate(currentUser);
+    io.spring.core.article.Article article =
+        new io.spring.core.article.Article(
+            "a title", "desc", "body", Arrays.asList("java"), currentUser.getId());
+    when(delegateEnvironment.<io.spring.core.article.Article>getLocalContext()).thenReturn(article);
+    when(articleQueryService.findById(article.getId(), currentUser))
+        .thenReturn(Optional.of(articleData("a-title")));
+
+    DataFetcherResult<Article> result = articleDatafetcher.getArticle(delegateEnvironment);
+
+    assertEquals("a-title", result.getData().getSlug());
+    Map<String, ArticleData> localContext = articleLocalContext(result);
+    assertTrue(localContext.containsKey("a-title"));
+  }
+
+  @Test
+  public void should_throw_when_article_payload_article_is_missing() {
+    SecurityContextHelper.anonymous();
+    io.spring.core.article.Article article =
+        new io.spring.core.article.Article(
+            "a title", "desc", "body", Arrays.asList("java"), "user-id");
+    when(delegateEnvironment.<io.spring.core.article.Article>getLocalContext()).thenReturn(article);
+    when(articleQueryService.findById(article.getId(), null)).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class, () -> articleDatafetcher.getArticle(delegateEnvironment));
+  }
+
+  @Test
+  public void should_resolve_article_of_a_comment() {
+    SecurityContextHelper.anonymous();
+    CommentData commentData =
+        new CommentData("comment-id", "body", "article-id", CREATED_AT, UPDATED_AT, profileData());
+    when(delegateEnvironment.<CommentData>getLocalContext()).thenReturn(commentData);
+    when(articleQueryService.findById("article-id", null))
+        .thenReturn(Optional.of(articleData("a-title")));
+
+    DataFetcherResult<Article> result = articleDatafetcher.getCommentArticle(delegateEnvironment);
+
+    assertEquals("a-title", result.getData().getSlug());
+  }
+
+  @Test
+  public void should_throw_when_article_of_a_comment_is_missing() {
+    SecurityContextHelper.anonymous();
+    CommentData commentData =
+        new CommentData("comment-id", "body", "article-id", CREATED_AT, UPDATED_AT, profileData());
+    when(delegateEnvironment.<CommentData>getLocalContext()).thenReturn(commentData);
+    when(articleQueryService.findById("article-id", null)).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> articleDatafetcher.getCommentArticle(delegateEnvironment));
+  }
+
+  @Test
+  public void should_find_article_by_slug() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleQueryService.findBySlug("a-title", currentUser))
+        .thenReturn(Optional.of(articleData("a-title")));
+
+    DataFetcherResult<Article> result = articleDatafetcher.findArticleBySlug("a-title");
+
+    Article article = result.getData();
+    assertEquals("a-title", article.getSlug());
+    assertEquals("a title", article.getTitle());
+    assertEquals("body", article.getBody());
+    assertEquals("desc", article.getDescription());
+    assertTrue(article.getFavorited());
+    assertEquals(3, article.getFavoritesCount());
+    assertEquals(Collections.singletonList("java"), article.getTagList());
+    assertEquals("2021-01-01T00:00:00.000Z", article.getCreatedAt());
+    assertEquals("2021-02-02T00:00:00.000Z", article.getUpdatedAt());
+  }
+
+  @Test
+  public void should_throw_when_article_slug_is_unknown() {
+    SecurityContextHelper.anonymous();
+    when(articleQueryService.findBySlug("missing", null)).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class, () -> articleDatafetcher.findArticleBySlug("missing"));
+  }
+
+  private void assertConnectionContainsArticle(
+      DataFetcherResult<ArticlesConnection> result, String slug) {
+    assertEquals(1, result.getData().getEdges().size());
+    assertEquals(slug, result.getData().getEdges().get(0).getNode().getSlug());
+    assertEquals(
+        String.valueOf(UPDATED_AT.getMillis()), result.getData().getEdges().get(0).getCursor());
+    assertEquals(
+        String.valueOf(UPDATED_AT.getMillis()),
+        result.getData().getPageInfo().getStartCursor().getValue());
+    Map<String, ArticleData> localContext = articleLocalContext(result);
+    assertTrue(localContext.containsKey(slug));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, ArticleData> articleLocalContext(DataFetcherResult<?> result) {
+    return (Map<String, ArticleData>) result.getLocalContext();
+  }
+
+  private DgsDataFetchingEnvironment dgsEnvironment() {
+    return new DgsDataFetchingEnvironment(delegateEnvironment);
+  }
+
+  private CursorPager<ArticleData> pagerOf(
+      ArticleData articleData, Direction direction, boolean hasExtra) {
+    List<ArticleData> data = Collections.singletonList(articleData);
+    return new CursorPager<>(data, direction, hasExtra);
+  }
+
+  private ProfileData profileData() {
+    return new ProfileData("author-id", "john", "bio", "image", false);
+  }
+
+  private ArticleData articleData(String slug) {
+    return new ArticleData(
+        "article-id",
+        slug,
+        "a title",
+        "desc",
+        "body",
+        true,
+        3,
+        CREATED_AT,
+        UPDATED_AT,
+        Collections.singletonList("java"),
+        profileData());
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,241 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.article.UpdateArticleParam;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ArticlePayload;
+import io.spring.graphql.types.CreateArticleInput;
+import io.spring.graphql.types.DeletionStatus;
+import io.spring.graphql.types.UpdateArticleInput;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleMutationTest {
+
+  @Mock private ArticleCommandService articleCommandService;
+  @Mock private ArticleFavoriteRepository articleFavoriteRepository;
+  @Mock private ArticleRepository articleRepository;
+
+  @Captor private ArgumentCaptor<NewArticleParam> newArticleParamCaptor;
+  @Captor private ArgumentCaptor<UpdateArticleParam> updateArticleParamCaptor;
+
+  @InjectMocks private ArticleMutation articleMutation;
+
+  private final User currentUser = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_create_article_with_tag_list() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = ownedArticle();
+    when(articleCommandService.createArticle(newArticleParamCaptor.capture(), eq(currentUser)))
+        .thenReturn(article);
+
+    DataFetcherResult<ArticlePayload> result =
+        articleMutation.createArticle(
+            CreateArticleInput.newBuilder()
+                .title("a title")
+                .description("desc")
+                .body("body")
+                .tagList(Arrays.asList("java", "spring"))
+                .build());
+
+    assertEquals(Arrays.asList("java", "spring"), newArticleParamCaptor.getValue().getTagList());
+    assertEquals("a title", newArticleParamCaptor.getValue().getTitle());
+    assertSame(article, result.getLocalContext());
+  }
+
+  @Test
+  public void should_create_article_with_empty_tag_list_when_absent() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleCommandService.createArticle(newArticleParamCaptor.capture(), eq(currentUser)))
+        .thenReturn(ownedArticle());
+
+    articleMutation.createArticle(
+        CreateArticleInput.newBuilder().title("a title").description("desc").body("body").build());
+
+    assertEquals(Collections.emptyList(), newArticleParamCaptor.getValue().getTagList());
+  }
+
+  @Test
+  public void should_reject_article_creation_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+
+    assertThrows(
+        AuthenticationException.class,
+        () -> articleMutation.createArticle(CreateArticleInput.newBuilder().build()));
+  }
+
+  @Test
+  public void should_update_owned_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), updateArticleParamCaptor.capture()))
+        .thenReturn(article);
+
+    DataFetcherResult<ArticlePayload> result =
+        articleMutation.updateArticle(
+            "a-title",
+            UpdateArticleInput.newBuilder()
+                .title("new title")
+                .body("new body")
+                .description("new desc")
+                .build());
+
+    UpdateArticleParam param = updateArticleParamCaptor.getValue();
+    assertEquals("new title", param.getTitle());
+    assertEquals("new body", param.getBody());
+    assertEquals("new desc", param.getDescription());
+    assertSame(article, result.getLocalContext());
+  }
+
+  @Test
+  public void should_throw_when_updating_unknown_article() {
+    when(articleRepository.findBySlug("missing")).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> articleMutation.updateArticle("missing", UpdateArticleInput.newBuilder().build()));
+  }
+
+  @Test
+  public void should_reject_updating_article_of_another_user() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(otherUsersArticle()));
+
+    assertThrows(
+        NoAuthorizationException.class,
+        () -> articleMutation.updateArticle("a-title", UpdateArticleInput.newBuilder().build()));
+    verify(articleCommandService, never()).updateArticle(any(), any());
+  }
+
+  @Test
+  public void should_favorite_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = otherUsersArticle();
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    ArgumentCaptor<ArticleFavorite> captor = ArgumentCaptor.forClass(ArticleFavorite.class);
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.favoriteArticle("a-title");
+
+    verify(articleFavoriteRepository).save(captor.capture());
+    assertEquals(article.getId(), captor.getValue().getArticleId());
+    assertEquals(currentUser.getId(), captor.getValue().getUserId());
+    assertSame(article, result.getLocalContext());
+  }
+
+  @Test
+  public void should_throw_when_favoriting_unknown_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleRepository.findBySlug("missing")).thenReturn(Optional.empty());
+
+    assertThrows(ResourceNotFoundException.class, () -> articleMutation.favoriteArticle("missing"));
+  }
+
+  @Test
+  public void should_reject_favoriting_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+
+    assertThrows(AuthenticationException.class, () -> articleMutation.favoriteArticle("a-title"));
+  }
+
+  @Test
+  public void should_remove_existing_favorite() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = otherUsersArticle();
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), currentUser.getId());
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(article.getId(), currentUser.getId()))
+        .thenReturn(Optional.of(favorite));
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.unfavoriteArticle("a-title");
+
+    verify(articleFavoriteRepository).remove(favorite);
+    assertSame(article, result.getLocalContext());
+  }
+
+  @Test
+  public void should_ignore_unfavorite_when_no_favorite_exists() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = otherUsersArticle();
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(article.getId(), currentUser.getId()))
+        .thenReturn(Optional.empty());
+
+    articleMutation.unfavoriteArticle("a-title");
+
+    verify(articleFavoriteRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_delete_owned_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+
+    DeletionStatus status = articleMutation.deleteArticle("a-title");
+
+    verify(articleRepository).remove(article);
+    assertTrue(status.getSuccess());
+  }
+
+  @Test
+  public void should_reject_deleting_article_of_another_user() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(otherUsersArticle()));
+
+    assertThrows(NoAuthorizationException.class, () -> articleMutation.deleteArticle("a-title"));
+    verify(articleRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_throw_when_deleting_unknown_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleRepository.findBySlug("missing")).thenReturn(Optional.empty());
+
+    assertThrows(ResourceNotFoundException.class, () -> articleMutation.deleteArticle("missing"));
+  }
+
+  private Article ownedArticle() {
+    return new Article(
+        "a title", "desc", "body", Collections.singletonList("java"), currentUser.getId());
+  }
+
+  private Article otherUsersArticle() {
+    return new Article("a title", "desc", "body", Collections.singletonList("java"), "other-id");
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,176 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.CommentsConnection;
+import java.util.Collections;
+import java.util.Map;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentDatafetcherTest {
+
+  private static final DateTime CREATED_AT = new DateTime(2021, 3, 3, 0, 0, DateTimeZone.UTC);
+
+  @Mock private CommentQueryService commentQueryService;
+  @Mock private DataFetchingEnvironment delegateEnvironment;
+
+  @Captor private ArgumentCaptor<CursorPageParameter<DateTime>> pageParameterCaptor;
+
+  @InjectMocks private CommentDatafetcher commentDatafetcher;
+
+  private final User currentUser = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_resolve_comment_payload_comment_from_local_context() {
+    when(delegateEnvironment.<CommentData>getLocalContext()).thenReturn(commentData("comment-id"));
+
+    DataFetcherResult<Comment> result = commentDatafetcher.getComment(dgsEnvironment());
+
+    assertEquals("comment-id", result.getData().getId());
+    assertEquals("comment body", result.getData().getBody());
+    assertEquals("2021-03-03T00:00:00.000Z", result.getData().getCreatedAt());
+    assertEquals("2021-03-03T00:00:00.000Z", result.getData().getUpdatedAt());
+    Map<String, CommentData> localContext = commentLocalContext(result);
+    assertTrue(localContext.containsKey("comment-id"));
+  }
+
+  @Test
+  public void should_return_article_comments_forward_page() {
+    SecurityContextHelper.authenticate(currentUser);
+    stubArticleSource();
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq("article-id"), eq(currentUser), pageParameterCaptor.capture()))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(commentData("comment-id")), Direction.NEXT, true));
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(10, "1000", null, null, dgsEnvironment());
+
+    assertEquals(Direction.NEXT, pageParameterCaptor.getValue().getDirection());
+    assertEquals(1000L, pageParameterCaptor.getValue().getCursor().getMillis());
+    assertEquals(1, result.getData().getEdges().size());
+    assertEquals("comment-id", result.getData().getEdges().get(0).getNode().getId());
+    assertEquals(
+        String.valueOf(CREATED_AT.getMillis()), result.getData().getEdges().get(0).getCursor());
+    assertTrue(result.getData().getPageInfo().isHasNextPage());
+    assertFalse(result.getData().getPageInfo().isHasPreviousPage());
+    Map<String, CommentData> localContext = commentLocalContext(result);
+    assertTrue(localContext.containsKey("comment-id"));
+  }
+
+  @Test
+  public void should_return_article_comments_backward_page_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+    stubArticleSource();
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq("article-id"), isNull(), pageParameterCaptor.capture()))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(commentData("comment-id")), Direction.PREV, true));
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(null, null, 5, null, dgsEnvironment());
+
+    assertEquals(Direction.PREV, pageParameterCaptor.getValue().getDirection());
+    assertNull(pageParameterCaptor.getValue().getCursor());
+    assertTrue(result.getData().getPageInfo().isHasPreviousPage());
+  }
+
+  @Test
+  public void should_return_empty_comments_connection_with_null_cursors() {
+    SecurityContextHelper.anonymous();
+    stubArticleSource();
+    when(commentQueryService.findByArticleIdWithCursor(
+            eq("article-id"), isNull(), pageParameterCaptor.capture()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(10, null, null, null, dgsEnvironment());
+
+    assertTrue(result.getData().getEdges().isEmpty());
+    assertNull(result.getData().getPageInfo().getStartCursor());
+    assertNull(result.getData().getPageInfo().getEndCursor());
+  }
+
+  @Test
+  public void should_reject_article_comments_without_first_or_last() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> commentDatafetcher.articleComments(null, null, null, null, dgsEnvironment()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, CommentData> commentLocalContext(DataFetcherResult<?> result) {
+    return (Map<String, CommentData>) result.getLocalContext();
+  }
+
+  private void stubArticleSource() {
+    when(delegateEnvironment.<Article>getSource())
+        .thenReturn(Article.newBuilder().slug("a-title").build());
+    when(delegateEnvironment.<Map<String, ArticleData>>getLocalContext())
+        .thenReturn(Collections.singletonMap("a-title", articleData()));
+  }
+
+  private DgsDataFetchingEnvironment dgsEnvironment() {
+    return new DgsDataFetchingEnvironment(delegateEnvironment);
+  }
+
+  private ProfileData profileData() {
+    return new ProfileData("author-id", "john", "bio", "image", false);
+  }
+
+  private CommentData commentData(String id) {
+    return new CommentData(id, "comment body", "article-id", CREATED_AT, CREATED_AT, profileData());
+  }
+
+  private ArticleData articleData() {
+    return new ArticleData(
+        "article-id",
+        "a-title",
+        "a title",
+        "desc",
+        "body",
+        false,
+        0,
+        CREATED_AT,
+        CREATED_AT,
+        Collections.singletonList("java"),
+        profileData());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,177 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.CommentQueryService;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.CommentPayload;
+import io.spring.graphql.types.DeletionStatus;
+import java.util.Collections;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentMutationTest {
+
+  @Mock private ArticleRepository articleRepository;
+  @Mock private CommentRepository commentRepository;
+  @Mock private CommentQueryService commentQueryService;
+
+  @Captor private ArgumentCaptor<Comment> commentCaptor;
+
+  @InjectMocks private CommentMutation commentMutation;
+
+  private final User currentUser = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_create_comment_on_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = ownedArticle();
+    CommentData commentData = commentData();
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(currentUser))).thenReturn(Optional.of(commentData));
+
+    DataFetcherResult<CommentPayload> result = commentMutation.createComment("a-title", "body");
+
+    verify(commentRepository).save(commentCaptor.capture());
+    assertSame(article.getId(), commentCaptor.getValue().getArticleId());
+    assertSame(currentUser.getId(), commentCaptor.getValue().getUserId());
+    assertSame(commentData, result.getLocalContext());
+  }
+
+  @Test
+  public void should_reject_comment_creation_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+
+    assertThrows(
+        AuthenticationException.class, () -> commentMutation.createComment("a-title", "body"));
+  }
+
+  @Test
+  public void should_throw_when_commenting_unknown_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleRepository.findBySlug("missing")).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class, () -> commentMutation.createComment("missing", "body"));
+  }
+
+  @Test
+  public void should_throw_when_created_comment_cannot_be_read_back() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(ownedArticle()));
+    when(commentQueryService.findById(any(), eq(currentUser))).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class, () -> commentMutation.createComment("a-title", "body"));
+  }
+
+  @Test
+  public void should_remove_own_comment() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = ownedArticle();
+    Comment comment = new Comment("body", currentUser.getId(), article.getId());
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    when(commentRepository.findById(article.getId(), comment.getId()))
+        .thenReturn(Optional.of(comment));
+
+    DeletionStatus status = commentMutation.removeComment("a-title", comment.getId());
+
+    verify(commentRepository).remove(comment);
+    assertTrue(status.getSuccess());
+  }
+
+  @Test
+  public void should_reject_removing_comment_without_authorization() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = otherUsersArticle();
+    Comment comment = new Comment("body", "another-user-id", article.getId());
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    when(commentRepository.findById(article.getId(), comment.getId()))
+        .thenReturn(Optional.of(comment));
+
+    assertThrows(
+        NoAuthorizationException.class,
+        () -> commentMutation.removeComment("a-title", comment.getId()));
+    verify(commentRepository, never()).remove(any());
+  }
+
+  @Test
+  public void should_throw_when_removing_unknown_comment() {
+    SecurityContextHelper.authenticate(currentUser);
+    Article article = ownedArticle();
+    when(articleRepository.findBySlug("a-title")).thenReturn(Optional.of(article));
+    when(commentRepository.findById(article.getId(), "missing")).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class, () -> commentMutation.removeComment("a-title", "missing"));
+  }
+
+  @Test
+  public void should_throw_when_removing_comment_of_unknown_article() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(articleRepository.findBySlug("missing")).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> commentMutation.removeComment("missing", "comment-id"));
+  }
+
+  @Test
+  public void should_reject_comment_removal_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+
+    assertThrows(
+        AuthenticationException.class,
+        () -> commentMutation.removeComment("a-title", "comment-id"));
+  }
+
+  private CommentData commentData() {
+    return new CommentData(
+        "comment-id",
+        "body",
+        "article-id",
+        new DateTime(),
+        new DateTime(),
+        new ProfileData("author-id", "jake", "bio", "image", false));
+  }
+
+  private Article ownedArticle() {
+    return new Article(
+        "a title", "desc", "body", Collections.singletonList("java"), currentUser.getId());
+  }
+
+  private Article otherUsersArticle() {
+    return new Article("a title", "desc", "body", Collections.singletonList("java"), "other-id");
+  }
+}

--- a/src/test/java/io/spring/graphql/ConstraintViolationFixture.java
+++ b/src/test/java/io/spring/graphql/ConstraintViolationFixture.java
@@ -1,0 +1,66 @@
+package io.spring.graphql;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+/**
+ * Builds real {@link ConstraintViolationException}s so the graphql error mapping can be exercised
+ * against actual bean-validation metadata instead of mocks.
+ */
+public final class ConstraintViolationFixture {
+
+  private static final Validator VALIDATOR =
+      Validation.buildDefaultValidatorFactory().getValidator();
+
+  private ConstraintViolationFixture() {}
+
+  /** Violations whose property path is a plain property name, e.g. {@code email}. */
+  public static ConstraintViolationException propertyPathViolations() {
+    Set<ConstraintViolation<RegistrationForm>> violations =
+        VALIDATOR.validate(new RegistrationForm("", "a"));
+    return new ConstraintViolationException(violations);
+  }
+
+  /** Violations whose property path is a method path, e.g. {@code register.arg0.email}. */
+  public static ConstraintViolationException methodPathViolations() {
+    try {
+      Method method = Registrar.class.getMethod("register", RegistrationForm.class);
+      Set<ConstraintViolation<Registrar>> violations =
+          VALIDATOR
+              .forExecutables()
+              .validateParameters(
+                  new Registrar(), method, new Object[] {new RegistrationForm("", "a")});
+      return new ConstraintViolationException(violations);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static class RegistrationForm {
+
+    @NotBlank(message = "can't be empty")
+    private final String username;
+
+    @Email(message = "should be an email")
+    @Size(min = 5, message = "should be at least 5 characters")
+    private final String email;
+
+    public RegistrationForm(String username, String email) {
+      this.username = username;
+      this.email = email;
+    }
+  }
+
+  public static class Registrar {
+
+    public void register(@Valid RegistrationForm form) {}
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,93 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import io.spring.graphql.types.User;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MeDatafetcherTest {
+
+  @Mock private UserQueryService userQueryService;
+  @Mock private JwtService jwtService;
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+
+  @InjectMocks private MeDatafetcher meDatafetcher;
+
+  private final io.spring.core.user.User user =
+      new io.spring.core.user.User("jake@jake.jake", "jake", "123", "bio", "image");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_return_current_user_with_token_from_authorization_header() {
+    SecurityContextHelper.authenticate(user);
+    when(userQueryService.findById(user.getId()))
+        .thenReturn(
+            Optional.of(new UserData(user.getId(), "jake@jake.jake", "jake", "bio", "image")));
+
+    DataFetcherResult<User> result =
+        meDatafetcher.getMe("Token jwt-token", dataFetchingEnvironment);
+
+    assertEquals("jake@jake.jake", result.getData().getEmail());
+    assertEquals("jake", result.getData().getUsername());
+    assertEquals("jwt-token", result.getData().getToken());
+    assertSame(user, result.getLocalContext());
+  }
+
+  @Test
+  public void should_return_null_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+
+    assertNull(meDatafetcher.getMe("Token jwt-token", dataFetchingEnvironment));
+  }
+
+  @Test
+  public void should_return_null_when_principal_is_null() {
+    SecurityContextHelper.authenticateWithNullPrincipal();
+
+    assertNull(meDatafetcher.getMe("Token jwt-token", dataFetchingEnvironment));
+  }
+
+  @Test
+  public void should_throw_when_current_user_is_not_found() {
+    SecurityContextHelper.authenticate(user);
+    when(userQueryService.findById(user.getId())).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> meDatafetcher.getMe("Token jwt-token", dataFetchingEnvironment));
+  }
+
+  @Test
+  public void should_build_user_payload_user_with_generated_token() {
+    when(dataFetchingEnvironment.<io.spring.core.user.User>getLocalContext()).thenReturn(user);
+    when(jwtService.toToken(user)).thenReturn("generated-token");
+
+    DataFetcherResult<User> result = meDatafetcher.getUserPayloadUser(dataFetchingEnvironment);
+
+    assertEquals("jake@jake.jake", result.getData().getEmail());
+    assertEquals("jake", result.getData().getUsername());
+    assertEquals("generated-token", result.getData().getToken());
+    assertSame(user, result.getLocalContext());
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,153 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.Profile;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProfileDatafetcherTest {
+
+  @Mock private ProfileQueryService profileQueryService;
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+
+  @InjectMocks private ProfileDatafetcher profileDatafetcher;
+
+  private final User currentUser = new User("jake@jake.jake", "jake", "123", "bio", "image");
+  private final ProfileData profileData =
+      new ProfileData("author-id", "john", "john's bio", "john's image", true);
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_build_profile_from_user_local_context() {
+    SecurityContextHelper.authenticate(currentUser);
+    User target = new User("john@john.com", "john", "123", "john's bio", "john's image");
+    when(dataFetchingEnvironment.<User>getLocalContext()).thenReturn(target);
+    when(profileQueryService.findByUsername("john", currentUser))
+        .thenReturn(Optional.of(profileData));
+
+    Profile profile = profileDatafetcher.getUserProfile(dataFetchingEnvironment);
+
+    assertEquals("john", profile.getUsername());
+    assertEquals("john's bio", profile.getBio());
+    assertEquals("john's image", profile.getImage());
+    assertTrue(profile.getFollowing());
+  }
+
+  @Test
+  public void should_resolve_article_author_from_local_context_map() {
+    SecurityContextHelper.anonymous();
+    ArticleData articleData = articleData("a-title");
+    Map<String, ArticleData> localContext = Collections.singletonMap("a-title", articleData);
+    when(dataFetchingEnvironment.<Map<String, ArticleData>>getLocalContext())
+        .thenReturn(localContext);
+    when(dataFetchingEnvironment.<Article>getSource())
+        .thenReturn(Article.newBuilder().slug("a-title").build());
+    when(profileQueryService.findByUsername("john", null)).thenReturn(Optional.of(profileData));
+
+    Profile profile = profileDatafetcher.getAuthor(dataFetchingEnvironment);
+
+    assertEquals("john", profile.getUsername());
+  }
+
+  @Test
+  public void should_resolve_comment_author_from_local_context_map() {
+    SecurityContextHelper.authenticate(currentUser);
+    CommentData commentData =
+        new CommentData(
+            "comment-id",
+            "comment body",
+            "article-id",
+            new DateTime(),
+            new DateTime(),
+            profileData);
+    when(dataFetchingEnvironment.<Map<String, CommentData>>getLocalContext())
+        .thenReturn(Collections.singletonMap("comment-id", commentData));
+    when(dataFetchingEnvironment.<Comment>getSource())
+        .thenReturn(Comment.newBuilder().id("comment-id").build());
+    when(profileQueryService.findByUsername("john", currentUser))
+        .thenReturn(Optional.of(profileData));
+
+    Profile profile = profileDatafetcher.getCommentAuthor(dataFetchingEnvironment);
+
+    assertEquals("john", profile.getUsername());
+  }
+
+  @Test
+  public void should_query_profile_by_username_argument() {
+    SecurityContextHelper.anonymous();
+    when(dataFetchingEnvironment.<String>getArgument("username")).thenReturn("john");
+    when(profileQueryService.findByUsername("john", null)).thenReturn(Optional.of(profileData));
+
+    ProfilePayload payload = profileDatafetcher.queryProfile("john", dataFetchingEnvironment);
+
+    assertEquals("john", payload.getProfile().getUsername());
+    assertTrue(payload.getProfile().getFollowing());
+  }
+
+  @Test
+  public void should_expose_not_following_profile() {
+    SecurityContextHelper.anonymous();
+    when(dataFetchingEnvironment.<String>getArgument("username")).thenReturn("john");
+    when(profileQueryService.findByUsername("john", null))
+        .thenReturn(Optional.of(new ProfileData("author-id", "john", null, null, false)));
+
+    ProfilePayload payload = profileDatafetcher.queryProfile("john", dataFetchingEnvironment);
+
+    assertFalse(payload.getProfile().getFollowing());
+  }
+
+  @Test
+  public void should_throw_when_profile_is_not_found() {
+    SecurityContextHelper.anonymous();
+    when(dataFetchingEnvironment.<String>getArgument("username")).thenReturn("missing");
+    when(profileQueryService.findByUsername("missing", null)).thenReturn(Optional.empty());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> profileDatafetcher.queryProfile("missing", dataFetchingEnvironment));
+  }
+
+  private ArticleData articleData(String slug) {
+    DateTime now = new DateTime();
+    return new ArticleData(
+        "article-id",
+        slug,
+        "a title",
+        "desc",
+        "body",
+        false,
+        0,
+        now,
+        now,
+        Collections.singletonList("java"),
+        profileData);
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,121 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RelationMutationTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private ProfileQueryService profileQueryService;
+
+  @Captor private ArgumentCaptor<FollowRelation> followRelationCaptor;
+
+  @InjectMocks private RelationMutation relationMutation;
+
+  private final User currentUser = new User("jake@jake.jake", "jake", "123", "bio", "image");
+  private final User target =
+      new User("john@john.com", "john", "123", "john's bio", "john's image");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_follow_target_user() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername("john", currentUser))
+        .thenReturn(Optional.of(new ProfileData(target.getId(), "john", "bio", "image", true)));
+
+    ProfilePayload payload = relationMutation.follow("john");
+
+    verify(userRepository).saveRelation(followRelationCaptor.capture());
+    assertEquals(currentUser.getId(), followRelationCaptor.getValue().getUserId());
+    assertEquals(target.getId(), followRelationCaptor.getValue().getTargetId());
+    assertEquals("john", payload.getProfile().getUsername());
+    assertTrue(payload.getProfile().getFollowing());
+  }
+
+  @Test
+  public void should_throw_when_following_unknown_user() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(userRepository.findByUsername("missing")).thenReturn(Optional.empty());
+
+    assertThrows(ResourceNotFoundException.class, () -> relationMutation.follow("missing"));
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  public void should_reject_follow_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+
+    assertThrows(AuthenticationException.class, () -> relationMutation.follow("john"));
+  }
+
+  @Test
+  public void should_unfollow_target_user() {
+    SecurityContextHelper.authenticate(currentUser);
+    FollowRelation relation = new FollowRelation(currentUser.getId(), target.getId());
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(currentUser.getId(), target.getId()))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername("john", currentUser))
+        .thenReturn(Optional.of(new ProfileData(target.getId(), "john", "bio", "image", false)));
+
+    ProfilePayload payload = relationMutation.unfollow("john");
+
+    verify(userRepository).removeRelation(relation);
+    assertEquals("john", payload.getProfile().getUsername());
+  }
+
+  @Test
+  public void should_throw_when_unfollowing_unknown_user() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(userRepository.findByUsername("missing")).thenReturn(Optional.empty());
+
+    assertThrows(ResourceNotFoundException.class, () -> relationMutation.unfollow("missing"));
+  }
+
+  @Test
+  public void should_throw_when_relation_does_not_exist() {
+    SecurityContextHelper.authenticate(currentUser);
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(currentUser.getId(), target.getId()))
+        .thenReturn(Optional.empty());
+
+    assertThrows(ResourceNotFoundException.class, () -> relationMutation.unfollow("john"));
+    verify(userRepository, never()).removeRelation(any());
+  }
+
+  @Test
+  public void should_reject_unfollow_for_anonymous_user() {
+    SecurityContextHelper.anonymous();
+
+    assertThrows(AuthenticationException.class, () -> relationMutation.unfollow("john"));
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityContextHelper.java
+++ b/src/test/java/io/spring/graphql/SecurityContextHelper.java
@@ -1,0 +1,38 @@
+package io.spring.graphql;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/** Helpers to drive the {@link SecurityContextHolder} state the graphql components read from. */
+final class SecurityContextHelper {
+
+  private SecurityContextHelper() {}
+
+  static void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  static void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "anonymous-key",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+
+  static void authenticateWithNullPrincipal() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+  }
+
+  static void clear() {
+    SecurityContextHolder.clearContext();
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,44 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.spring.core.user.User;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class SecurityUtilTest {
+
+  private final User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_return_current_user_when_authenticated() {
+    SecurityContextHelper.authenticate(user);
+
+    Optional<User> current = SecurityUtil.getCurrentUser();
+
+    assertTrue(current.isPresent());
+    assertSame(user, current.get());
+  }
+
+  @Test
+  public void should_return_empty_when_anonymous() {
+    SecurityContextHelper.anonymous();
+
+    assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+
+  @Test
+  public void should_return_empty_when_principal_is_null() {
+    SecurityContextHelper.authenticateWithNullPrincipal();
+
+    assertFalse(SecurityUtil.getCurrentUser().isPresent());
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,38 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TagDatafetcherTest {
+
+  @Mock private TagsQueryService tagsQueryService;
+
+  @InjectMocks private TagDatafetcher tagDatafetcher;
+
+  @Test
+  public void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
+
+    List<String> tags = tagDatafetcher.getTags();
+
+    assertEquals(Arrays.asList("java", "spring"), tags);
+  }
+
+  @Test
+  public void should_return_empty_list_when_no_tag_exists() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    assertEquals(Collections.emptyList(), tagDatafetcher.getTags());
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,162 @@
+package io.spring.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.application.user.UpdateUserParam;
+import io.spring.application.user.UserService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.CreateUserInput;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.ErrorItem;
+import io.spring.graphql.types.UpdateUserInput;
+import io.spring.graphql.types.UserPayload;
+import io.spring.graphql.types.UserResult;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class UserMutationTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private PasswordEncoder encryptService;
+  @Mock private UserService userService;
+
+  @Captor private ArgumentCaptor<RegisterParam> registerParamCaptor;
+  @Captor private ArgumentCaptor<UpdateUserCommand> updateUserCommandCaptor;
+
+  @InjectMocks private UserMutation userMutation;
+
+  private final User currentUser = new User("jake@jake.jake", "jake", "encoded", "bio", "image");
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHelper.clear();
+  }
+
+  @Test
+  public void should_create_user() {
+    when(userService.createUser(registerParamCaptor.capture())).thenReturn(currentUser);
+
+    DataFetcherResult<UserResult> result =
+        userMutation.createUser(
+            CreateUserInput.newBuilder()
+                .email("jake@jake.jake")
+                .username("jake")
+                .password("123")
+                .build());
+
+    assertEquals("jake@jake.jake", registerParamCaptor.getValue().getEmail());
+    assertEquals("jake", registerParamCaptor.getValue().getUsername());
+    assertEquals("123", registerParamCaptor.getValue().getPassword());
+    assertTrue(result.getData() instanceof UserPayload);
+    assertSame(currentUser, result.getLocalContext());
+  }
+
+  @Test
+  public void should_return_error_result_when_registration_is_invalid() {
+    when(userService.createUser(any()))
+        .thenThrow(ConstraintViolationFixture.propertyPathViolations());
+
+    DataFetcherResult<UserResult> result =
+        userMutation.createUser(CreateUserInput.newBuilder().build());
+
+    Error error = (Error) result.getData();
+    assertEquals("BAD_REQUEST", error.getMessage());
+    List<String> fields =
+        error.getErrors().stream().map(ErrorItem::getKey).collect(Collectors.toList());
+    assertTrue(fields.contains("email"));
+    assertTrue(fields.contains("username"));
+    assertNull(result.getLocalContext());
+  }
+
+  @Test
+  public void should_login_with_matching_password() {
+    when(userRepository.findByEmail("jake@jake.jake")).thenReturn(Optional.of(currentUser));
+    when(encryptService.matches("123", "encoded")).thenReturn(true);
+
+    DataFetcherResult<UserPayload> result = userMutation.login("123", "jake@jake.jake");
+
+    assertSame(currentUser, result.getLocalContext());
+  }
+
+  @Test
+  public void should_reject_login_with_wrong_password() {
+    when(userRepository.findByEmail("jake@jake.jake")).thenReturn(Optional.of(currentUser));
+    when(encryptService.matches("wrong", "encoded")).thenReturn(false);
+
+    assertThrows(
+        InvalidAuthenticationException.class, () -> userMutation.login("wrong", "jake@jake.jake"));
+  }
+
+  @Test
+  public void should_reject_login_of_unknown_email() {
+    when(userRepository.findByEmail("nobody@example.com")).thenReturn(Optional.empty());
+
+    assertThrows(
+        InvalidAuthenticationException.class,
+        () -> userMutation.login("123", "nobody@example.com"));
+  }
+
+  @Test
+  public void should_update_current_user() {
+    SecurityContextHelper.authenticate(currentUser);
+
+    DataFetcherResult<UserPayload> result =
+        userMutation.updateUser(
+            UpdateUserInput.newBuilder()
+                .email("new@example.com")
+                .username("new-jake")
+                .password("new-password")
+                .bio("new bio")
+                .image("new image")
+                .build());
+
+    verify(userService).updateUser(updateUserCommandCaptor.capture());
+    UpdateUserParam param = updateUserCommandCaptor.getValue().getParam();
+    assertSame(currentUser, updateUserCommandCaptor.getValue().getTargetUser());
+    assertEquals("new@example.com", param.getEmail());
+    assertEquals("new-jake", param.getUsername());
+    assertEquals("new-password", param.getPassword());
+    assertEquals("new bio", param.getBio());
+    assertEquals("new image", param.getImage());
+    assertSame(currentUser, result.getLocalContext());
+  }
+
+  @Test
+  public void should_not_update_user_for_anonymous_request() {
+    SecurityContextHelper.anonymous();
+
+    assertNull(userMutation.updateUser(UpdateUserInput.newBuilder().build()));
+    verify(userService, never()).updateUser(any());
+  }
+
+  @Test
+  public void should_not_update_user_when_principal_is_null() {
+    SecurityContextHelper.authenticateWithNullPrincipal();
+
+    assertNull(userMutation.updateUser(UpdateUserInput.newBuilder().build()));
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -1,0 +1,104 @@
+package io.spring.graphql.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.types.errors.ErrorType;
+import graphql.GraphQLError;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ResultPath;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.graphql.ConstraintViolationFixture;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.ErrorItem;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+public class GraphQLCustomizeExceptionHandlerTest {
+
+  private final GraphQLCustomizeExceptionHandler handler = new GraphQLCustomizeExceptionHandler();
+
+  @Test
+  public void should_map_invalid_authentication_to_unauthenticated_error() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new InvalidAuthenticationException()));
+
+    assertEquals(1, result.getErrors().size());
+    GraphQLError error = result.getErrors().get(0);
+    assertEquals("invalid email or password", error.getMessage());
+    assertEquals(ErrorType.UNAUTHENTICATED.name(), errorTypeOf(error));
+    assertEquals(List.of("me"), error.getPath());
+  }
+
+  @Test
+  public void should_map_constraint_violations_to_bad_request_error_with_extensions() {
+    ConstraintViolationException exception = ConstraintViolationFixture.propertyPathViolations();
+
+    DataFetcherExceptionHandlerResult result = handler.onException(parametersFor(exception));
+
+    assertEquals(1, result.getErrors().size());
+    GraphQLError error = result.getErrors().get(0);
+    assertEquals(ErrorType.BAD_REQUEST.name(), errorTypeOf(error));
+    Map<String, Object> extensions = error.getExtensions();
+    assertTrue(extensions.containsKey("email"));
+    assertTrue(extensions.containsKey("username"));
+    assertEquals(List.of("can't be empty"), extensions.get("username"));
+    assertEquals(2, ((List<?>) extensions.get("email")).size());
+  }
+
+  @Test
+  public void should_delegate_unknown_exceptions_to_the_default_handler() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new RuntimeException("boom")));
+
+    assertEquals(1, result.getErrors().size());
+    assertEquals(ErrorType.INTERNAL.name(), errorTypeOf(result.getErrors().get(0)));
+  }
+
+  @Test
+  public void should_expose_property_path_violations_as_data() {
+    Error error =
+        GraphQLCustomizeExceptionHandler.getErrorsAsData(
+            ConstraintViolationFixture.propertyPathViolations());
+
+    assertEquals("BAD_REQUEST", error.getMessage());
+    Map<String, List<String>> byKey = byKey(error);
+    assertEquals(List.of("can't be empty"), byKey.get("username"));
+    assertEquals(2, byKey.get("email").size());
+  }
+
+  @Test
+  public void should_strip_method_prefix_from_violation_paths() {
+    Error error =
+        GraphQLCustomizeExceptionHandler.getErrorsAsData(
+            ConstraintViolationFixture.methodPathViolations());
+
+    Map<String, List<String>> byKey = byKey(error);
+    assertEquals(List.of("can't be empty"), byKey.get("username"));
+    assertNotNull(byKey.get("email"));
+  }
+
+  private Map<String, List<String>> byKey(Error error) {
+    return error.getErrors().stream()
+        .collect(Collectors.toMap(ErrorItem::getKey, ErrorItem::getValue));
+  }
+
+  private String errorTypeOf(GraphQLError error) {
+    return String.valueOf(error.getExtensions().get("errorType"));
+  }
+
+  private DataFetcherExceptionHandlerParameters parametersFor(Throwable throwable) {
+    DataFetcherExceptionHandlerParameters parameters =
+        mock(DataFetcherExceptionHandlerParameters.class);
+    when(parameters.getException()).thenReturn(throwable);
+    when(parameters.getPath()).thenReturn(ResultPath.rootPath().segment("me"));
+    return parameters;
+  }
+}


### PR DESCRIPTION
## Summary

Test-only PR: the `io.spring.graphql` package (DGS datafetchers/mutations) had essentially no coverage. Adds 13 new files under `src/test/java/io/spring/graphql/` — plain Mockito unit tests, no DGS harness, no production changes.

Two things worth knowing before reading the diff:

**`DgsDataFetchingEnvironment` is `final`**, so it can't be mocked. Instead it is wrapped around a mocked delegate:

```java
@Mock private DataFetchingEnvironment delegateEnvironment;

private DgsDataFetchingEnvironment dgsEnvironment() {
  return new DgsDataFetchingEnvironment(delegateEnvironment);
}

when(delegateEnvironment.<Profile>getSource()).thenReturn(Profile.newBuilder().username("john").build());
```

**Constraint-violation mapping is exercised against real bean-validation metadata**, not mocked `ConstraintViolation`s — `GraphQLCustomizeExceptionHandler.getParam()` branches on the shape of the property path, so `ConstraintViolationFixture` produces both kinds via the standard `Validator` and its `forExecutables()` view:

- `propertyPathViolations()` → path `email` (single segment, returned as-is)
- `methodPathViolations()` → path `register.arg0.email` (method prefix stripped by `getParam`)

The fixture bean carries `@Email` + `@Size` on the same field so the multi-message-per-field path through `errorsToMap` / `getErrorsAsData` is covered too.

Auth is driven through `SecurityContextHolder` via a small `SecurityContextHelper` (`authenticate` / `anonymous` / `authenticateWithNullPrincipal` / `clear`); every test class clears the context in `@AfterEach` so nothing leaks into the rest of the suite. Both the authenticated and the anonymous/null-principal paths of `MeDatafetcher.getMe`, `UserMutation.updateUser` and `SecurityUtil` are covered, along with the `AuthenticationException` / `NoAuthorizationException` / `ResourceNotFoundException` / `IllegalArgumentException` paths of the mutations and datafetchers.

Full suite: 155 tests, 0 failures (`./gradlew test jacocoTestReport -x spotlessJava -x spotlessJavaCheck`). Formatting was applied with google-java-format 1.13.0 (matching spotless 6.2.1's default) since spotless itself can't run on JDK 17 here.

Based on `devin/1785307367-add-jacoco` (#876); GitHub will retarget to `master` once that merges.

## Coverage (instruction)

**Project total: 33.3% → 61.8%** (3477/10456 → 6462/10456)

Targeted packages:

| Package | Before | After |
|---|---|---|
| `io/spring/graphql` | 4.7% | 95.8% |
| `io/spring/graphql/exception` | 3.0% | 100.0% |

Targeted classes:

| Class | Before | After |
|---|---|---|
| `ArticleDatafetcher` | 1.4% | 100.0% |
| `ArticleMutation` | 6.2% | 100.0% |
| `CommentDatafetcher` | 3.3% | 100.0% |
| `CommentMutation` | 11.8% | 100.0% |
| `MeDatafetcher` | 10.3% | 100.0% |
| `ProfileDatafetcher` | 6.4% | 100.0% |
| `RelationMutation` | 7.8% | 100.0% |
| `SecurityUtil` | 0.0% | 85.7% |
| `TagDatafetcher` | 60.0% | 100.0% |
| `UserMutation` | 9.8% | 100.0% |
| `GraphQLCustomizeExceptionHandler` | 3.1% | 100.0% |
| `AuthenticationException` | 0.0% | 100.0% |

The residual 4.2% in `io/spring/graphql` is `DgsConstants` (codegen'd constant holders, no executable code beyond implicit constructors); `SecurityUtil`'s residual is its implicit constructor.

Incidental gains, from real (non-mocked) param/DTO objects flowing through the mutations:

| Package | Before | After |
|---|---|---|
| `io/spring/application/article` | 20.5% | 71.6% |
| `io/spring/application/user` | 52.2% | 85.2% |
| `io/spring/application` | 64.4% | 66.0% |
| `io/spring/graphql/types` (codegen) | 0.0% | 31.7% |


Link to Devin session: https://app.devin.ai/sessions/7d55b41c5af44ae7b82795cde088c9f9
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/879?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->