### PR TITLE
test: cover article/user command services and their validators

### DIFF
--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,190 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.article.Tag;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+public class ArticleCommandServiceTest {
+
+  private ArticleRepository articleRepository;
+  private ArticleQueryService articleQueryService;
+  private AnnotationConfigApplicationContext context;
+  private ArticleCommandService articleCommandService;
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    articleRepository = mock(ArticleRepository.class);
+    articleQueryService = mock(ArticleQueryService.class);
+    user = new User("john@example.com", "john", "123", "", "");
+
+    // ArticleCommandService is @Validated: method level bean validation only happens through the
+    // Spring proxy, and DuplicatedArticleValidator gets its ArticleQueryService injected by the
+    // Spring backed constraint validator factory.
+    context = new AnnotationConfigApplicationContext();
+    context.registerBean(ArticleRepository.class, () -> articleRepository);
+    context.registerBean(ArticleQueryService.class, () -> articleQueryService);
+    context.registerBean(LocalValidatorFactoryBean.class, LocalValidatorFactoryBean::new);
+    context.registerBean(
+        MethodValidationPostProcessor.class,
+        () -> {
+          MethodValidationPostProcessor processor = new MethodValidationPostProcessor();
+          processor.setValidator(context.getBean(LocalValidatorFactoryBean.class));
+          return processor;
+        });
+    context.registerBean(ArticleCommandService.class);
+    context.refresh();
+
+    articleCommandService = context.getBean(ArticleCommandService.class);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    context.close();
+  }
+
+  @Test
+  public void should_create_and_save_article_from_the_param() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("How to train your dragon")
+            .description("Ever wonder how?")
+            .body("It takes a Jacobian")
+            .tagList(Arrays.asList("dragons", "training"))
+            .build();
+    when(articleQueryService.findBySlug(eq("how-to-train-your-dragon"), isNull()))
+        .thenReturn(Optional.empty());
+
+    Article created = articleCommandService.createArticle(param, user);
+
+    ArgumentCaptor<Article> captor = ArgumentCaptor.forClass(Article.class);
+    verify(articleRepository).save(captor.capture());
+    Article saved = captor.getValue();
+
+    assertThat(saved).isSameAs(created);
+    assertThat(saved.getTitle()).isEqualTo("How to train your dragon");
+    assertThat(saved.getSlug()).isEqualTo("how-to-train-your-dragon");
+    assertThat(saved.getDescription()).isEqualTo("Ever wonder how?");
+    assertThat(saved.getBody()).isEqualTo("It takes a Jacobian");
+    assertThat(saved.getUserId()).isEqualTo(user.getId());
+    assertThat(saved.getTags())
+        .extracting(Tag::getName)
+        .containsExactlyInAnyOrder("dragons", "training");
+    assertThat(saved.getId()).isNotBlank();
+  }
+
+  @Test
+  public void should_deduplicate_the_tag_list_of_a_new_article() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("Tagged article")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "java", "spring"))
+            .build();
+    when(articleQueryService.findBySlug(eq("tagged-article"), isNull()))
+        .thenReturn(Optional.empty());
+
+    Article created = articleCommandService.createArticle(param, user);
+
+    assertThat(created.getTags())
+        .extracting(Tag::getName)
+        .containsExactlyInAnyOrder("java", "spring");
+  }
+
+  @Test
+  public void should_reject_creation_when_the_title_is_already_used() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("How to train your dragon")
+            .description("Ever wonder how?")
+            .body("It takes a Jacobian")
+            .tagList(Arrays.asList("dragons"))
+            .build();
+    when(articleQueryService.findBySlug(eq("how-to-train-your-dragon"), isNull()))
+        .thenReturn(Optional.of(new ArticleData()));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(() -> articleCommandService.createArticle(param, user))
+        .satisfies(
+            exception ->
+                assertThat(exception.getConstraintViolations())
+                    .extracting(ConstraintViolation::getMessage)
+                    .containsExactly("article name exists"));
+
+    verify(articleRepository, never()).save(any());
+  }
+
+  @Test
+  public void should_reject_creation_when_required_fields_are_blank() {
+    NewArticleParam param =
+        NewArticleParam.builder().title("").description("").body("").tagList(List.of()).build();
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(() -> articleCommandService.createArticle(param, user))
+        .satisfies(
+            exception ->
+                assertThat(exception.getConstraintViolations())
+                    .extracting(ConstraintViolation::getMessage)
+                    .contains("can't be empty"));
+
+    verify(articleRepository, never()).save(any());
+  }
+
+  @Test
+  public void should_update_title_slug_description_and_body() {
+    Article article =
+        new Article("old title", "old desc", "old body", Arrays.asList("java"), user.getId());
+
+    Article updated =
+        articleCommandService.updateArticle(
+            article, new UpdateArticleParam("new title", "new body", "new desc"));
+
+    verify(articleRepository).save(article);
+    assertThat(updated).isSameAs(article);
+    assertThat(updated.getTitle()).isEqualTo("new title");
+    assertThat(updated.getSlug()).isEqualTo("new-title");
+    assertThat(updated.getDescription()).isEqualTo("new desc");
+    assertThat(updated.getBody()).isEqualTo("new body");
+  }
+
+  @Test
+  public void should_keep_the_fields_left_empty_in_the_update_param() {
+    Article article =
+        new Article("old title", "old desc", "old body", Arrays.asList("java"), user.getId());
+
+    Article updated =
+        articleCommandService.updateArticle(article, new UpdateArticleParam("", "", "new desc"));
+
+    verify(articleRepository).save(article);
+    assertThat(updated.getTitle()).isEqualTo("old title");
+    assertThat(updated.getSlug()).isEqualTo("old-title");
+    assertThat(updated.getBody()).isEqualTo("old body");
+    assertThat(updated.getDescription()).isEqualTo("new desc");
+  }
+}

