### PR TITLE
Build against Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+# google-java-format (used by Spotless) needs access to internal javac APIs,
+# which are encapsulated by the module system on JDK 16+.
+org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # google-java-format (used by Spotless) needs access to internal javac APIs,
 # which are encapsulated by the module system on JDK 16+.
-org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+org.gradle.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=384m \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Moves the build target from Java 11 to Java 17 (`sourceCompatibility`/`targetCompatibility` in `build.gradle`). No dependency or Spring Boot version changes — Boot 2.6.3, Gradle 7.4 and the default Lombok (1.18.22) all compile and run fine on JDK 17.

Supporting changes needed to keep `./gradlew clean build` green on JDK 17:

- **`gradle.properties` (new)** — `google-java-format` (via Spotless) reflects into `com.sun.tools.javac.*`, which JPMS encapsulates on JDK 16+, so `spotlessJava` died with `IllegalAccessError: ... module jdk.compiler does not export com.sun.tools.javac.parser`. Fixed by giving the Gradle daemon `--add-exports=jdk.compiler/com.sun.tools.javac.{api,file,parser,tree,util}=ALL-UNNAMED`, alongside Gradle's default `-Xmx512m -XX:MaxMetaspaceSize=384m` (setting `org.gradle.jvmargs` replaces rather than appends to the defaults).
- **`DefaultJwtServiceTest.java`** — a pre-existing `googleJavaFormat` violation (over-long constructor line) that already failed `spotlessJavaCheck` on `master` under JDK 11; previously masked in this branch by the crash above. `spotlessApply` line-wraps it.
- **`README.md`** — setup instructions now say Java 17.

## Verification (JDK 17.0.19)

- `./gradlew clean build` — BUILD SUCCESSFUL: `generateJava` (DGS codegen), `compileJava`, Spotless, 68 tests / 0 failures. Emitted bytecode is class file major version 61.
- `./gradlew bootRun` — app starts on 8080; Flyway validates the migration against `dev.db`, then over REST: register user → `GET /user` with `Authorization: Token <jwt>` → `POST /articles` (MyBatis write) all succeed, and the DGS `{ articles(first:2) { edges { node { title slug } } } }` query returns the created article.


Link to Devin session: https://app.devin.ai/sessions/a47dbb87b79b41cbb426aa88f2eb3efb
Requested by: @Thomas-Blake
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/897?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->