### PR TITLE
test: cover io.spring.graphql datafetchers, mutations and exception handler

### DIFF
--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,368 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.TestHelper;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.core.article.Article;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.ArticlesConnection;
+import io.spring.graphql.types.Profile;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleDatafetcherTest extends GraphqlTestBase {
+
+  @Mock private ArticleQueryService articleQueryService;
+  @Mock private UserRepository userRepository;
+
+  @Captor private ArgumentCaptor<CursorPageParameter<DateTime>> pageCaptor;
+
+  @InjectMocks private ArticleDatafetcher articleDatafetcher;
+
+  private User user;
+  private ArticleData articleData;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    articleData = TestHelper.articleDataFixture("1", user);
+  }
+
+  private CursorPager<ArticleData> pagerOf(ArticleData... articles) {
+    return new CursorPager<>(Arrays.asList(articles), Direction.NEXT, true);
+  }
+
+  @Test
+  void should_get_feed_of_current_user_forward() {
+    login(user);
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(pagerOf(articleData));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(10, "1000", null, null, dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+    assertThat(result.getData().getEdges().get(0).getNode().getSlug())
+        .isEqualTo(articleData.getSlug());
+    assertThat(result.getData().getEdges().get(0).getCursor())
+        .isEqualTo(articleData.getCursor().toString());
+    assertThat(result.getData().getPageInfo().isHasNextPage()).isTrue();
+    assertThat(result.getData().getPageInfo().isHasPreviousPage()).isFalse();
+    Map<String, ArticleData> localContext = asMap(result.getLocalContext());
+    assertThat(localContext).containsEntry(articleData.getSlug(), articleData);
+
+    verify(articleQueryService).findUserFeedWithCursor(eq(user), pageCaptor.capture());
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.NEXT);
+    assertThat(pageCaptor.getValue().getLimit()).isEqualTo(10);
+    assertThat(pageCaptor.getValue().getCursor().getMillis()).isEqualTo(1000L);
+  }
+
+  @Test
+  void should_get_feed_of_current_user_backward() {
+    login(user);
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData), Direction.PREV, true));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(null, null, 5, "2000", dgsEnvironment);
+
+    assertThat(result.getData().getPageInfo().isHasPreviousPage()).isTrue();
+    verify(articleQueryService).findUserFeedWithCursor(eq(user), pageCaptor.capture());
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageCaptor.getValue().getCursor().getMillis()).isEqualTo(2000L);
+  }
+
+  @Test
+  void should_read_feed_as_anonymous_user() {
+    logout();
+    when(articleQueryService.findUserFeedWithCursor(isNull(), any()))
+        .thenReturn(pagerOf(articleData));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getFeed(10, null, null, null, dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_reject_feed_without_first_or_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> articleDatafetcher.getFeed(null, null, null, null, dgsEnvironment));
+  }
+
+  @Test
+  void should_get_feed_of_a_profile() {
+    when(environment.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(userRepository.findByUsername("johnjacob")).thenReturn(Optional.of(user));
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(pagerOf(articleData));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userFeed(10, null, null, null, dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_get_feed_of_a_profile_backward() {
+    when(environment.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(userRepository.findByUsername("johnjacob")).thenReturn(Optional.of(user));
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(pagerOf(articleData));
+
+    articleDatafetcher.userFeed(null, null, 5, null, dgsEnvironment);
+
+    verify(articleQueryService).findUserFeedWithCursor(eq(user), pageCaptor.capture());
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.PREV);
+  }
+
+  @Test
+  void should_fail_profile_feed_when_user_not_found() {
+    when(environment.getSource()).thenReturn(Profile.newBuilder().username("unknown").build());
+    when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleDatafetcher.userFeed(10, null, null, null, dgsEnvironment));
+  }
+
+  @Test
+  void should_reject_profile_feed_without_first_or_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> articleDatafetcher.userFeed(null, null, null, null, dgsEnvironment));
+  }
+
+  @Test
+  void should_get_favorites_of_a_profile() {
+    login(user);
+    when(environment.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), eq("johnjacob"), any(), eq(user)))
+        .thenReturn(pagerOf(articleData));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userFavorites(10, null, null, null, dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_get_favorites_of_a_profile_backward() {
+    login(user);
+    when(environment.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), eq("johnjacob"), any(), eq(user)))
+        .thenReturn(pagerOf(articleData));
+
+    articleDatafetcher.userFavorites(null, null, 5, "3000", dgsEnvironment);
+
+    verify(articleQueryService)
+        .findRecentArticlesWithCursor(
+            isNull(), isNull(), eq("johnjacob"), pageCaptor.capture(), eq(user));
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageCaptor.getValue().getCursor().getMillis()).isEqualTo(3000L);
+  }
+
+  @Test
+  void should_reject_favorites_without_first_or_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> articleDatafetcher.userFavorites(null, null, null, null, dgsEnvironment));
+  }
+
+  @Test
+  void should_get_articles_of_a_profile() {
+    login(user);
+    when(environment.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), eq("johnjacob"), isNull(), any(), eq(user)))
+        .thenReturn(pagerOf(articleData));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.userArticles(10, null, null, null, dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+  }
+
+  @Test
+  void should_get_articles_of_a_profile_backward() {
+    login(user);
+    when(environment.getSource()).thenReturn(Profile.newBuilder().username("johnjacob").build());
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), eq("johnjacob"), isNull(), any(), eq(user)))
+        .thenReturn(pagerOf(articleData));
+
+    articleDatafetcher.userArticles(null, null, 5, null, dgsEnvironment);
+
+    verify(articleQueryService)
+        .findRecentArticlesWithCursor(
+            isNull(), eq("johnjacob"), isNull(), pageCaptor.capture(), eq(user));
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.PREV);
+  }
+
+  @Test
+  void should_reject_profile_articles_without_first_or_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> articleDatafetcher.userArticles(null, null, null, null, dgsEnvironment));
+  }
+
+  @Test
+  void should_get_articles_with_filters() {
+    login(user);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            eq("joda"), eq("johnjacob"), eq("someone"), any(), eq(user)))
+        .thenReturn(pagerOf(articleData));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getArticles(
+            10, null, null, null, "johnjacob", "someone", "joda", dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+    assertThat(result.getData().getPageInfo().getStartCursor().getValue())
+        .isEqualTo(articleData.getCursor().toString());
+  }
+
+  @Test
+  void should_get_articles_backward() {
+    login(user);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), isNull(), any(), eq(user)))
+        .thenReturn(pagerOf(articleData));
+
+    articleDatafetcher.getArticles(null, null, 5, "4000", null, null, null, dgsEnvironment);
+
+    verify(articleQueryService)
+        .findRecentArticlesWithCursor(isNull(), isNull(), isNull(), pageCaptor.capture(), eq(user));
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageCaptor.getValue().getCursor().getMillis()).isEqualTo(4000L);
+  }
+
+  @Test
+  void should_get_empty_articles_page() {
+    login(user);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), isNull(), any(), eq(user)))
+        .thenReturn(new CursorPager<>(new ArrayList<>(), Direction.NEXT, false));
+
+    DataFetcherResult<ArticlesConnection> result =
+        articleDatafetcher.getArticles(10, null, null, null, null, null, null, dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).isEmpty();
+    assertThat(result.getData().getPageInfo().getStartCursor()).isNull();
+    assertThat(result.getData().getPageInfo().getEndCursor()).isNull();
+    assertThat(result.getData().getPageInfo().isHasNextPage()).isFalse();
+  }
+
+  @Test
+  void should_reject_articles_without_first_or_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                articleDatafetcher.getArticles(
+                    null, null, null, null, null, null, null, dgsEnvironment));
+  }
+
+  @Test
+  void should_get_article_of_a_payload() {
+    login(user);
+    Article article =
+        new Article("title", "desc", "body", Arrays.asList("joda"), user.getId(), new DateTime());
+    when(environment.<Article>getLocalContext()).thenReturn(article);
+    when(articleQueryService.findById(article.getId(), user)).thenReturn(Optional.of(articleData));
+
+    DataFetcherResult<io.spring.graphql.types.Article> result =
+        articleDatafetcher.getArticle(environment);
+
+    assertThat(result.getData().getSlug()).isEqualTo(articleData.getSlug());
+    assertThat(result.getData().getTitle()).isEqualTo(articleData.getTitle());
+    Map<String, ArticleData> localContext = asMap(result.getLocalContext());
+    assertThat(localContext).containsEntry(articleData.getSlug(), articleData);
+  }
+
+  @Test
+  void should_fail_article_of_a_payload_when_not_found() {
+    login(user);
+    Article article =
+        new Article("title", "desc", "body", Arrays.asList("joda"), user.getId(), new DateTime());
+    when(environment.<Article>getLocalContext()).thenReturn(article);
+    when(articleQueryService.findById(article.getId(), user)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleDatafetcher.getArticle(environment));
+  }
+
+  @Test
+  void should_get_article_of_a_comment() {
+    login(user);
+    CommentData comment =
+        new CommentData("comment-id", "body", "article-id", new DateTime(), new DateTime(), null);
+    when(environment.<CommentData>getLocalContext()).thenReturn(comment);
+    when(articleQueryService.findById("article-id", user)).thenReturn(Optional.of(articleData));
+
+    DataFetcherResult<io.spring.graphql.types.Article> result =
+        articleDatafetcher.getCommentArticle(environment);
+
+    assertThat(result.getData().getSlug()).isEqualTo(articleData.getSlug());
+  }
+
+  @Test
+  void should_fail_article_of_a_comment_when_not_found() {
+    login(user);
+    CommentData comment =
+        new CommentData("comment-id", "body", "article-id", new DateTime(), new DateTime(), null);
+    when(environment.<CommentData>getLocalContext()).thenReturn(comment);
+    when(articleQueryService.findById("article-id", user)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleDatafetcher.getCommentArticle(environment));
+  }
+
+  @Test
+  void should_find_article_by_slug() {
+    login(user);
+    when(articleQueryService.findBySlug(articleData.getSlug(), user))
+        .thenReturn(Optional.of(articleData));
+
+    DataFetcherResult<io.spring.graphql.types.Article> result =
+        articleDatafetcher.findArticleBySlug(articleData.getSlug());
+
+    assertThat(result.getData().getBody()).isEqualTo(articleData.getBody());
+    assertThat(result.getData().getFavoritesCount()).isEqualTo(articleData.getFavoritesCount());
+  }
+
+  @Test
+  void should_fail_find_article_by_slug_when_not_found() {
+    logout();
+    when(articleQueryService.findBySlug("unknown", null)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleDatafetcher.findArticleBySlug("unknown"));
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,235 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.article.UpdateArticleParam;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ArticlePayload;
+import io.spring.graphql.types.CreateArticleInput;
+import io.spring.graphql.types.DeletionStatus;
+import io.spring.graphql.types.UpdateArticleInput;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleMutationTest extends GraphqlTestBase {
+
+  @Mock private ArticleCommandService articleCommandService;
+  @Mock private ArticleFavoriteRepository articleFavoriteRepository;
+  @Mock private ArticleRepository articleRepository;
+
+  @Captor private ArgumentCaptor<NewArticleParam> newArticleParamCaptor;
+  @Captor private ArgumentCaptor<UpdateArticleParam> updateArticleParamCaptor;
+
+  @InjectMocks private ArticleMutation articleMutation;
+
+  private User user;
+  private Article article;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    article = new Article("title", "desc", "body", Arrays.asList("joda"), user.getId());
+  }
+
+  @Test
+  void should_create_article() {
+    login(user);
+    CreateArticleInput input =
+        CreateArticleInput.newBuilder()
+            .title("title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("joda"))
+            .build();
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(user)))
+        .thenReturn(article);
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.createArticle(input);
+
+    assertThat((Article) result.getLocalContext()).isEqualTo(article);
+    verify(articleCommandService).createArticle(newArticleParamCaptor.capture(), eq(user));
+    assertThat(newArticleParamCaptor.getValue().getTitle()).isEqualTo("title");
+    assertThat(newArticleParamCaptor.getValue().getTagList()).containsExactly("joda");
+  }
+
+  @Test
+  void should_create_article_without_tags() {
+    login(user);
+    CreateArticleInput input =
+        CreateArticleInput.newBuilder().title("title").description("desc").body("body").build();
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(user)))
+        .thenReturn(article);
+
+    articleMutation.createArticle(input);
+
+    verify(articleCommandService).createArticle(newArticleParamCaptor.capture(), eq(user));
+    assertThat(newArticleParamCaptor.getValue().getTagList()).isEmpty();
+  }
+
+  @Test
+  void should_not_create_article_without_login() {
+    logout();
+
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> articleMutation.createArticle(CreateArticleInput.newBuilder().build()));
+  }
+
+  @Test
+  void should_update_article() {
+    login(user);
+    UpdateArticleInput changes =
+        UpdateArticleInput.newBuilder()
+            .title("new title")
+            .body("new body")
+            .description("new desc")
+            .build();
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any(UpdateArticleParam.class)))
+        .thenReturn(article);
+
+    DataFetcherResult<ArticlePayload> result =
+        articleMutation.updateArticle(article.getSlug(), changes);
+
+    assertThat((Article) result.getLocalContext()).isEqualTo(article);
+    verify(articleCommandService).updateArticle(eq(article), updateArticleParamCaptor.capture());
+    assertThat(updateArticleParamCaptor.getValue().getTitle()).isEqualTo("new title");
+    assertThat(updateArticleParamCaptor.getValue().getBody()).isEqualTo("new body");
+    assertThat(updateArticleParamCaptor.getValue().getDescription()).isEqualTo("new desc");
+  }
+
+  @Test
+  void should_not_update_article_of_other_user() {
+    User other = new User("other@test.com", "other", "123", "", "");
+    login(other);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+
+    assertThatExceptionOfType(NoAuthorizationException.class)
+        .isThrownBy(
+            () ->
+                articleMutation.updateArticle(
+                    article.getSlug(), UpdateArticleInput.newBuilder().build()));
+  }
+
+  @Test
+  void should_not_update_missing_article() {
+    when(articleRepository.findBySlug("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(
+            () ->
+                articleMutation.updateArticle("unknown", UpdateArticleInput.newBuilder().build()));
+  }
+
+  @Test
+  void should_favorite_article() {
+    login(user);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.favoriteArticle(article.getSlug());
+
+    assertThat((Article) result.getLocalContext()).isEqualTo(article);
+    ArgumentCaptor<ArticleFavorite> captor = ArgumentCaptor.forClass(ArticleFavorite.class);
+    verify(articleFavoriteRepository).save(captor.capture());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+  }
+
+  @Test
+  void should_not_favorite_missing_article() {
+    login(user);
+    when(articleRepository.findBySlug("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleMutation.favoriteArticle("unknown"));
+  }
+
+  @Test
+  void should_not_favorite_article_without_login() {
+    logout();
+
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> articleMutation.favoriteArticle("slug"));
+  }
+
+  @Test
+  void should_unfavorite_article() {
+    login(user);
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), user.getId());
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(article.getId(), user.getId()))
+        .thenReturn(Optional.of(favorite));
+
+    DataFetcherResult<ArticlePayload> result = articleMutation.unfavoriteArticle(article.getSlug());
+
+    assertThat((Article) result.getLocalContext()).isEqualTo(article);
+    verify(articleFavoriteRepository).remove(favorite);
+  }
+
+  @Test
+  void should_ignore_unfavorite_when_article_is_not_favorited() {
+    login(user);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(article.getId(), user.getId()))
+        .thenReturn(Optional.empty());
+
+    articleMutation.unfavoriteArticle(article.getSlug());
+
+    verify(articleFavoriteRepository, never()).remove(any(ArticleFavorite.class));
+  }
+
+  @Test
+  void should_delete_article() {
+    login(user);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+
+    DeletionStatus status = articleMutation.deleteArticle(article.getSlug());
+
+    assertThat(status.getSuccess()).isTrue();
+    verify(articleRepository).remove(article);
+  }
+
+  @Test
+  void should_not_delete_article_of_other_user() {
+    User other = new User("other@test.com", "other", "123", "", "");
+    login(other);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+
+    assertThatExceptionOfType(NoAuthorizationException.class)
+        .isThrownBy(() -> articleMutation.deleteArticle(article.getSlug()));
+    verify(articleRepository, never()).remove(any(Article.class));
+  }
+
+  @Test
+  void should_not_delete_missing_article() {
+    login(user);
+    when(articleRepository.findBySlug("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> articleMutation.deleteArticle("unknown"));
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,135 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.TestHelper;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.CommentsConnection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentDatafetcherTest extends GraphqlTestBase {
+
+  @Mock private CommentQueryService commentQueryService;
+
+  @Captor private ArgumentCaptor<CursorPageParameter<DateTime>> pageCaptor;
+
+  @InjectMocks private CommentDatafetcher commentDatafetcher;
+
+  private User user;
+  private ArticleData articleData;
+  private CommentData commentData;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    articleData = TestHelper.articleDataFixture("1", user);
+    commentData =
+        new CommentData(
+            "comment-id",
+            "comment body",
+            articleData.getId(),
+            new DateTime(),
+            new DateTime(),
+            new ProfileData(user.getId(), user.getUsername(), "", "", false));
+  }
+
+  private void sourceArticle() {
+    Map<String, ArticleData> localContext = new HashMap<>();
+    localContext.put(articleData.getSlug(), articleData);
+    when(environment.getSource())
+        .thenReturn(Article.newBuilder().slug(articleData.getSlug()).build());
+    when(environment.<Map<String, ArticleData>>getLocalContext()).thenReturn(localContext);
+  }
+
+  @Test
+  void should_build_comment_of_a_payload() {
+    when(environment.<CommentData>getLocalContext()).thenReturn(commentData);
+
+    DataFetcherResult<Comment> result = commentDatafetcher.getComment(dgsEnvironment);
+
+    assertThat(result.getData().getId()).isEqualTo(commentData.getId());
+    assertThat(result.getData().getBody()).isEqualTo(commentData.getBody());
+    Map<String, CommentData> localContext = asMap(result.getLocalContext());
+    assertThat(localContext).containsEntry(commentData.getId(), commentData);
+  }
+
+  @Test
+  void should_get_comments_of_an_article_forward() {
+    login(user);
+    sourceArticle();
+    when(commentQueryService.findByArticleIdWithCursor(eq(articleData.getId()), eq(user), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(commentData), Direction.NEXT, true));
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(10, "1000", null, null, dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).hasSize(1);
+    assertThat(result.getData().getEdges().get(0).getNode().getBody())
+        .isEqualTo(commentData.getBody());
+    assertThat(result.getData().getPageInfo().isHasNextPage()).isTrue();
+    Map<String, CommentData> localContext = asMap(result.getLocalContext());
+    assertThat(localContext).containsEntry(commentData.getId(), commentData);
+
+    verify(commentQueryService)
+        .findByArticleIdWithCursor(eq(articleData.getId()), eq(user), pageCaptor.capture());
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.NEXT);
+    assertThat(pageCaptor.getValue().getCursor().getMillis()).isEqualTo(1000L);
+  }
+
+  @Test
+  void should_get_comments_of_an_article_backward_as_anonymous_user() {
+    logout();
+    sourceArticle();
+    when(commentQueryService.findByArticleIdWithCursor(eq(articleData.getId()), isNull(), any()))
+        .thenReturn(new CursorPager<>(new ArrayList<>(), Direction.PREV, false));
+
+    DataFetcherResult<CommentsConnection> result =
+        commentDatafetcher.articleComments(null, null, 5, "2000", dgsEnvironment);
+
+    assertThat(result.getData().getEdges()).isEmpty();
+    assertThat(result.getData().getPageInfo().getStartCursor()).isNull();
+    assertThat(result.getData().getPageInfo().getEndCursor()).isNull();
+
+    verify(commentQueryService)
+        .findByArticleIdWithCursor(eq(articleData.getId()), isNull(), pageCaptor.capture());
+    assertThat(pageCaptor.getValue().getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageCaptor.getValue().getCursor().getMillis()).isEqualTo(2000L);
+  }
+
+  @Test
+  void should_reject_comments_without_first_or_last() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> commentDatafetcher.articleComments(null, null, null, null, dgsEnvironment));
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,155 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.CommentQueryService;
+import io.spring.application.data.CommentData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.CommentPayload;
+import io.spring.graphql.types.DeletionStatus;
+import java.util.Arrays;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentMutationTest extends GraphqlTestBase {
+
+  @Mock private ArticleRepository articleRepository;
+  @Mock private CommentRepository commentRepository;
+  @Mock private CommentQueryService commentQueryService;
+
+  @InjectMocks private CommentMutation commentMutation;
+
+  private User user;
+  private Article article;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    article = new Article("title", "desc", "body", Arrays.asList("joda"), user.getId());
+  }
+
+  @Test
+  void should_create_comment() {
+    login(user);
+    CommentData commentData =
+        new CommentData(
+            "id", "comment body", article.getId(), new DateTime(), new DateTime(), null);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(String.class), eq(user)))
+        .thenReturn(Optional.of(commentData));
+
+    DataFetcherResult<CommentPayload> result =
+        commentMutation.createComment(article.getSlug(), "comment body");
+
+    assertThat((CommentData) result.getLocalContext()).isEqualTo(commentData);
+    ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+    verify(commentRepository).save(captor.capture());
+    assertThat(captor.getValue().getBody()).isEqualTo("comment body");
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+  }
+
+  @Test
+  void should_not_create_comment_without_login() {
+    logout();
+
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> commentMutation.createComment("slug", "body"));
+  }
+
+  @Test
+  void should_not_create_comment_on_missing_article() {
+    login(user);
+    when(articleRepository.findBySlug("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.createComment("unknown", "body"));
+  }
+
+  @Test
+  void should_fail_when_created_comment_cannot_be_read_back() {
+    login(user);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(String.class), eq(user))).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.createComment(article.getSlug(), "body"));
+  }
+
+  @Test
+  void should_remove_own_comment() {
+    login(user);
+    Comment comment = new Comment("body", user.getId(), article.getId());
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(commentRepository.findById(article.getId(), comment.getId()))
+        .thenReturn(Optional.of(comment));
+
+    DeletionStatus status = commentMutation.removeComment(article.getSlug(), comment.getId());
+
+    assertThat(status.getSuccess()).isTrue();
+    verify(commentRepository).remove(comment);
+  }
+
+  @Test
+  void should_not_remove_comment_of_other_user() {
+    User other = new User("other@test.com", "other", "123", "", "");
+    login(other);
+    Comment comment = new Comment("body", user.getId(), article.getId());
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(commentRepository.findById(article.getId(), comment.getId()))
+        .thenReturn(Optional.of(comment));
+
+    assertThatExceptionOfType(NoAuthorizationException.class)
+        .isThrownBy(() -> commentMutation.removeComment(article.getSlug(), comment.getId()));
+    verify(commentRepository, never()).remove(any(Comment.class));
+  }
+
+  @Test
+  void should_not_remove_missing_comment() {
+    login(user);
+    when(articleRepository.findBySlug(article.getSlug())).thenReturn(Optional.of(article));
+    when(commentRepository.findById(article.getId(), "unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.removeComment(article.getSlug(), "unknown"));
+  }
+
+  @Test
+  void should_not_remove_comment_of_missing_article() {
+    login(user);
+    when(articleRepository.findBySlug("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> commentMutation.removeComment("unknown", "comment-id"));
+  }
+
+  @Test
+  void should_not_remove_comment_without_login() {
+    logout();
+
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> commentMutation.removeComment("slug", "comment-id"));
+  }
+}

--- a/src/test/java/io/spring/graphql/ConstraintViolationFixture.java
+++ b/src/test/java/io/spring/graphql/ConstraintViolationFixture.java
@@ -1,0 +1,64 @@
+package io.spring.graphql;
+
+import java.lang.reflect.Method;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+/** Builds real bean validation failures, so tests exercise the actual violation metadata. */
+public final class ConstraintViolationFixture {
+
+  private static final Validator VALIDATOR =
+      Validation.buildDefaultValidatorFactory().getValidator();
+
+  private ConstraintViolationFixture() {}
+
+  /** Violations with a single path segment, as produced by validating a bean directly. */
+  public static javax.validation.ConstraintViolationException beanViolations() {
+    return new javax.validation.ConstraintViolationException(
+        VALIDATOR.validate(new NewUser("", "not-an-email")));
+  }
+
+  /** Violations with a nested path, as produced by validating the parameters of a service call. */
+  public static javax.validation.ConstraintViolationException methodParameterViolations() {
+    try {
+      Method method = Service.class.getMethod("register", NewUser.class);
+      return new javax.validation.ConstraintViolationException(
+          VALIDATOR
+              .forExecutables()
+              .validateParameters(
+                  new Service(), method, new Object[] {new NewUser("", "not-an-email")}));
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static class NewUser {
+    @NotBlank(message = "can't be empty")
+    @Size(min = 3, message = "too short")
+    private final String username;
+
+    @Email(message = "should be an email")
+    private final String email;
+
+    public NewUser(String username, String email) {
+      this.username = username;
+      this.email = email;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+  }
+
+  public static class Service {
+    public void register(@Valid NewUser newUser) {}
+  }
+}

--- a/src/test/java/io/spring/graphql/GraphqlTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphqlTestBase.java
@@ -1,0 +1,49 @@
+package io.spring.graphql;
+
+import static org.mockito.Mockito.mock;
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/** Shared security context and DGS environment plumbing for the graphql layer unit tests. */
+abstract class GraphqlTestBase {
+
+  protected DataFetchingEnvironment environment;
+  protected DgsDataFetchingEnvironment dgsEnvironment;
+
+  protected GraphqlTestBase() {
+    environment = mock(DataFetchingEnvironment.class);
+    dgsEnvironment = new DgsDataFetchingEnvironment(environment);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected static <K, V> Map<K, V> asMap(Object localContext) {
+    return (Map<K, V>) localContext;
+  }
+
+  protected void login(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  protected void logout() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,81 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeDatafetcherTest extends GraphqlTestBase {
+
+  @Mock private UserQueryService userQueryService;
+  @Mock private JwtService jwtService;
+
+  @InjectMocks private MeDatafetcher meDatafetcher;
+
+  private User user;
+  private UserData userData;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "bio", "image");
+    userData = new UserData(user.getId(), user.getEmail(), user.getUsername(), "bio", "image");
+  }
+
+  @Test
+  void should_get_current_user_with_the_token_of_the_request() {
+    login(user);
+    when(userQueryService.findById(user.getId())).thenReturn(Optional.of(userData));
+
+    DataFetcherResult<io.spring.graphql.types.User> result =
+        meDatafetcher.getMe("Token jwt-token", environment);
+
+    assertThat(result.getData().getEmail()).isEqualTo(user.getEmail());
+    assertThat(result.getData().getUsername()).isEqualTo(user.getUsername());
+    assertThat(result.getData().getToken()).isEqualTo("jwt-token");
+    assertThat((User) result.getLocalContext()).isEqualTo(user);
+  }
+
+  @Test
+  void should_get_null_when_anonymous() {
+    logout();
+
+    assertThat(meDatafetcher.getMe("Token jwt-token", environment)).isNull();
+  }
+
+  @Test
+  void should_fail_when_current_user_is_gone() {
+    login(user);
+    when(userQueryService.findById(user.getId())).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> meDatafetcher.getMe("Token jwt-token", environment));
+  }
+
+  @Test
+  void should_build_user_payload_with_a_fresh_token() {
+    when(environment.<User>getLocalContext()).thenReturn(user);
+    when(jwtService.toToken(user)).thenReturn("new-token");
+
+    DataFetcherResult<io.spring.graphql.types.User> result =
+        meDatafetcher.getUserPayloadUser(environment);
+
+    assertThat(result.getData().getEmail()).isEqualTo(user.getEmail());
+    assertThat(result.getData().getUsername()).isEqualTo(user.getUsername());
+    assertThat(result.getData().getToken()).isEqualTo("new-token");
+    assertThat((User) result.getLocalContext()).isEqualTo(user);
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,124 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Article;
+import io.spring.graphql.types.Comment;
+import io.spring.graphql.types.Profile;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileDatafetcherTest extends GraphqlTestBase {
+
+  @Mock private ProfileQueryService profileQueryService;
+
+  @InjectMocks private ProfileDatafetcher profileDatafetcher;
+
+  private User user;
+  private ProfileData profileData;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "bio", "image");
+    profileData = new ProfileData(user.getId(), user.getUsername(), "bio", "image", true);
+  }
+
+  @Test
+  void should_get_profile_of_a_user() {
+    login(user);
+    when(environment.<User>getLocalContext()).thenReturn(user);
+    when(profileQueryService.findByUsername(user.getUsername(), user))
+        .thenReturn(Optional.of(profileData));
+
+    Profile profile = profileDatafetcher.getUserProfile(environment);
+
+    assertThat(profile.getUsername()).isEqualTo(user.getUsername());
+    assertThat(profile.getBio()).isEqualTo("bio");
+    assertThat(profile.getImage()).isEqualTo("image");
+    assertThat(profile.getFollowing()).isTrue();
+  }
+
+  @Test
+  void should_get_author_of_an_article() {
+    logout();
+    ArticleData articleData =
+        new ArticleData(
+            "id",
+            "slug",
+            "title",
+            "desc",
+            "body",
+            false,
+            0,
+            new DateTime(),
+            new DateTime(),
+            null,
+            profileData);
+    Map<String, ArticleData> localContext = new HashMap<>();
+    localContext.put("slug", articleData);
+    when(environment.<Map<String, ArticleData>>getLocalContext()).thenReturn(localContext);
+    when(environment.getSource()).thenReturn(Article.newBuilder().slug("slug").build());
+    when(profileQueryService.findByUsername(user.getUsername(), null))
+        .thenReturn(Optional.of(profileData));
+
+    assertThat(profileDatafetcher.getAuthor(environment).getUsername())
+        .isEqualTo(user.getUsername());
+  }
+
+  @Test
+  void should_get_author_of_a_comment() {
+    logout();
+    CommentData commentData =
+        new CommentData(
+            "comment-id", "body", "article-id", new DateTime(), new DateTime(), profileData);
+    Map<String, CommentData> localContext = new HashMap<>();
+    localContext.put("comment-id", commentData);
+    when(environment.<Map<String, CommentData>>getLocalContext()).thenReturn(localContext);
+    when(environment.getSource()).thenReturn(Comment.newBuilder().id("comment-id").build());
+    when(profileQueryService.findByUsername(user.getUsername(), null))
+        .thenReturn(Optional.of(profileData));
+
+    assertThat(profileDatafetcher.getCommentAuthor(environment).getUsername())
+        .isEqualTo(user.getUsername());
+  }
+
+  @Test
+  void should_query_profile_by_username() {
+    login(user);
+    when(environment.<String>getArgument("username")).thenReturn(user.getUsername());
+    when(profileQueryService.findByUsername(user.getUsername(), user))
+        .thenReturn(Optional.of(profileData));
+
+    ProfilePayload payload = profileDatafetcher.queryProfile(user.getUsername(), environment);
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo(user.getUsername());
+  }
+
+  @Test
+  void should_fail_when_profile_not_found() {
+    logout();
+    when(environment.<String>getArgument("username")).thenReturn("unknown");
+    when(profileQueryService.findByUsername("unknown", null)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> profileDatafetcher.queryProfile("unknown", environment));
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,122 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.api.exception.ResourceNotFoundException;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.types.ProfilePayload;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RelationMutationTest extends GraphqlTestBase {
+
+  @Mock private UserRepository userRepository;
+  @Mock private ProfileQueryService profileQueryService;
+
+  @InjectMocks private RelationMutation relationMutation;
+
+  private User user;
+  private User target;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    target = new User("target@test.com", "target", "123", "bio", "image");
+  }
+
+  @Test
+  void should_follow_user() {
+    login(user);
+    when(userRepository.findByUsername("target")).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername("target", user))
+        .thenReturn(Optional.of(new ProfileData(target.getId(), "target", "bio", "image", true)));
+
+    ProfilePayload payload = relationMutation.follow("target");
+
+    assertThat(payload.getProfile().getUsername()).isEqualTo("target");
+    assertThat(payload.getProfile().getFollowing()).isTrue();
+    ArgumentCaptor<FollowRelation> captor = ArgumentCaptor.forClass(FollowRelation.class);
+    verify(userRepository).saveRelation(captor.capture());
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().getTargetId()).isEqualTo(target.getId());
+  }
+
+  @Test
+  void should_not_follow_missing_user() {
+    login(user);
+    when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> relationMutation.follow("unknown"));
+    verify(userRepository, never()).saveRelation(any(FollowRelation.class));
+  }
+
+  @Test
+  void should_not_follow_without_login() {
+    logout();
+
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> relationMutation.follow("target"));
+  }
+
+  @Test
+  void should_unfollow_user() {
+    login(user);
+    FollowRelation relation = new FollowRelation(user.getId(), target.getId());
+    when(userRepository.findByUsername("target")).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(user.getId(), target.getId()))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername("target", user))
+        .thenReturn(Optional.of(new ProfileData(target.getId(), "target", "bio", "image", false)));
+
+    ProfilePayload payload = relationMutation.unfollow("target");
+
+    assertThat(payload.getProfile().getFollowing()).isFalse();
+    verify(userRepository).removeRelation(relation);
+  }
+
+  @Test
+  void should_not_unfollow_missing_user() {
+    login(user);
+    when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> relationMutation.unfollow("unknown"));
+  }
+
+  @Test
+  void should_not_unfollow_user_without_relation() {
+    login(user);
+    when(userRepository.findByUsername("target")).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(user.getId(), target.getId())).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ResourceNotFoundException.class)
+        .isThrownBy(() -> relationMutation.unfollow("target"));
+    verify(userRepository, never()).removeRelation(any(FollowRelation.class));
+  }
+
+  @Test
+  void should_not_unfollow_without_login() {
+    logout();
+
+    assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> relationMutation.unfollow("target"));
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,34 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.core.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class SecurityUtilTest extends GraphqlTestBase {
+
+  @Test
+  void should_return_current_user_when_authenticated() {
+    User user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    login(user);
+
+    assertThat(SecurityUtil.getCurrentUser()).contains(user);
+  }
+
+  @Test
+  void should_return_empty_when_anonymous() {
+    logout();
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  void should_return_empty_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(null, null));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,35 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TagDatafetcherTest extends GraphqlTestBase {
+
+  @Mock private TagsQueryService tagsQueryService;
+
+  @InjectMocks private TagDatafetcher tagDatafetcher;
+
+  @Test
+  void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring"));
+
+    assertThat(tagDatafetcher.getTags()).containsExactly("java", "spring");
+  }
+
+  @Test
+  void should_return_empty_list_when_no_tag_exists() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    assertThat(tagDatafetcher.getTags()).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,145 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import graphql.execution.DataFetcherResult;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.application.user.UserService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.CreateUserInput;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.UpdateUserInput;
+import io.spring.graphql.types.UserPayload;
+import io.spring.graphql.types.UserResult;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserMutationTest extends GraphqlTestBase {
+
+  @Mock private UserRepository userRepository;
+  @Mock private PasswordEncoder encryptService;
+  @Mock private UserService userService;
+
+  @InjectMocks private UserMutation userMutation;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("john@jacob.com", "johnjacob", "encoded-123", "", "");
+  }
+
+  @Test
+  void should_create_user() {
+    CreateUserInput input =
+        CreateUserInput.newBuilder()
+            .email("john@jacob.com")
+            .username("johnjacob")
+            .password("123")
+            .build();
+    when(userService.createUser(any(RegisterParam.class))).thenReturn(user);
+
+    DataFetcherResult<UserResult> result = userMutation.createUser(input);
+
+    assertThat(result.getData()).isInstanceOf(UserPayload.class);
+    assertThat((User) result.getLocalContext()).isEqualTo(user);
+    ArgumentCaptor<RegisterParam> captor = ArgumentCaptor.forClass(RegisterParam.class);
+    verify(userService).createUser(captor.capture());
+    assertThat(captor.getValue().getEmail()).isEqualTo("john@jacob.com");
+    assertThat(captor.getValue().getUsername()).isEqualTo("johnjacob");
+    assertThat(captor.getValue().getPassword()).isEqualTo("123");
+  }
+
+  @Test
+  void should_return_errors_as_data_when_create_user_is_invalid() {
+    when(userService.createUser(any(RegisterParam.class)))
+        .thenThrow(ConstraintViolationFixture.beanViolations());
+
+    DataFetcherResult<UserResult> result =
+        userMutation.createUser(CreateUserInput.newBuilder().build());
+
+    assertThat(result.getData()).isInstanceOf(Error.class);
+    Error error = (Error) result.getData();
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).extracting("key").contains("username", "email");
+    assertThat(result.getLocalContext()).isNull();
+  }
+
+  @Test
+  void should_login_with_valid_credentials() {
+    when(userRepository.findByEmail("john@jacob.com")).thenReturn(Optional.of(user));
+    when(encryptService.matches("123", user.getPassword())).thenReturn(true);
+
+    DataFetcherResult<UserPayload> result = userMutation.login("123", "john@jacob.com");
+
+    assertThat(result.getData()).isInstanceOf(UserPayload.class);
+    assertThat((User) result.getLocalContext()).isEqualTo(user);
+  }
+
+  @Test
+  void should_not_login_with_wrong_password() {
+    when(userRepository.findByEmail("john@jacob.com")).thenReturn(Optional.of(user));
+    when(encryptService.matches("wrong", user.getPassword())).thenReturn(false);
+
+    assertThatExceptionOfType(InvalidAuthenticationException.class)
+        .isThrownBy(() -> userMutation.login("wrong", "john@jacob.com"));
+  }
+
+  @Test
+  void should_not_login_with_unknown_email() {
+    when(userRepository.findByEmail("unknown@test.com")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(InvalidAuthenticationException.class)
+        .isThrownBy(() -> userMutation.login("123", "unknown@test.com"));
+  }
+
+  @Test
+  void should_update_current_user() {
+    login(user);
+    UpdateUserInput changes =
+        UpdateUserInput.newBuilder()
+            .email("new@test.com")
+            .username("newname")
+            .bio("new bio")
+            .password("new password")
+            .image("new image")
+            .build();
+
+    DataFetcherResult<UserPayload> result = userMutation.updateUser(changes);
+
+    assertThat(result.getData()).isInstanceOf(UserPayload.class);
+    assertThat((User) result.getLocalContext()).isEqualTo(user);
+    ArgumentCaptor<UpdateUserCommand> captor = ArgumentCaptor.forClass(UpdateUserCommand.class);
+    verify(userService).updateUser(captor.capture());
+    assertThat(captor.getValue().getTargetUser()).isEqualTo(user);
+    assertThat(captor.getValue().getParam().getEmail()).isEqualTo("new@test.com");
+    assertThat(captor.getValue().getParam().getUsername()).isEqualTo("newname");
+    assertThat(captor.getValue().getParam().getBio()).isEqualTo("new bio");
+    assertThat(captor.getValue().getParam().getImage()).isEqualTo("new image");
+    assertThat(captor.getValue().getParam().getPassword()).isEqualTo("new password");
+  }
+
+  @Test
+  void should_not_update_user_when_anonymous() {
+    logout();
+
+    assertThat(userMutation.updateUser(UpdateUserInput.newBuilder().build())).isNull();
+    verify(userService, never()).updateUser(any(UpdateUserCommand.class));
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -1,0 +1,98 @@
+package io.spring.graphql.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import graphql.GraphQLError;
+import graphql.Scalars;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.graphql.ConstraintViolationFixture;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.ErrorItem;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GraphQLCustomizeExceptionHandlerTest {
+
+  private final GraphQLCustomizeExceptionHandler handler = new GraphQLCustomizeExceptionHandler();
+
+  private DataFetcherExceptionHandlerParameters parametersOf(Throwable exception) {
+    DataFetchingEnvironment environment = mock(DataFetchingEnvironment.class);
+    when(environment.getExecutionStepInfo())
+        .thenReturn(
+            ExecutionStepInfo.newExecutionStepInfo()
+                .type(Scalars.GraphQLString)
+                .path(ResultPath.parse("/user"))
+                .build());
+    return DataFetcherExceptionHandlerParameters.newExceptionParameters()
+        .dataFetchingEnvironment(environment)
+        .exception(exception)
+        .build();
+  }
+
+  @Test
+  void should_map_invalid_authentication_to_unauthenticated_error() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersOf(new InvalidAuthenticationException()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("invalid email or password");
+    assertThat(error.getPath()).containsExactly("user");
+    assertThat(error.getExtensions()).containsEntry("errorType", "UNAUTHENTICATED");
+  }
+
+  @Test
+  void should_map_constraint_violations_to_bad_request_error() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersOf(ConstraintViolationFixture.beanViolations()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getPath()).containsExactly("user");
+    assertThat(error.getExtensions()).containsEntry("errorType", "BAD_REQUEST");
+    assertThat(error.getExtensions().get("email")).isEqualTo(List.of("should be an email"));
+    assertThat((List<String>) error.getExtensions().get("username"))
+        .containsExactlyInAnyOrder("can't be empty", "too short");
+  }
+
+  @Test
+  void should_strip_the_method_prefix_of_nested_violation_paths() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersOf(ConstraintViolationFixture.methodParameterViolations()));
+
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getExtensions()).containsKeys("username", "email");
+  }
+
+  @Test
+  void should_delegate_unknown_exceptions_to_the_default_handler() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersOf(new RuntimeException("boom")));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("boom");
+  }
+
+  @Test
+  void should_convert_violations_into_error_data() {
+    Error error =
+        GraphQLCustomizeExceptionHandler.getErrorsAsData(
+            ConstraintViolationFixture.beanViolations());
+
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).hasSize(2);
+    ErrorItem username =
+        error.getErrors().stream()
+            .filter(item -> item.getKey().equals("username"))
+            .findFirst()
+            .orElseThrow(AssertionError::new);
+    assertThat(username.getValue()).containsExactlyInAnyOrder("can't be empty", "too short");
+  }
+}