--- a/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
+++ b/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
@@ -1,0 +1,56 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedArticleValidatorTest {
+
+  @Mock private ArticleQueryService articleQueryService;
+
+  @Mock private ConstraintValidatorContext context;
+
+  private DuplicatedArticleValidator validator;
+
+  @BeforeEach
+  public void setUp() {
+    validator = new DuplicatedArticleValidator();
+    ReflectionTestUtils.setField(validator, "articleQueryService", articleQueryService);
+  }
+
+  @Test
+  public void should_be_valid_when_no_article_with_the_same_slug_exists() {
+    when(articleQueryService.findBySlug(eq("how-to-train-your-dragon"), isNull()))
+        .thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("How to train your dragon", context)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_an_article_with_the_same_slug_exists() {
+    when(articleQueryService.findBySlug(eq("how-to-train-your-dragon"), isNull()))
+        .thenReturn(Optional.of(new ArticleData()));
+
+    assertThat(validator.isValid("How to train your dragon", context)).isFalse();
+  }
+
+  @Test
+  public void should_lookup_by_the_slugified_title() {
+    when(articleQueryService.findBySlug(eq("a-b-c"), isNull())).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("A B C", context)).isTrue();
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
@@ -1,0 +1,57 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedEmailValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private ConstraintValidatorContext context;
+
+  private DuplicatedEmailValidator validator;
+
+  @BeforeEach
+  public void setUp() {
+    validator = new DuplicatedEmailValidator();
+    ReflectionTestUtils.setField(validator, "userRepository", userRepository);
+  }
+
+  @Test
+  public void should_be_valid_when_no_user_has_the_email() {
+    when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("john@example.com", context)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_a_user_already_has_the_email() {
+    when(userRepository.findByEmail("john@example.com"))
+        .thenReturn(Optional.of(new User("john@example.com", "john", "123", "", "")));
+
+    assertThat(validator.isValid("john@example.com", context)).isFalse();
+  }
+
+  @Test
+  public void should_skip_the_lookup_for_null_or_empty_email() {
+    assertThat(validator.isValid(null, context)).isTrue();
+    assertThat(validator.isValid("", context)).isTrue();
+
+    verify(userRepository, never()).findByEmail(anyString());
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
@@ -1,0 +1,57 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedUsernameValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private ConstraintValidatorContext context;
+
+  private DuplicatedUsernameValidator validator;
+
+  @BeforeEach
+  public void setUp() {
+    validator = new DuplicatedUsernameValidator();
+    ReflectionTestUtils.setField(validator, "userRepository", userRepository);
+  }
+
+  @Test
+  public void should_be_valid_when_no_user_has_the_username() {
+    when(userRepository.findByUsername("john")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("john", context)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_a_user_already_has_the_username() {
+    when(userRepository.findByUsername("john"))
+        .thenReturn(Optional.of(new User("john@example.com", "john", "123", "", "")));
+
+    assertThat(validator.isValid("john", context)).isFalse();
+  }
+
+  @Test
+  public void should_skip_the_lookup_for_null_or_empty_username() {
+    assertThat(validator.isValid(null, context)).isTrue();
+    assertThat(validator.isValid("", context)).isTrue();
+
+    verify(userRepository, never()).findByUsername(anyString());
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,269 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+public class UserServiceTest {
+
+  private static final String DEFAULT_IMAGE = "https://static.productionready.io/images/user.jpg";
+
+  private UserRepository userRepository;
+  private PasswordEncoder passwordEncoder;
+  private AnnotationConfigApplicationContext context;
+  private UserService userService;
+
+  @BeforeEach
+  public void setUp() {
+    userRepository = mock(UserRepository.class);
+    passwordEncoder = mock(PasswordEncoder.class);
+
+    // UserService is @Validated: RegisterParam and UpdateUserCommand are only validated through
+    // the Spring proxy, and the constraint validators get their UserRepository injected by the
+    // Spring backed constraint validator factory.
+    context = new AnnotationConfigApplicationContext();
+    context.registerBean(UserRepository.class, () -> userRepository);
+    context.registerBean(PasswordEncoder.class, () -> passwordEncoder);
+    context.registerBean(LocalValidatorFactoryBean.class, LocalValidatorFactoryBean::new);
+    context.registerBean(
+        MethodValidationPostProcessor.class,
+        () -> {
+          MethodValidationPostProcessor processor = new MethodValidationPostProcessor();
+          processor.setValidator(context.getBean(LocalValidatorFactoryBean.class));
+          return processor;
+        });
+    context.registerBean(
+        UserService.class, () -> new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder));
+    context.refresh();
+
+    userService = context.getBean(UserService.class);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    context.close();
+  }
+
+  @Test
+  public void should_create_user_with_encoded_password_and_default_image() {
+    when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("john")).thenReturn(Optional.empty());
+    when(passwordEncoder.encode("123456")).thenReturn("encoded-123456");
+
+    User created = userService.createUser(new RegisterParam("john@example.com", "john", "123456"));
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository).save(captor.capture());
+    User saved = captor.getValue();
+
+    assertThat(saved).isSameAs(created);
+    assertThat(saved.getEmail()).isEqualTo("john@example.com");
+    assertThat(saved.getUsername()).isEqualTo("john");
+    assertThat(saved.getPassword()).isEqualTo("encoded-123456");
+    assertThat(saved.getBio()).isEmpty();
+    assertThat(saved.getImage()).isEqualTo(DEFAULT_IMAGE);
+    assertThat(saved.getId()).isNotBlank();
+  }
+
+  @Test
+  public void should_reject_registration_with_an_already_used_email() {
+    when(userRepository.findByEmail("john@example.com"))
+        .thenReturn(Optional.of(new User("john@example.com", "existing", "123", "", "")));
+    when(userRepository.findByUsername("john")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () -> userService.createUser(new RegisterParam("john@example.com", "john", "123456")))
+        .satisfies(
+            exception ->
+                assertThat(exception.getConstraintViolations())
+                    .extracting(ConstraintViolation::getMessage)
+                    .containsExactly("duplicated email"));
+
+    verify(userRepository, never()).save(any());
+    verify(passwordEncoder, never()).encode(anyString());
+  }
+
+  @Test
+  public void should_reject_registration_with_an_already_used_username() {
+    when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("john"))
+        .thenReturn(Optional.of(new User("other@example.com", "john", "123", "", "")));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () -> userService.createUser(new RegisterParam("john@example.com", "john", "123456")))
+        .satisfies(
+            exception ->
+                assertThat(exception.getConstraintViolations())
+                    .extracting(ConstraintViolation::getMessage)
+                    .containsExactly("duplicated username"));
+
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  public void should_update_all_the_fields_of_the_target_user() {
+    User user = new User("john@example.com", "john", "123", "old bio", "old image");
+    when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+
+    userService.updateUser(
+        new UpdateUserCommand(
+            user,
+            UpdateUserParam.builder()
+                .email("new@example.com")
+                .username("newname")
+                .password("new password")
+                .bio("new bio")
+                .image("new image")
+                .build()));
+
+    verify(userRepository).save(user);
+    assertThat(user.getEmail()).isEqualTo("new@example.com");
+    assertThat(user.getUsername()).isEqualTo("newname");
+    assertThat(user.getPassword()).isEqualTo("new password");
+    assertThat(user.getBio()).isEqualTo("new bio");
+    assertThat(user.getImage()).isEqualTo("new image");
+  }
+
+  @Test
+  public void should_keep_the_fields_left_empty_in_the_update_param() {
+    User user = new User("john@example.com", "john", "123", "old bio", "old image");
+    when(userRepository.findByEmail("")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("")).thenReturn(Optional.empty());
+
+    userService.updateUser(
+        new UpdateUserCommand(user, UpdateUserParam.builder().bio("new bio").build()));
+
+    verify(userRepository).save(user);
+    assertThat(user.getEmail()).isEqualTo("john@example.com");
+    assertThat(user.getUsername()).isEqualTo("john");
+    assertThat(user.getPassword()).isEqualTo("123");
+    assertThat(user.getBio()).isEqualTo("new bio");
+    assertThat(user.getImage()).isEqualTo("old image");
+  }
+
+  @Test
+  public void should_accept_an_update_keeping_the_email_and_username_of_the_same_user() {
+    User user = new User("john@example.com", "john", "123", "", "");
+    when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.of(user));
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
+
+    userService.updateUser(
+        new UpdateUserCommand(
+            user,
+            UpdateUserParam.builder()
+                .email("john@example.com")
+                .username("john")
+                .bio("new bio")
+                .build()));
+
+    verify(userRepository).save(user);
+    assertThat(user.getBio()).isEqualTo("new bio");
+  }
+
+  @Test
+  public void should_reject_an_update_with_the_email_of_another_user() {
+    User user = new User("john@example.com", "john", "123", "", "");
+    User anotherUser = new User("taken@example.com", "other", "123", "", "");
+    when(userRepository.findByEmail("taken@example.com")).thenReturn(Optional.of(anotherUser));
+    when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () ->
+                userService.updateUser(
+                    new UpdateUserCommand(
+                        user,
+                        UpdateUserParam.builder()
+                            .email("taken@example.com")
+                            .username("john")
+                            .build())))
+        .satisfies(
+            exception -> {
+              assertThat(exception.getConstraintViolations())
+                  .extracting(ConstraintViolation::getMessage)
+                  .containsExactly("email already exist");
+              assertThat(exception.getConstraintViolations())
+                  .allSatisfy(
+                      violation ->
+                          assertThat(violation.getPropertyPath().toString()).endsWith("email"));
+            });
+
+    verify(userRepository, never()).save(any());
+    assertThat(user.getEmail()).isEqualTo("john@example.com");
+  }
+
+  @Test
+  public void should_reject_an_update_with_the_username_of_another_user() {
+    User user = new User("john@example.com", "john", "123", "", "");
+    User anotherUser = new User("other@example.com", "taken", "123", "", "");
+    when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.of(user));
+    when(userRepository.findByUsername("taken")).thenReturn(Optional.of(anotherUser));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () ->
+                userService.updateUser(
+                    new UpdateUserCommand(
+                        user,
+                        UpdateUserParam.builder()
+                            .email("john@example.com")
+                            .username("taken")
+                            .build())))
+        .satisfies(
+            exception ->
+                assertThat(exception.getConstraintViolations())
+                    .extracting(ConstraintViolation::getMessage)
+                    .containsExactly("username already exist"));
+
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  public void should_report_both_email_and_username_when_both_are_taken() {
+    User user = new User("john@example.com", "john", "123", "", "");
+    when(userRepository.findByEmail("taken@example.com"))
+        .thenReturn(Optional.of(new User("taken@example.com", "someone", "123", "", "")));
+    when(userRepository.findByUsername("taken"))
+        .thenReturn(Optional.of(new User("other@example.com", "taken", "123", "", "")));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () ->
+                userService.updateUser(
+                    new UpdateUserCommand(
+                        user,
+                        UpdateUserParam.builder()
+                            .email("taken@example.com")
+                            .username("taken")
+                            .build())))
+        .satisfies(
+            exception ->
+                assertThat(exception.getConstraintViolations())
+                    .extracting(ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder("email already exist", "username already exist"));
+
+    verify(userRepository, never()).save(any());
+  }
+}


