### PR TITLE
test: cover TagsApi and UserQueryService

### DIFF
--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -1,0 +1,60 @@
+package io.spring.api;
+
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.JacksonCustomizations;
+import io.spring.api.security.WebSecurityConfig;
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest({TagsApi.class})
+@Import({WebSecurityConfig.class, JacksonCustomizations.class})
+public class TagsApiTest extends TestWithCurrentUser {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    super.setUp();
+    RestAssuredMockMvc.mockMvc(mvc);
+  }
+
+  @Test
+  public void should_get_all_tags() throws Exception {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags.size()", equalTo(2))
+        .body("tags[0]", equalTo("java"))
+        .body("tags[1]", equalTo("spring"));
+  }
+
+  @Test
+  public void should_get_empty_tags() throws Exception {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", empty());
+  }
+}

--- a/src/test/java/io/spring/application/user/UserQueryServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserQueryServiceTest.java
@@ -1,0 +1,41 @@
+package io.spring.application.user;
+
+import io.spring.application.UserQueryService;
+import io.spring.application.data.UserData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import({UserQueryService.class, MyBatisUserRepository.class})
+public class UserQueryServiceTest extends DbTestBase {
+  @Autowired private UserQueryService userQueryService;
+
+  @Autowired private UserRepository userRepository;
+
+  @Test
+  public void should_fetch_user_by_id_success() {
+    User user = new User("a@test.com", "a", "123", "bio", "image");
+    userRepository.save(user);
+
+    Optional<UserData> optional = userQueryService.findById(user.getId());
+    Assertions.assertTrue(optional.isPresent());
+
+    UserData userData = optional.get();
+    Assertions.assertEquals(user.getId(), userData.getId());
+    Assertions.assertEquals(user.getEmail(), userData.getEmail());
+    Assertions.assertEquals(user.getUsername(), userData.getUsername());
+    Assertions.assertEquals(user.getBio(), userData.getBio());
+    Assertions.assertEquals(user.getImage(), userData.getImage());
+  }
+
+  @Test
+  public void should_get_empty_optional_when_user_not_found() {
+    Assertions.assertFalse(userQueryService.findById("not-exists-id").isPresent());
+  }
+}


### PR DESCRIPTION
## Summary

Workstream C of the parallel test-coverage effort: two previously untested read paths now have tests. Only new test files are added — no production code, no `build.gradle`, no existing test touched.

- `TagsApiTest` — `@WebMvcTest(TagsApi.class)` + `@Import({WebSecurityConfig.class, JacksonCustomizations.class})`, extends `TestWithCurrentUser` (supplies the `UserRepository`/`UserReadService`/`JwtService` mocks the security filter chain needs), `@MockBean TagsQueryService`. Hits `GET /tags` via `RestAssuredMockMvc` and asserts 200 plus the `tags` array for both the populated (`["java", "spring"]`) and empty-list cases.
- `UserQueryServiceTest` — `UserQueryService` lives in `io.spring.application` (not `io.spring.application.user`) and delegates to the MyBatis `UserReadService`, so this is a `DbTestBase` persistence test with `@Import({UserQueryService.class, MyBatisUserRepository.class})`: it saves a `User`, asserts every `UserData` field round-trips, and asserts `findById("not-exists-id")` yields an empty `Optional`.

Notes:
- Coverage numbers not reported — the JaCoCo config (Workstream 0) is not on `master` yet, so `jacocoTestReport` isn't available on this branch.
- `./gradlew spotlessApply` fails on this box with `java.lang.reflect.InvocationTargetException` under JDK 17, so both files were formatted manually to google-java-format style (2-space indent, no wildcard imports).
- `./gradlew test -x spotlessJava -x spotlessJavaCheck` passes for the full suite.


Link to Devin session: https://app.devin.ai/sessions/1883c2338beb4496935df129d6ac23d8
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/889?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->