### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,34 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
+  }
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar());
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar());
     return ts != null ? new DateTime(ts.getTime()) : null;
   }
 }

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Weekly SonarQube sweep. Fixes the 5 highest-ranked open issues (severity → type → effort → recency) from SonarQube project `choikh0423_demo-spring-boot-test-coverage`, which analyzes this codebase. No BLOCKER issues exist; the 4 CRITICAL issues are all included, plus the highest-ranked reliability MAJOR.

| # | Issue key | Rule | Severity / type | Location | Fix |
|---|---|---|---|---|---|
| 1 | `AZ1u3HBdEnUkF3fpjVtN` | `java:S1948` | CRITICAL / BUG | `InvalidRequestException:7` | Non-serializable `Errors` field in a `Serializable` exception → `private final transient Errors errors` |
| 2 | `AZ1u3HCaEnUkF3fpjVtj` | `java:S1452` | CRITICAL / CODE_SMELL | `ArticleApi.article` | `ResponseEntity<?>` → `ResponseEntity<Map<String, Object>>` |
| 3 | `AZ1u3HCaEnUkF3fpjVtk` | `java:S1452` | CRITICAL / CODE_SMELL | `ArticleApi.updateArticle` | same wildcard removal |
| 4 | `AZ1u3HBkEnUkF3fpjVtQ` | `java:S1452` | CRITICAL / CODE_SMELL | `CommentsApi.createComment` | same wildcard removal |
| 5 | `AZ1u3HAmEnUkF3fpjVtC` | `java:S2885` | MAJOR / BUG | `DateTimeHandler:18` | Shared `static final Calendar` is not thread-safe |

For #5, Sonar suggests making the field an instance variable, but MyBatis type handlers are themselves shared singletons, so that would keep the same race. Instead the handler keeps only the immutable `TimeZone` and hands JDBC a fresh calendar per call:

```java
private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
private static Calendar utcCalendar() { return Calendar.getInstance(UTC); }
```

The wildcard removals are type-safe because each handler already builds its body from `articleResponse(...)` / `commentResponse(...)`, both `Map<String, Object>`.

Also includes a one-line `spotlessApply` reformat of `DefaultJwtServiceTest` — a pre-existing violation on `master`, unrelated to these fixes, needed for `./gradlew spotlessCheck` to pass.

Verified with `./gradlew spotlessCheck` and `./gradlew test` (both green, JDK 11). The repo has no CI workflows, so there are no checks to wait on.


Link to Devin session: https://app.devin.ai/sessions/3c88493c3e404d0d9d783b2a993e2058
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/908?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->