### PR DESCRIPTION
## Summary

Adds unit tests for `ArticleCommandService`, `UserService` and the three constraint validators. Test-only change; no `src/main` code touched.

Both command services are `@Validated`, so their bean-validation behaviour (`@Valid NewArticleParam`, `@Valid UpdateUserCommand`) only fires through the Spring method-validation proxy, and the constraint validators get their collaborators via `@Autowired` field injection. The service tests therefore build a throwaway context per test instead of instantiating the service directly:

```java
context.registerBean(ArticleRepository.class, () -> articleRepository);   // Mockito mock
context.registerBean(ArticleQueryService.class, () -> articleQueryService);
context.registerBean(LocalValidatorFactoryBean.class, LocalValidatorFactoryBean::new);
context.registerBean(MethodValidationPostProcessor.class, () -> { ...setValidator(lvfb) });
context.registerBean(ArticleCommandService.class);
```

`LocalValidatorFactoryBean` supplies the Spring-backed `ConstraintValidatorFactory`, so `DuplicatedArticleValidator`/`DuplicatedEmailValidator`/`UpdateUserValidator` resolve their mocked repositories, and violations surface as `ConstraintViolationException` (the API layer is what turns those into `InvalidRequestException`, so the exception asserted here is the one the service actually throws).

Coverage:

