### PR TITLE
test: cover TagsApi and the REST exception handling layer

### DIFF
--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -1,0 +1,70 @@
+package io.spring.api;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.JacksonCustomizations;
+import io.spring.api.security.WebSecurityConfig;
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TagsApi.class)
+@Import({WebSecurityConfig.class, JacksonCustomizations.class})
+public class TagsApiTest extends TestWithCurrentUser {
+  @Autowired private MockMvc mvc;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @Override
+  @BeforeEach
+  public void setUp() throws Exception {
+    super.setUp();
+    RestAssuredMockMvc.mockMvc(mvc);
+  }
+
+  @Test
+  public void should_get_tags_success() throws Exception {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring", "jpg"));
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .then()
+        .statusCode(200)
+        .body("tags", hasSize(3))
+        .body("tags", contains("java", "spring", "jpg"));
+
+    verify(tagsQueryService).allTags();
+  }
+
+  @Test
+  public void should_get_empty_tags_success() throws Exception {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    RestAssuredMockMvc.when().get("/tags").then().statusCode(200).body("tags", empty());
+  }
+
+  @Test
+  public void should_get_tags_without_authentication() throws Exception {
+    when(tagsQueryService.allTags()).thenReturn(Collections.singletonList("java"));
+
+    RestAssuredMockMvc.given()
+        .header("Authorization", "Token " + token)
+        .when()
+        .get("/tags")
+        .then()
+        .statusCode(200)
+        .body("tags", contains("java"));
+  }
+}

--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -56,7 +56,7 @@ public class TagsApiTest extends TestWithCurrentUser {
   }
 
   @Test
