### PR TITLE
build: add JaCoCo coverage reporting (workstream 0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'jacoco'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
 }
@@ -58,6 +59,24 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy tasks.named('jacocoTestReport')
+}
+
+tasks.named('jacocoTestReport') {
+	dependsOn tasks.named('test')
+	reports {
+		html.required = true
+		xml.required = true
+		csv.required = false
+	}
+	// DGS codegen output (build/generated) is not hand-written source.
+	classDirectories.setFrom(files(classDirectories.files.collect {
+		fileTree(dir: it, exclude: [
+			'io/spring/graphql/types/**',
+			'io/spring/graphql/client/**',
+			'io/spring/graphql/DgsConstants*'
+		])
+	}))
 }
 
 tasks.named('clean') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 # google-java-format (used by Spotless) reflects into the JDK compiler internals,
-# which are strongly encapsulated from JDK 16 onwards.
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+# which are strongly encapsulated from JDK 16 onwards. Setting org.gradle.jvmargs
+# replaces Gradle's daemon defaults, so they are restated here.
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# google-java-format (used by Spotless) reflects into the JDK compiler internals,
+# which are strongly encapsulated from JDK 16 onwards.
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds coverage measurement so the follow-up test workstreams have a number to move. `jacocoTestReport` is wired as `finalizedBy test`, so plain `./gradlew test` now also emits HTML + XML at `build/reports/jacoco/test/`.

The report **excludes DGS codegen output** (`io/spring/graphql/types/**`, `client/**`, `DgsConstants*`). Those ~2950 instructions live in `build/generated`, are never hand-written, and can't meaningfully be covered — including them drags the headline number down by ~13pp and makes it insensitive to real test additions.

```
jacocoTestReport {
  reports { html; xml }                       // csv off
  classDirectories -= build/generated DGS types
}
test { finalizedBy jacocoTestReport }
```

### Baseline (this branch, `./gradlew test jacocoTestReport`)

| counter | coverage |
|---|---|
| instruction | **46.8%** |
| line | 53.6% |
| branch | 22.5% |
| method | 68.8% |

Largest gaps, by instruction coverage:

| package | coverage |
|---|---|
| `io.spring.graphql` | 4.9% (81/1644) |
| `io.spring.graphql.exception` | 3.0% (8/263) |
| `io.spring.application.article` | 20.5% |
| `io.spring.application.data` | 25.7% |
| `io.spring.application.user` | 52.2% |
| `io.spring.core.favorite` | 54.5% |

(For reference, *without* the generated-code exclusion the same run reports 33.3% instruction / 34.1% line.)

### Also: Spotless now runs on JDK 16+

`googleJavaFormat` reflects into `jdk.compiler` internals, which are strongly encapsulated from JDK 16 on — `./gradlew spotlessApply` died with `InvocationTargetException` on this repo's JDK 17 toolchain, which is why the enforced formatter had been getting skipped via `-x spotlessJava -x spotlessJavaCheck`. A new `gradle.properties` adds the five `--add-exports jdk.compiler/com.sun.tools.javac.*=ALL-UNNAMED` flags to `org.gradle.jvmargs`; `spotlessApply` and `spotlessCheck` both pass now.

Running the newly-working formatter surfaced one pre-existing violation on master (a long line in `DefaultJwtServiceTest`), reformatted here so `spotlessCheck` is green.

### Follow-ups

Three parallel test workstreams are in flight against this baseline: GraphQL datafetchers/mutations, `io.spring.core` domain entities, and `TagsApi` + `UserQueryService`.


Link to Devin session: https://app.devin.ai/sessions/934e3c27623c41a19affb262c9942dd8
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/888?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->