### PR DESCRIPTION
## Summary

Adds 84 tests for `io.spring.graphql`, the repo's largest coverage gap. Instruction coverage of the hand-written classes in that package (excluding DGS-generated `types/` and `DgsConstants`) goes **4.7% → 99.8%** (89/1907 → 1904/1907 instructions; the only gap is `SecurityUtil`'s implicit constructor). No production code, `build.gradle`, or existing test was touched — this branch is purely new files under `src/test/java/io/spring/graphql/`.

**Approach: plain JUnit 5 + Mockito, not the DGS harness.** The DGS test harness (`DgsQueryExecutor` + `@SpringBootTest`) would need a new test dependency and a Spring context per slice; instantiating the datafetchers directly reaches every branch, needs no `build.gradle` change, and the whole graphql suite runs in ~2s. Full suite: 152 tests, 0 failures.

Two pieces of plumbing make the direct-instantiation approach work:

- `GraphqlTestBase` — `login(user)` / `logout()` drive `SecurityContextHolder` so `SecurityUtil.getCurrentUser()` resolves (note `logout()` installs an `AnonymousAuthenticationToken`; a *null* authentication would NPE in `SecurityUtil`, which is existing behaviour and not what production hits). It also builds the DGS environment as
  ```java
  environment = mock(DataFetchingEnvironment.class);          // stub getSource()/getLocalContext()/getArgument()
  dgsEnvironment = new DgsDataFetchingEnvironment(environment); // final class -> wrap, don't mock
  ```