-  public void should_get_tags_without_authentication() throws Exception {
+  public void should_get_tags_for_an_authenticated_user() throws Exception {
     when(tagsQueryService.allTags()).thenReturn(Collections.singletonList("java"));
 
     RestAssuredMockMvc.given()

--- a/src/test/java/io/spring/api/exception/ApiExceptionsTest.java
+++ b/src/test/java/io/spring/api/exception/ApiExceptionsTest.java
@@ -1,0 +1,60 @@
+package io.spring.api.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public class ApiExceptionsTest {
+
+  @Test
+  public void invalid_request_exception_should_expose_the_binding_errors() {
+    Errors errors = new BeanPropertyBindingResult(new Object(), "target");
+    errors.reject("invalid", "invalid target");
+
+    InvalidRequestException exception = new InvalidRequestException(errors);
+
+    assertSame(errors, exception.getErrors());
+    assertEquals("", exception.getMessage());
+    assertTrue(exception instanceof RuntimeException);
+  }
+
+  @Test
+  public void resource_not_found_exception_should_be_mapped_to_404() {
+    ResponseStatus responseStatus =
+        ResourceNotFoundException.class.getAnnotation(ResponseStatus.class);
+
+    assertEquals(HttpStatus.NOT_FOUND, responseStatus.value());
+    assertTrue(new ResourceNotFoundException() instanceof RuntimeException);
+  }
+
+  @Test
+  public void no_authorization_exception_should_be_mapped_to_403() {
+    ResponseStatus responseStatus =
+        NoAuthorizationException.class.getAnnotation(ResponseStatus.class);
+
+    assertEquals(HttpStatus.FORBIDDEN, responseStatus.value());
+    assertTrue(new NoAuthorizationException() instanceof RuntimeException);
+  }
+
+  @Test
+  public void field_error_resource_should_expose_its_parts() {
+    FieldErrorResource fieldErrorResource =
+        new FieldErrorResource("loginParam", "email", "NotBlank", "can't be empty");
+
+    assertEquals("loginParam", fieldErrorResource.getResource());
+    assertEquals("email", fieldErrorResource.getField());
+    assertEquals("NotBlank", fieldErrorResource.getCode());
+    assertEquals("can't be empty", fieldErrorResource.getMessage());
+  }
+
+  @Test
+  public void invalid_authentication_exception_should_carry_a_default_message() {
+    assertEquals("invalid email or password", new InvalidAuthenticationException().getMessage());
+  }
+}

--- a/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
@@ -1,0 +1,218 @@
+package io.spring.api.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Method;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.executable.ExecutableValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+public class CustomizeExceptionHandlerTest {
+
+  private static final ValidatorFactory VALIDATOR_FACTORY =
+      Validation.buildDefaultValidatorFactory();
+
+  private MockMvc mvc;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  public void setUp() {
+    mvc =
+        MockMvcBuilders.standaloneSetup(new TestController())
+            .setControllerAdvice(new CustomizeExceptionHandler())
+            .build();
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  public void should_handle_invalid_request_exception_with_422_and_grouped_errors()
+      throws Exception {
+    ResultActions result =
+        mvc.perform(get("/test/invalid-request"))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(
+                mvcResult ->
+                    assertEquals(
+                        MediaType.APPLICATION_JSON_VALUE,
+                        mvcResult.getResponse().getContentType()));
+
+    assertJsonBody(
+        "{\"errors\":{"
+            + "\"email\":[\"can't be empty\",\"should be an email\"],"
+            + "\"password\":[\"can't be empty\"]}}",
+        result);
+  }
+
+  @Test
+  public void should_handle_bean_validation_failure_with_422_and_grouped_errors() throws Exception {
+    ResultActions result =
+        mvc.perform(
+                post("/test/validated")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"email\":\"not-an-email\",\"password\":\"\"}"))
+            .andExpect(status().isUnprocessableEntity());
+
+    assertJsonBody(
+        "{\"errors\":{"
+            + "\"email\":[\"should be an email\"],"
+            + "\"password\":[\"can't be empty\"]}}",
+        result);
+  }
+
+  @Test
+  public void should_handle_constraint_violation_of_a_bean_property_with_422() throws Exception {
+    ResultActions result =
+        mvc.perform(get("/test/bean-constraint-violation"))
+            .andExpect(status().isUnprocessableEntity());
+
+    assertJsonBody("{\"errors\":{\"password\":[\"can't be empty\"]}}", result);
+  }
+
+  @Test
+  public void should_strip_method_and_parameter_from_constraint_violation_property_path()
+      throws Exception {
+    ResultActions result =
+        mvc.perform(get("/test/method-constraint-violation"))
+            .andExpect(status().isUnprocessableEntity());
+
+    assertJsonBody("{\"errors\":{\"password\":[\"can't be empty\"]}}", result);
+  }
+
+  @Test
+  public void should_handle_invalid_authentication_exception_with_422_and_message()
+      throws Exception {
+    ResultActions result =
+        mvc.perform(get("/test/invalid-authentication"))
+            .andExpect(status().isUnprocessableEntity());
+
+    assertJsonBody("{\"message\":\"invalid email or password\"}", result);
+  }
+
+  @Test
+  public void should_map_resource_not_found_exception_to_404() throws Exception {
+    mvc.perform(get("/test/not-found")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void should_map_no_authorization_exception_to_403() throws Exception {
+    mvc.perform(get("/test/forbidden")).andExpect(status().isForbidden());
+  }
+
+  private void assertJsonBody(String expected, ResultActions result) throws Exception {
+    assertEquals(
+        objectMapper.readTree(expected),
+        objectMapper.readTree(result.andReturn().getResponse().getContentAsString()));
+  }
+
+  private static Set<ConstraintViolation<TestParam>> beanViolations(TestParam param) {
+    return VALIDATOR_FACTORY.getValidator().validate(param);
+  }
+
+  private static Set<ConstraintViolation<TestService>> methodViolations(TestParam param)
+      throws NoSuchMethodException {
+    Validator validator = VALIDATOR_FACTORY.getValidator();
+    ExecutableValidator executableValidator = validator.forExecutables();
+    Method method = TestService.class.getMethod("update", TestParam.class);
+    return executableValidator.validateParameters(new TestService(), method, new Object[] {param});
+  }
+
+  @RestController
+  @RequestMapping("/test")
+  static class TestController {
+
+    @RequestMapping("/invalid-request")
+    public void invalidRequest() {
+      Errors errors = new BeanPropertyBindingResult(new TestParam(), "testParam");
+      errors.rejectValue("email", "NotBlank", "can't be empty");
+      errors.rejectValue("email", "Email", "should be an email");
+      errors.rejectValue("password", "NotBlank", "can't be empty");
+      throw new InvalidRequestException(errors);
+    }
+
+    @PostMapping("/validated")
+    public void validated(@Valid @RequestBody TestParam param) {}
+
+    @RequestMapping("/bean-constraint-violation")
+    public void beanConstraintViolation() {
+      throw new ConstraintViolationException(beanViolations(new TestParam("a@b.com", "")));
+    }
+
+    @RequestMapping("/method-constraint-violation")
+    public void methodConstraintViolation() throws NoSuchMethodException {
+      throw new ConstraintViolationException(methodViolations(new TestParam("a@b.com", "")));
+    }
+
+    @RequestMapping("/invalid-authentication")
+    public void invalidAuthentication() {
+      throw new InvalidAuthenticationException();
+    }
+
+    @RequestMapping("/not-found")
+    public void notFound() {
+      throw new ResourceNotFoundException();
+    }
+
+    @RequestMapping("/forbidden")
+    public void forbidden() {
+      throw new NoAuthorizationException();
+    }
+  }
+
+  static class TestService {
+    public void update(@Valid TestParam param) {}
+  }
+
+  static class TestParam {
+    @Email(message = "should be an email")
+    private String email;
+
+    @NotBlank(message = "can't be empty")
+    private String password;
+
+    TestParam() {}
+
+    TestParam(String email, String password) {
+      this.email = email;
+      this.password = password;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public void setEmail(String email) {
+      this.email = email;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+  }
+}

--- a/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
@@ -17,6 +17,7 @@ import javax.validation.ValidatorFactory;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.executable.ExecutableValidator;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -45,6 +46,11 @@ public class CustomizeExceptionHandlerTest {
             .setControllerAdvice(new CustomizeExceptionHandler())
             .build();
     objectMapper = new ObjectMapper();
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    VALIDATOR_FACTORY.close();
   }
 
   @Test

--- a/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/api/exception/CustomizeExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package io.spring.api.exception;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,11 +60,7 @@ public class CustomizeExceptionHandlerTest {
     ResultActions result =
         mvc.perform(get("/test/invalid-request"))
             .andExpect(status().isUnprocessableEntity())
-            .andExpect(
-                mvcResult ->
-                    assertEquals(
-                        MediaType.APPLICATION_JSON_VALUE,
-                        mvcResult.getResponse().getContentType()));
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
 
     assertJsonBody(
         "{\"errors\":{"

--- a/src/test/java/io/spring/api/exception/ErrorResourceSerializerTest.java
+++ b/src/test/java/io/spring/api/exception/ErrorResourceSerializerTest.java
@@ -1,0 +1,100 @@
+package io.spring.api.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+public class ErrorResourceSerializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  public void setUp() {
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  public void should_serialize_single_field_error() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Collections.singletonList(
+                new FieldErrorResource("registerParam", "email", "Email", "should be an email")));
+
+    assertJsonEquals("{\"errors\":{\"email\":[\"should be an email\"]}}", errorResource);
+  }
+
+  @Test
+  public void should_group_multiple_messages_of_the_same_field_into_one_list() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Arrays.asList(
+                new FieldErrorResource("loginParam", "email", "NotBlank", "can't be empty"),
+                new FieldErrorResource("loginParam", "email", "Email", "should be an email")));
+
+    assertJsonEquals(
+        "{\"errors\":{\"email\":[\"can't be empty\",\"should be an email\"]}}", errorResource);
+  }
+
+  @Test
+  public void should_keep_errors_of_different_fields_separated() throws Exception {
+    ErrorResource errorResource =
+        new ErrorResource(
+            Arrays.asList(
+                new FieldErrorResource("loginParam", "email", "NotBlank", "can't be empty"),
+                new FieldErrorResource("loginParam", "password", "NotBlank", "can't be empty"),
+                new FieldErrorResource("loginParam", "email", "Email", "should be an email")));
+
+    assertJsonEquals(
+        "{\"errors\":{"
+            + "\"email\":[\"can't be empty\",\"should be an email\"],"
+            + "\"password\":[\"can't be empty\"]}}",
+        errorResource);
+  }
+
+  @Test
+  public void should_serialize_empty_errors_object_when_no_field_error() throws Exception {
+    assertJsonEquals("{\"errors\":{}}", new ErrorResource(Collections.emptyList()));
+  }
+
+  @Test
+  public void should_finish_the_json_document_when_writing_a_message_fails() throws Exception {
+    JsonGenerator generator = mock(JsonGenerator.class);
+    doThrow(new IOException("boom")).when(generator).writeString(anyString());
+
+    new ErrorResourceSerializer()
+        .serialize(
+            new ErrorResource(
+                Collections.singletonList(
+                    new FieldErrorResource("loginParam", "email", "NotBlank", "can't be empty"))),
+            generator,
+            null);
+
+    InOrder inOrder = inOrder(generator);
+    inOrder.verify(generator).writeStartObject();
+    inOrder.verify(generator).writeObjectFieldStart("errors");
+    inOrder.verify(generator).writeArrayFieldStart("email");
+    inOrder.verify(generator).writeString("can't be empty");
+    inOrder.verify(generator).writeEndArray();
+    inOrder.verify(generator, times(2)).writeEndObject();
+  }
+
+  private void assertJsonEquals(String expected, ErrorResource actual) throws Exception {
+    assertEquals(objectMapper.readTree(expected), objectMapper.readTree(writeAsString(actual)));
+  }
+
+  private String writeAsString(ErrorResource errorResource) throws Exception {
+    return objectMapper.writeValueAsString(errorResource);
+  }
+}

--- a/src/test/java/io/spring/api/exception/ExceptionHandlingApiTest.java
+++ b/src/test/java/io/spring/api/exception/ExceptionHandlingApiTest.java
@@ -1,0 +1,173 @@
+package io.spring.api.exception;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.JacksonCustomizations;
+import io.spring.api.CommentsApi;
+import io.spring.api.ProfileApi;
+import io.spring.api.UsersApi;
+import io.spring.api.security.WebSecurityConfig;
+import io.spring.application.CommentQueryService;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.UserQueryService;
+import io.spring.application.user.UserService;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * End to end coverage of the {@code @ControllerAdvice} wiring: the exceptions are raised by the
+ * real controllers and translated by {@link CustomizeExceptionHandler}.
+ */
+@WebMvcTest({UsersApi.class, CommentsApi.class, ProfileApi.class})
+@Import({WebSecurityConfig.class, JacksonCustomizations.class})
+public class ExceptionHandlingApiTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private UserRepository userRepository;
+  @MockBean private JwtService jwtService;
+  @MockBean private UserQueryService userQueryService;
+  @MockBean private UserService userService;
+  @MockBean private ArticleRepository articleRepository;
+  @MockBean private CommentRepository commentRepository;
+  @MockBean private CommentQueryService commentQueryService;
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private User user;
+  private String token;
+  private Article article;
+  private Comment comment;
+
+  @BeforeEach
+  public void setUp() {
+    RestAssuredMockMvc.mockMvc(mvc);
+
+    user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    token = "token";
+    when(jwtService.getSubFromToken(eq(token))).thenReturn(Optional.of(user.getId()));
+    when(userRepository.findById(eq(user.getId()))).thenReturn(Optional.of(user));
+
+    User anotherUser = new User("other@example.com", "other", "123", "", "");
+    article = new Article("title", "desc", "body", Arrays.asList("java"), anotherUser.getId());
+    comment = new Comment("comment", anotherUser.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+  }
+
+  @Test
+  public void should_return_422_with_all_violations_of_the_same_field() {
+    Map<String, Object> param = loginParam(" ", "");
+
+    given()
+        .contentType("application/json")
+        .body(param)
+        .when()
+        .post("/users/login")
+        .then()
+        .statusCode(422)
+        .body("errors", aMapWithSize(2))
+        .body("errors.email", hasSize(2))
+        .body("errors.email", containsInAnyOrder("can't be empty", "should be an email"))
+        .body("errors.password", contains("can't be empty"));
+  }
+
+  @Test
+  public void should_return_422_with_one_message_per_violated_field() {
+    Map<String, Object> param = loginParam("not-an-email", "123");
+
+    given()
+        .contentType("application/json")
+        .body(param)
+        .when()
+        .post("/users/login")
+        .then()
+        .statusCode(422)
+        .body("errors", aMapWithSize(1))
+        .body("errors.email", contains("should be an email"));
+  }
+
+  @Test
+  public void should_return_404_when_the_article_of_the_comments_does_not_exist() {
+    when(articleRepository.findBySlug(eq("not-exists"))).thenReturn(Optional.empty());
+
+    RestAssuredMockMvc.when().get("/articles/{slug}/comments", "not-exists").then().statusCode(404);
+  }
+
+  @Test
+  public void should_return_404_when_deleting_a_comment_that_does_not_exist() {
+    when(commentRepository.findById(eq(article.getId()), eq("not-exists")))
+        .thenReturn(Optional.empty());
+
+    given()
+        .header("Authorization", "Token " + token)
+        .when()
+        .delete("/articles/{slug}/comments/{id}", article.getSlug(), "not-exists")
+        .then()
+        .statusCode(404);
+  }
+
+  @Test
+  public void should_return_404_when_unfollowing_an_unknown_user() {
+    when(userRepository.findByUsername(eq("unknown"))).thenReturn(Optional.empty());
+
+    given()
+        .header("Authorization", "Token " + token)
+        .when()
+        .delete("/profiles/{username}/follow", "unknown")
+        .then()
+        .statusCode(404);
+  }
+
+  @Test
+  public void should_return_403_when_deleting_a_comment_of_another_user() {
+    given()
+        .header("Authorization", "Token " + token)
+        .when()
+        .delete("/articles/{slug}/comments/{id}", article.getSlug(), comment.getId())
+        .then()
+        .statusCode(403);
+
+    verify(commentRepository, never()).remove(eq(comment));
+  }
+
+  private Map<String, Object> loginParam(final String email, final String password) {
+    return new HashMap<String, Object>() {
+      {
+        put(
+            "user",
+            new HashMap<String, Object>() {
+              {
+                put("email", email);
+                put("password", password);
+              }
+            });
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Tests only — no production code touched. Closes the two remaining gaps in the REST layer: `TagsApi` (previously untested) and the error-response paths in `io.spring.api.exception`.

Coverage (JaCoCo instruction, `build/reports/jacoco/test/jacocoTestReport.xml`):

| package | before | after |
| --- | --- | --- |
| `io.spring.api` | 97.0% (766/790) | **100.0% (790/790)** |
| `io.spring.api.exception` | 78.4% (240/306) | **100.0% (306/306)** |

New files:

- `api/TagsApiTest` — rest-assured `@WebMvcTest(TagsApi.class)`, asserts the `{"tags": [...]}` shape for a populated list, an empty list, and an authenticated caller.
- `api/exception/ExceptionHandlingApiTest` — drives the real `@ControllerAdvice` wiring through `UsersApi`/`CommentsApi`/`ProfileApi`: 422 with the serializer's list grouping (`POST /users/login` with `email=" "` violates both `@NotBlank` and `@Email`, so `errors.email` has two messages), 404 from `ResourceNotFoundException` (unknown article slug, unknown comment, unfollow of an unknown user — the last was the only uncovered line left in `io.spring.api`), and 403 from `NoAuthorizationException` when deleting another user's comment.
- `api/exception/CustomizeExceptionHandlerTest` — standalone `MockMvc` over a test controller with `.setControllerAdvice(new CustomizeExceptionHandler())`, for the branches a real request can't reach: `InvalidRequestException` (asserts the exact `{"errors":{"email":[…,…],"password":[…]}}` body and the JSON content type), `MethodArgumentNotValidException`, `InvalidAuthenticationException`, and `ConstraintViolationException` both from bean validation (path `password`) and from method validation (path `update.arg0.password`), which pins `getParam`'s stripping of the method/parameter prefix down to `password`.
- `api/exception/ErrorResourceSerializerTest` — direct `ObjectMapper` serialization: grouping several messages under one field, separating fields, `{"errors":{}}` for an empty list, and the swallowed-`IOException` path (mocked `JsonGenerator` that throws on `writeString`, verifying the document is still closed).
- `api/exception/ApiExceptionsTest` — `InvalidRequestException.getErrors()`, the `@ResponseStatus` mappings of `ResourceNotFoundException` (404) / `NoAuthorizationException` (403), `InvalidAuthenticationException`'s default message, and `FieldErrorResource`'s accessors.

Note: `CustomizeExceptionHandler` has no generic `Exception` → 500 fallback, so there is no such branch to cover; adding one would be a production change, which this task excludes.

`./gradlew spotlessApply test jacocoTestReport` is green (94 tests).


Link to Devin session: https://app.devin.ai/sessions/5bf94baab8214e99ad8ae004f7a82395
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/913?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->