| package | before | after |
| --- | --- | --- |
| `io/spring/application/article` | 20.5% (36/176) | 94.3% (166/176) |
| `io/spring/application/user` | 52.2% (198/379) | 96.8% (367/379) |

What is asserted, beyond happy paths:
- `createArticle`: `ArgumentCaptor` on `articleRepository.save` checks title/slug/description/body/author id and de-duplicated tag list; duplicated title yields `article name exists` and no `save`; blank fields yield `can't be empty` and no `save`.
- `updateArticle`: title change also re-slugs; fields left empty in `UpdateArticleParam` keep their previous values.
- `createUser`: password stored is the `PasswordEncoder.encode` result, image is the configured default; duplicated email / username each reject before `save` (and before encoding).
- `updateUser` + `UpdateUserValidator`: email or username owned by *another* user is rejected (property path points at `email`), both taken reports both messages, and email/username belonging to the same user is accepted.
- Validators: repository-finds-nothing vs. duplicate found, plus the null/empty short-circuit that skips the lookup; `DuplicatedArticleValidator` is asserted to look up the *slugified* title.

Note: `@Email` on `UpdateUserParam` is not cascaded from `updateUser` (`UpdateUserCommand.param` has no `@Valid`), so that constraint is exercised at the API layer, not here.


Link to Devin session: https://app.devin.ai/sessions/8216ba384d0b48e1a2d5816ca9e2332f
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/912?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->