- `ConstraintViolationFixture` — produces *real* `ConstraintViolationException`s from a validator (both a plain bean path like `username` and an executable path like `register.newUser.username`) instead of hand-mocking `ConstraintViolation`, so `GraphQLCustomizeExceptionHandler.getParam()`'s path-stripping and the field→messages grouping are exercised against genuine violation metadata. `RegisterParam` itself isn't usable here: its `@DuplicatedEmailConstraint` validator needs an autowired `UserRepository`.

Coverage per behaviour, not just per method: for every cursor-paginated fetcher both the `first`/`after` (NEXT) and `last`/`before` (PREV) branches are exercised, the captured `CursorPageParameter` is asserted (direction, limit, parsed millis cursor), and the missing-`first`-and-`last` `IllegalArgumentException` is covered. Auth/not-found paths are covered throughout: `AuthenticationException` for anonymous mutations, `ResourceNotFoundException` for missing articles/comments/profiles/relations, `NoAuthorizationException` for writing another user's article or comment, and `InvalidAuthenticationException` for bad login credentials.

## Notes for reconciliation

- **No `build.gradle` change.** JaCoCo (Workstream 0) is not on this branch; the before/after numbers above were measured by applying the `jacoco` plugin locally, running `./gradlew test jacocoTestReport` with and without the new test directory, and then reverting `build.gradle`. Nothing to reconcile.
- **spotless could not run locally** — `./gradlew spotlessApply` crashes under JDK 17 (`google-java-format` needs `--add-exports` into `jdk.compiler`). All new files were instead formatted by invoking `google-java-format 1.13.0` (the version spotless pins) directly with those `--add-exports` flags, so they should be spotless-clean.

## Verification

```
./gradlew test -x spotlessJava -x spotlessJavaCheck   # 152 tests, 0 failures
```


Link to Devin session: https://app.devin.ai/sessions/61d1e7c0c92c4de89b14778b3995687c
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/890?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->