### PR TITLE
build: add JaCoCo coverage reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,10 @@ def generatedClassExcludes = {
 }
 
 def handWrittenSourceDirectories = {
-    files({ sourceSets.main.java.srcDirs - generatedSourceRoots() })
+    files({
+        def buildPath = layout.buildDirectory.get().asFile.toPath()
+        sourceSets.main.java.srcDirs.findAll { !it.toPath().startsWith(buildPath) }
+    })
 }
 
 def coveredClassDirectories = {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
+    id 'jacoco'
 }
 
 version = '0.0.1-SNAPSHOT'
@@ -56,8 +57,46 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = '0.8.11'
+}
+
+// DGS codegen output under build/generated is not hand-written code.
+def jacocoExcludes = ['io/spring/graphql/types/**', 'io/spring/graphql/DgsConstants*']
+
+def coveredClassDirectories = {
+    files(sourceSets.main.output.classesDirs.collect {
+        fileTree(dir: it, exclude: jacocoExcludes)
+    })
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy tasks.named('jacocoTestReport')
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn tasks.named('test')
+    classDirectories.setFrom(coveredClassDirectories())
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    dependsOn tasks.named('jacocoTestReport')
+    classDirectories.setFrom(coveredClassDirectories())
+    violationRules {
+        rule {
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.40
+            }
+        }
+    }
 }
 
 tasks.named('clean') {

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ tasks.named('test') {
 tasks.named('jacocoTestReport') {
     dependsOn tasks.named('test')
     classDirectories.setFrom(coveredClassDirectories())
+    sourceDirectories.setFrom(files('src/main/java'))
     reports {
         xml.required = true
         html.required = true

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,9 @@ def generatedSourceRoots = {
 def generatedClassExcludes = {
     generatedSourceRoots().collectMany { root ->
         fileTree(root).matching { include '**/*.java' }.files.collect {
-            root.toPath().relativize(it.toPath()).toString().replaceFirst(/\.java$/, '*.class')
+            // Ant patterns are always '/'-separated, unlike Path.toString() on Windows.
+            def relative = root.toPath().relativize(it.toPath()).collect { it.toString() }.join('/')
+            relative.replaceFirst(/\.java$/, '*.class')
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,17 +61,21 @@ jacoco {
     toolVersion = '0.8.11'
 }
 
-// DGS codegen output is not hand-written code, so it is kept out of the coverage
-// denominator. The exclusions are derived from whatever generateJava actually emitted
-// rather than hardcoded, so they survive changes to the codegen package or artifact set.
+// Generated sources (DGS codegen) are not hand-written code, so they are kept out of the
+// coverage denominator. A generated source root is any main source root under the build
+// directory; the excludes are derived from what it actually contains, so neither the codegen
+// package, its output layout, nor the set of emitted artifacts is hardcoded here.
 // Resolved lazily: by the time a jacoco task reads this, compileJava has run generateJava.
-def generatedSourceRoot = layout.buildDirectory.dir('generated')
+def generatedSourceRoots = {
+    def buildPath = layout.buildDirectory.get().asFile.toPath()
+    sourceSets.main.java.srcDirs.findAll { it.exists() && it.toPath().startsWith(buildPath) }
+}
 
 def generatedClassExcludes = {
-    def root = generatedSourceRoot.get().asFile
-    if (!root.exists()) return []
-    fileTree(root).matching { include '**/*.java' }.files.collect {
-        root.toPath().relativize(it.toPath()).toString().replaceFirst(/\.java$/, '*.class')
+    generatedSourceRoots().collectMany { root ->
+        fileTree(root).matching { include '**/*.java' }.files.collect {
+            root.toPath().relativize(it.toPath()).toString().replaceFirst(/\.java$/, '*.class')
+        }
     }
 }
 
@@ -90,7 +94,7 @@ tasks.named('test') {
 tasks.named('jacocoTestReport') {
     dependsOn tasks.named('test')
     classDirectories.setFrom(coveredClassDirectories())
-    sourceDirectories.setFrom(files('src/main/java'))
+    sourceDirectories.setFrom(files({ sourceSets.main.java.srcDirs - generatedSourceRoots() }))
     reports {
         xml.required = true
         html.required = true

--- a/build.gradle
+++ b/build.gradle
@@ -68,14 +68,16 @@ jacoco {
 // Resolved lazily: by the time a jacoco task reads this, compileJava has run generateJava.
 def generatedSourceRoots = {
     def buildPath = layout.buildDirectory.get().asFile.toPath()
-    def roots = sourceSets.main.java.srcDirs.findAll { it.exists() && it.toPath().startsWith(buildPath) }
-    if (roots.isEmpty() && tasks.findByName('generateJava') != null) {
-        // Codegen ran but its output is no longer a main source root, so the excludes below
-        // would silently be empty and generated code would re-enter the denominator.
-        throw new GradleException('Codegen is configured but produced no source root under ' +
+    def registered = sourceSets.main.java.srcDirs.findAll { it.toPath().startsWith(buildPath) }
+    if (registered.isEmpty() && tasks.findByName('generateJava') != null) {
+        // Codegen no longer contributes a main source root, so the excludes below would
+        // silently be empty and generated code would re-enter the denominator.
+        throw new GradleException('Codegen is configured but registers no source root under ' +
             "${buildPath}; jacoco cannot identify generated code. Update generatedSourceRoots.")
     }
-    roots
+    // Registration is what matters above; a root that has not been written yet simply
+    // contributes no excludes, which is correct because it has no compiled classes either.
+    registered.findAll { it.exists() }
 }
 
 def generatedClassExcludes = {

--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,24 @@ jacoco {
     toolVersion = '0.8.11'
 }
 
-// DGS codegen output under build/generated is not hand-written code.
-def jacocoExcludes = ['io/spring/graphql/types/**', 'io/spring/graphql/DgsConstants*']
+// DGS codegen output is not hand-written code, so it is kept out of the coverage
+// denominator. The exclusions are derived from whatever generateJava actually emitted
+// rather than hardcoded, so they survive changes to the codegen package or artifact set.
+// Resolved lazily: by the time a jacoco task reads this, compileJava has run generateJava.
+def generatedSourceRoot = layout.buildDirectory.dir('generated')
+
+def generatedClassExcludes = {
+    def root = generatedSourceRoot.get().asFile
+    if (!root.exists()) return []
+    fileTree(root).matching { include '**/*.java' }.files.collect {
+        root.toPath().relativize(it.toPath()).toString().replaceFirst(/\.java$/, '*.class')
+    }
+}
 
 def coveredClassDirectories = {
-    files(sourceSets.main.output.classesDirs.collect {
-        fileTree(dir: it, exclude: jacocoExcludes)
+    files({
+        def excludes = generatedClassExcludes()
+        sourceSets.main.output.classesDirs.collect { fileTree(dir: it, exclude: excludes) }
     })
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,10 +73,11 @@ def generatedSourceRoots = {
 
 def generatedClassExcludes = {
     generatedSourceRoots().collectMany { root ->
-        fileTree(root).matching { include '**/*.java' }.files.collect {
+        fileTree(root).matching { include '**/*.java' }.files.collectMany {
             // Ant patterns are always '/'-separated, unlike Path.toString() on Windows.
             def relative = root.toPath().relativize(it.toPath()).collect { it.toString() }.join('/')
-            relative.replaceFirst(/\.java$/, '*.class')
+            def base = relative.replaceFirst(/\.java$/, '')
+            [base + '.class', base + '$*.class']
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,14 @@ jacoco {
 // Resolved lazily: by the time a jacoco task reads this, compileJava has run generateJava.
 def generatedSourceRoots = {
     def buildPath = layout.buildDirectory.get().asFile.toPath()
-    sourceSets.main.java.srcDirs.findAll { it.exists() && it.toPath().startsWith(buildPath) }
+    def roots = sourceSets.main.java.srcDirs.findAll { it.exists() && it.toPath().startsWith(buildPath) }
+    if (roots.isEmpty() && tasks.findByName('generateJava') != null) {
+        // Codegen ran but its output is no longer a main source root, so the excludes below
+        // would silently be empty and generated code would re-enter the denominator.
+        throw new GradleException('Codegen is configured but produced no source root under ' +
+            "${buildPath}; jacoco cannot identify generated code. Update generatedSourceRoots.")
+    }
+    roots
 }
 
 def generatedClassExcludes = {
@@ -80,6 +87,10 @@ def generatedClassExcludes = {
             [base + '.class', base + '$*.class']
         }
     }
+}
+
+def handWrittenSourceDirectories = {
+    files({ sourceSets.main.java.srcDirs - generatedSourceRoots() })
 }
 
 def coveredClassDirectories = {
@@ -97,7 +108,7 @@ tasks.named('test') {
 tasks.named('jacocoTestReport') {
     dependsOn tasks.named('test')
     classDirectories.setFrom(coveredClassDirectories())
-    sourceDirectories.setFrom(files({ sourceSets.main.java.srcDirs - generatedSourceRoots() }))
+    sourceDirectories.setFrom(handWrittenSourceDirectories())
     reports {
         xml.required = true
         html.required = true
@@ -108,6 +119,7 @@ tasks.named('jacocoTestReport') {
 tasks.named('jacocoTestCoverageVerification') {
     dependsOn tasks.named('jacocoTestReport')
     classDirectories.setFrom(coveredClassDirectories())
+    sourceDirectories.setFrom(handWrittenSourceDirectories())
     violationRules {
         rule {
             limit {

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ tasks.named('jacocoTestReport') {
     }
 }
 
+// A ratchet: raise the minimum as coverage rises, never lower it to make a build pass.
 tasks.named('jacocoTestCoverageVerification') {
     dependsOn tasks.named('jacocoTestReport')
     classDirectories.setFrom(coveredClassDirectories())
@@ -130,10 +131,14 @@ tasks.named('jacocoTestCoverageVerification') {
             limit {
                 counter = 'INSTRUCTION'
                 value = 'COVEREDRATIO'
-                minimum = 0.40
+                minimum = 0.50
             }
         }
     }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('jacocoTestCoverageVerification')
 }
 
 tasks.named('clean') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 # google-java-format (used by Spotless) needs access to internal javac packages
 # that are encapsulated by JPMS on JDK 16+.
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+# Setting org.gradle.jvmargs replaces Gradle's daemon defaults, so restate the memory limits.
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # google-java-format (used by Spotless) needs access to internal javac packages
 # that are encapsulated by JPMS on JDK 16+.
-# Setting org.gradle.jvmargs replaces Gradle's daemon defaults, so restate the memory limits.
-org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+# Setting org.gradle.jvmargs replaces Gradle's daemon defaults, so restate memory and encoding.
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# google-java-format (used by Spotless) needs access to internal javac packages
+# that are encapsulated by JPMS on JDK 16+.
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,5 @@
+config.stopBubbling = true
+
+# Marks Lombok-generated members with @lombok.Generated, which JaCoCo honours by
+# filtering them out of coverage. Keeps the ratchet measuring hand-written code only.
+lombok.addLombokGeneratedAnnotation = true

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds coverage measurement so the follow-up test-coverage work has a baseline to move. `./gradlew test` now always produces XML + HTML reports under `build/reports/jacoco/test/`, and `./gradlew check` fails if instruction coverage regresses below the ratchet.

Wiring in `build.gradle`:

```groovy
plugins { ...; id 'jacoco' }
jacoco { toolVersion = '0.8.11' }          // 0.8.7 (Gradle 7.4 default) predates JDK 17 class-file support
test { finalizedBy jacocoTestReport }
jacocoTestReport { dependsOn test; xml + html }
jacocoTestCoverageVerification { INSTRUCTION COVEREDRATIO >= 0.50 }
check { dependsOn jacocoTestCoverageVerification }
```

Three non-obvious pieces:

- **Generated code is excluded from the coverage denominator.** DGS codegen emits ~2950 instructions of `io.spring.graphql.types.*` / `DgsConstants` into `build/generated`, all uncovered by construction. Rather than hardcode those package paths, the exclusions are derived from what `generateJava` actually emitted, so they survive a codegen package rename or client generation being enabled. If codegen ever stops registering a source root under `build/`, the build fails with an explicit message rather than silently re-admitting generated code to the denominator.

- **New `lombok.config` keeps generated accessors out of the denominator.** `lombok.addLombokGeneratedAnnotation = true` marks generated members with `@lombok.Generated`, which JaCoCo filters automatically. This is why `io.spring.application.data` reads 100% (43/43): the package is almost entirely `@Data` DTOs, and what remains is the hand-written `getCursor()`. Filtering per-member rather than excluding the package keeps that hand-written code measured. Overall this drops the denominator from 7435 to 4677 instructions — the ratchet now tracks hand-written code only.

- **New `gradle.properties` makes Spotless work on JDK 17.** `googleJavaFormat` reflects into `com.sun.tools.javac.*`, which JPMS encapsulates on JDK 16+, so `./gradlew spotlessApply` previously died with `IllegalAccessError` and had to be skipped via `-x spotlessJava -x spotlessJavaCheck`. Adding the five `--add-exports` flags to `org.gradle.jvmargs` fixes it. Since setting `org.gradle.jvmargs` *replaces* Gradle's daemon defaults, the memory limits are restated explicitly (`-Xmx1g`, 2x Gradle's stock 512m, as the daemon now also hosts google-java-format and DGS codegen). `spotlessApply` then reformatted one pre-existing violation in `DefaultJwtServiceTest`.

## Coverage

This PR alone measures **51.8%** (2422/4677), which is what the `0.50` ratchet sits just below. The four stacked test PRs — #911, #912, #913, #914 — take the same measurement to **94.8%** (4435/4677); merging all four onto this branch locally is conflict-free and green. The ratchet should be raised to `0.90` in a one-line follow-up once they land.

| package | this PR | with #911–#914 |
|---|---|---|
| `io/spring/graphql` | 0.0% | 99.8% |
| `io/spring/graphql/exception` | 3.0% | 100.0% |
| `io/spring/application/article` | 30.6% | 100.0% |
| `io/spring/application/user` | 80.1% | 100.0% |
| `io/spring/api/exception` | 78.3% | 100.0% |
| `io/spring/api` | 96.5% | 100.0% |
| `io/spring/core/user` | 90.3% | 100.0% |
| `io/spring/core/article` | 84.9% | 100.0% |
| `io/spring/application` | 73.4% | 76.5% |
| **total** | **51.8%** | **94.8%** |

Verified from clean: `./gradlew clean spotlessApply build jacocoTestReport` — green. The ratchet was confirmed to actually bite by temporarily raising the minimum to `0.99` via an init script, which failed `check` with `instructions covered ratio is 0.51, but expected minimum is 0.99`.

Note: `security/snyk` fails with "You have used your limit of private tests" — an org-level Snyk quota, unrelated to this diff.

Link to Devin session: https://app.devin.ai/sessions/f3122556a6ae4cdfa0fc30cf0dd70705
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/910?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->