### PR TITLE
test: add pure unit tests for core domain entities and AuthorizationService

### DIFF
--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -1,0 +1,94 @@
+package io.spring.core.comment;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+
+  @Test
+  public void should_assign_all_fields_from_constructor() {
+    Comment comment = new Comment("body", "userId", "articleId");
+
+    assertThat(comment.getBody(), is("body"));
+    assertThat(comment.getUserId(), is("userId"));
+    assertThat(comment.getArticleId(), is("articleId"));
+  }
+
+  @Test
+  public void should_generate_uuid_as_id() {
+    Comment comment = new Comment("body", "userId", "articleId");
+
+    assertThat(comment.getId(), is(notNullValue()));
+    assertThat(UUID.fromString(comment.getId()).toString(), is(comment.getId()));
+  }
+
+  @Test
+  public void should_generate_distinct_ids_for_different_comments() {
+    Comment comment = new Comment("body", "userId", "articleId");
+    Comment other = new Comment("body", "userId", "articleId");
+
+    assertThat(comment.getId(), is(not(other.getId())));
+  }
+
+  @Test
+  public void should_set_created_at_to_current_time() {
+    DateTime before = new DateTime();
+    Comment comment = new Comment("body", "userId", "articleId");
+    DateTime after = new DateTime();
+
+    assertThat(comment.getCreatedAt(), is(notNullValue()));
+    assertThat(comment.getCreatedAt().isBefore(before), is(false));
+    assertThat(comment.getCreatedAt().isAfter(after), is(false));
+  }
+
+  @Test
+  public void should_have_null_fields_when_created_with_default_constructor() {
+    Comment comment = new Comment();
+
+    assertThat(comment.getId(), is(nullValue()));
+    assertThat(comment.getBody(), is(nullValue()));
+    assertThat(comment.getUserId(), is(nullValue()));
+    assertThat(comment.getArticleId(), is(nullValue()));
+    assertThat(comment.getCreatedAt(), is(nullValue()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_differ() {
+    Comment comment = new Comment("body", "userId", "articleId");
+    Comment other = new Comment("body", "userId", "articleId");
+
+    assertThat(comment, is(not(other)));
+  }
+
+  @Test
+  public void should_be_equal_to_itself() {
+    Comment comment = new Comment("body", "userId", "articleId");
+
+    assertThat(comment, is(comment));
+    assertThat(comment.hashCode(), is(comment.hashCode()));
+  }
+
+  @Test
+  public void should_be_equal_when_ids_are_equal() {
+    Comment comment = new Comment();
+    Comment other = new Comment();
+
+    assertThat(comment, is(other));
+    assertThat(comment.hashCode(), is(other.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    Comment comment = new Comment("body", "userId", "articleId");
+
+    assertThat(comment.equals(null), is(false));
+    assertThat(comment.equals("body"), is(false));
+  }
+}

--- a/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
+++ b/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
@@ -1,0 +1,52 @@
+package io.spring.core.favorite;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ArticleFavoriteTest {
+
+  @Test
+  public void should_assign_all_fields_from_constructor() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+
+    assertThat(favorite.getArticleId(), is("articleId"));
+    assertThat(favorite.getUserId(), is("userId"));
+  }
+
+  @Test
+  public void should_have_null_fields_when_created_with_default_constructor() {
+    ArticleFavorite favorite = new ArticleFavorite();
+
+    assertThat(favorite.getArticleId(), is(nullValue()));
+    assertThat(favorite.getUserId(), is(nullValue()));
+  }
+
+  @Test
+  public void should_be_equal_when_both_ids_are_equal() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+    ArticleFavorite same = new ArticleFavorite("articleId", "userId");
+
+    assertThat(favorite, is(same));
+    assertThat(favorite.hashCode(), is(same.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_any_id_differs() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+
+    assertThat(favorite, is(not(new ArticleFavorite("otherArticleId", "userId"))));
+    assertThat(favorite, is(not(new ArticleFavorite("articleId", "otherUserId"))));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+
+    assertThat(favorite.equals(null), is(false));
+    assertThat(favorite.equals("articleId"), is(false));
+  }
+}

--- a/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
+++ b/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
@@ -1,0 +1,59 @@
+package io.spring.core.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.spring.core.article.Article;
+import io.spring.core.comment.Comment;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationServiceTest {
+
+  private final User author = new User("author@example.com", "author", "123", "bio", "image");
+  private final User other = new User("other@example.com", "other", "123", "bio", "image");
+
+  @Test
+  public void should_allow_author_to_write_article() {
+    Article article = articleOf(author);
+
+    assertThat(AuthorizationService.canWriteArticle(author, article), is(true));
+  }
+
+  @Test
+  public void should_not_allow_other_user_to_write_article() {
+    Article article = articleOf(author);
+
+    assertThat(AuthorizationService.canWriteArticle(other, article), is(false));
+  }
+
+  @Test
+  public void should_allow_article_author_to_write_others_comment() {
+    Article article = articleOf(author);
+    Comment comment = new Comment("body", other.getId(), article.getId());
+
+    assertThat(AuthorizationService.canWriteComment(author, article, comment), is(true));
+  }
+
+  @Test
+  public void should_allow_comment_author_to_write_own_comment() {
+    Article article = articleOf(author);
+    Comment comment = new Comment("body", other.getId(), article.getId());
+
+    assertThat(AuthorizationService.canWriteComment(other, article, comment), is(true));
+  }
+
+  @Test
+  public void should_not_allow_unrelated_user_to_write_comment() {
+    User unrelated = new User("unrelated@example.com", "unrelated", "123", "bio", "image");
+    Article article = articleOf(author);
+    Comment comment = new Comment("body", other.getId(), article.getId());
+
+    assertThat(AuthorizationService.canWriteComment(unrelated, article, comment), is(false));
+  }
+
+  private static Article articleOf(User user) {
+    return new Article("title", "desc", "body", Arrays.asList("java"), user.getId());
+  }
+}

--- a/src/test/java/io/spring/core/user/FollowRelationTest.java
+++ b/src/test/java/io/spring/core/user/FollowRelationTest.java
@@ -1,0 +1,62 @@
+package io.spring.core.user;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class FollowRelationTest {
+
+  @Test
+  public void should_assign_all_fields_from_constructor() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+
+    assertThat(relation.getUserId(), is("userId"));
+    assertThat(relation.getTargetId(), is("targetId"));
+  }
+
+  @Test
+  public void should_have_null_fields_when_created_with_default_constructor() {
+    FollowRelation relation = new FollowRelation();
+
+    assertThat(relation.getUserId(), is(nullValue()));
+    assertThat(relation.getTargetId(), is(nullValue()));
+  }
+
+  @Test
+  public void should_be_equal_when_both_ids_are_equal() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+    FollowRelation same = new FollowRelation("userId", "targetId");
+
+    assertThat(relation, is(same));
+    assertThat(relation.hashCode(), is(same.hashCode()));
+  }
+
+  @Test
+  public void should_not_be_equal_when_any_id_differs() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+
+    assertThat(relation, is(not(new FollowRelation("otherUserId", "targetId"))));
+    assertThat(relation, is(not(new FollowRelation("userId", "otherTargetId"))));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+
+    assertThat(relation.equals(null), is(false));
+    assertThat(relation.equals("userId"), is(false));
+  }
+
+  @Test
+  public void should_reflect_setter_changes() {
+    FollowRelation relation = new FollowRelation();
+
+    relation.setUserId("userId");
+    relation.setTargetId("targetId");
+
+    assertThat(relation, is(new FollowRelation("userId", "targetId")));
+  }
+}

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -1,0 +1,142 @@
+package io.spring.core.user;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+  @Test
+  public void should_assign_all_fields_from_constructor() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.getEmail(), is("john@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_generate_uuid_as_id() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.getId(), is(notNullValue()));
+    assertThat(UUID.fromString(user.getId()).toString(), is(user.getId()));
+  }
+
+  @Test
+  public void should_generate_distinct_ids_for_different_users() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+    User other = new User("jane@example.com", "jane", "123", "bio", "image");
+
+    assertThat(user.getId(), is(not(other.getId())));
+  }
+
+  @Test
+  public void should_have_null_id_when_created_with_default_constructor() {
+    User user = new User();
+
+    assertThat(user.getId(), is(nullValue()));
+  }
+
+  @Test
+  public void should_update_all_fields_when_all_values_present() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+    String id = user.getId();
+
+    user.update("new@example.com", "jane", "456", "new bio", "new image");
+
+    assertThat(user.getId(), is(id));
+    assertThat(user.getEmail(), is("new@example.com"));
+    assertThat(user.getUsername(), is("jane"));
+    assertThat(user.getPassword(), is("456"));
+    assertThat(user.getBio(), is("new bio"));
+    assertThat(user.getImage(), is("new image"));
+  }
+
+  @Test
+  public void should_keep_original_values_when_updating_with_null() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update(null, null, null, null, null);
+
+    assertThat(user.getEmail(), is("john@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_keep_original_values_when_updating_with_empty_string() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update("", "", "", "", "");
+
+    assertThat(user.getEmail(), is("john@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_update_only_the_provided_fields() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update("new@example.com", "", null, "new bio", "");
+
+    assertThat(user.getEmail(), is("new@example.com"));
+    assertThat(user.getUsername(), is("john"));
+    assertThat(user.getPassword(), is("123"));
+    assertThat(user.getBio(), is("new bio"));
+    assertThat(user.getImage(), is("image"));
+  }
+
+  @Test
+  public void should_update_field_with_blank_string() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    user.update(null, null, null, " ", null);
+
+    assertThat(user.getBio(), is(" "));
+  }
+
+  @Test
+  public void should_be_equal_only_when_id_is_equal() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+    User same = new User("other@example.com", "other", "456", "other", "other");
+    User other = new User("john@example.com", "john", "123", "bio", "image");
+
+    setId(same, user.getId());
+
+    assertThat(user, is(same));
+    assertThat(user.hashCode(), is(same.hashCode()));
+    assertThat(user, is(not(other)));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    User user = new User("john@example.com", "john", "123", "bio", "image");
+
+    assertThat(user.equals(null), is(false));
+    assertThat(user.equals("john"), is(false));
+  }
+
+  private static void setId(User user, String id) {
+    try {
+      Field field = User.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(user, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Workstream B of the parallel test-coverage effort: 36 new pure JUnit 5 unit tests (no Spring context, no Mockito) for the `io.spring.core` domain entities and `AuthorizationService`. Only new test files are added — no production code, no `build.gradle`, no existing test touched.

New files (Hamcrest matchers, mirroring `core/article/ArticleTest`):
- `user/UserTest` (11) — UUID id generation & distinctness, field assignment, `update(...)` semantics, `equals`/`hashCode` keyed on `id` only.
- `user/FollowRelationTest` (6) — construction, setters, value equality on both ids.
- `comment/CommentTest` (9) — id generation, field assignment, `createdAt` within `[before, after]` bounds, equality keyed on `id`.
- `favorite/ArticleFavoriteTest` (5) — construction, value equality on both ids.
- `service/AuthorizationServiceTest` (5) — `canWriteArticle` allow/deny, `canWriteComment` allowed for both the article author and the comment author, denied for an unrelated user.

Two behaviors worth calling out, both **asserted as-is** (no production change):

1. `User.update` guards on `Util.isEmpty` (`value == null || value.isEmpty()`), which is null/empty, **not blank**. So a whitespace-only value overwrites the field:
   ```java
   user.update(null, null, null, " ", null);
   user.getBio(); // " " — asserted in should_update_field_with_blank_string
   ```
   Possibly intentional, but it means `" "` is accepted as a bio/username/password at the entity level. Left alone per scope.

2. `User` and `Comment` use `@EqualsAndHashCode(of = "id")`, so two default-constructed instances (both `id == null`) compare equal. `CommentTest.should_be_equal_when_ids_are_equal` pins this; `UserTest` uses reflection to set a matching `id` rather than relying on the null-id case, so it exercises the real equality rule.

## Coverage (io.spring.core.*, JaCoCo instructions)

JaCoCo is not on `master` yet (Workstream 0 hasn't landed), so it was measured locally via a Gradle init script that applies the `jacoco` plugin without modifying `build.gradle`. Numbers are for the whole test suite (integration tests already covered some of this code).

| package | before | after |
|---|---|---|
| `io.spring.core.user` | 71.8% (186/259) | 88.8% (230/259) |
| `io.spring.core.comment` | 69.0% (69/100) | 97.0% (97/100) |
| `io.spring.core.favorite` | 54.5% (60/110) | 87.3% (96/110) |
| `io.spring.core.service` | 88.0% (22/25) | 88.0% (22/25) |
| `io.spring.core.article` | 70.8% (199/281) | 70.8% (199/281) |
| **total** | **69.2% (536/775)** | **83.1% (644/775)** |

`service` is unchanged because the integration tests already exercised both branches of `AuthorizationService`; the new tests pin the rules directly and cheaply (the 3 missed instructions are the implicit constructor plus `JwtService`'s interface).

## Verification

- `./gradlew test -x spotlessJava -x spotlessJavaCheck` → **104 tests, 0 failures, 0 errors** (36 new).
- `./gradlew spotlessApply` crashes under this box's JDK 17 (`google-java-format` `InvocationTargetException` — needs `--add-exports jdk.compiler/...`). Worked around locally by running `google-java-format 1.13.0` (the exact version spotless pins) directly with the required `--add-exports` flags; `--dry-run --set-exit-if-changed` over the new files exits 0, so they are google-java-format clean.
- Note for whoever runs this next: `repo.maven.apache.org` was returning HTTP 429 from the build box; dependencies were resolved through the Maven Central GCS mirror via a local Gradle init script (no repo change).


Link to Devin session: https://app.devin.ai/sessions/7d792bc7bb6341c1945869a2b4f0ca75
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/891?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->