### PR TITLE
test: cover DGS GraphQL datafetchers, mutations and exception handler

### DIFF
--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -13,6 +13,7 @@ import graphql.ExecutionResult;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import io.spring.TestHelper;
+import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -85,7 +86,7 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
 
     ExecutionResult result = dgsQueryExecutor.execute("{ article(slug: \"missing\") { slug } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
   }
 
   @Test
@@ -121,7 +122,7 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
 
     ExecutionResult result = dgsQueryExecutor.execute("{ articles { edges { node { slug } } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, IllegalArgumentException.class);
   }
 
   @Test
@@ -220,7 +221,7 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
             "{ profile(username: \"author\") { profile { feed(first: 10)"
                 + " { edges { node { slug } } } } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
   }
 
   @Test
@@ -261,15 +262,16 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
     anonymous();
     stubAuthorProfile();
 
-    assertThat(dgsQueryExecutor.execute("{ feed { edges { node { slug } } } }").getErrors())
-        .isNotEmpty();
+    assertSingleErrorFrom(
+        dgsQueryExecutor.execute("{ feed { edges { node { slug } } } }"),
+        IllegalArgumentException.class);
     for (String field : new String[] {"articles", "favorites", "feed"}) {
       ExecutionResult result =
           dgsQueryExecutor.execute(
               "{ profile(username: \"author\") { profile { "
                   + field
                   + " { edges { node { slug } } } } } }");
-      assertThat(result.getErrors()).as(field).isNotEmpty();
+      assertSingleErrorFrom(result, IllegalArgumentException.class);
     }
   }
 

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -3,10 +3,10 @@ package io.spring.graphql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.jayway.jsonpath.DocumentContext;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
@@ -24,6 +24,7 @@ import io.spring.application.data.CommentData;
 import io.spring.application.data.ProfileData;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import io.spring.graphql.types.Article;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +38,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(
-    classes = {DgsAutoConfiguration.class, ArticleDatafetcher.class, ProfileDatafetcher.class})
+    classes = {
+      DgsAutoConfiguration.class,
+      ArticleDatafetcher.class,
+      ProfileDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class ArticleDatafetcherTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
@@ -67,16 +73,15 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
             + data.getSlug()
             + "\") { slug title body favorited favoritesCount author { username bio } } }";
 
-    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(query, "data.article.slug"))
-        .isEqualTo(data.getSlug());
-    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(query, "data.article.title"))
-        .isEqualTo(data.getTitle());
-    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(query, "data.article.body"))
-        .isEqualTo(data.getBody());
-    assertThat(
-            dgsQueryExecutor.<String>executeAndExtractJsonPath(
-                query, "data.article.author.username"))
-        .isEqualTo("author");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
+
+    assertThat(context.read("data.article.slug", String.class)).isEqualTo(data.getSlug());
+    assertThat(context.read("data.article.title", String.class)).isEqualTo(data.getTitle());
+    assertThat(context.read("data.article.body", String.class)).isEqualTo(data.getBody());
+    assertThat(context.read("data.article.favorited", Boolean.class)).isFalse();
+    assertThat(context.read("data.article.author.username", String.class)).isEqualTo("author");
+    assertThat(context.read("data.article.author.bio", String.class)).isEqualTo("author bio");
+    verify(articleQueryService).findBySlug(eq(data.getSlug()), eq(null));
   }
 
   @Test
@@ -103,17 +108,14 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
         "{ articles(first: 10) { edges { node { slug author { username } } }"
             + " pageInfo { hasNextPage hasPreviousPage } } }";
 
-    List<String> slugs =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.edges[*].node.slug");
-    List<String> usernames =
-        dgsQueryExecutor.executeAndExtractJsonPath(
-            query, "data.articles.edges[*].node.author.username");
-    Boolean hasNext =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.hasNextPage");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(slugs).containsExactly(data.getSlug());
-    assertThat(usernames).containsExactly("author");
-    assertThat(hasNext).isFalse();
+    assertThat(context.<List<String>>read("data.articles.edges[*].node.slug"))
+        .containsExactly(data.getSlug());
+    assertThat(context.<List<String>>read("data.articles.edges[*].node.author.username"))
+        .containsExactly("author");
+    assertThat(context.read("data.articles.pageInfo.hasNextPage", Boolean.class)).isFalse();
+    assertThat(context.read("data.articles.pageInfo.hasPreviousPage", Boolean.class)).isFalse();
   }
 
   @Test
@@ -140,16 +142,13 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
             + "\", withTag: \"java\", authoredBy: \"author\", favoritedBy: \"fan\")"
             + " { edges { cursor node { slug } } pageInfo { hasPreviousPage hasNextPage } } }";
 
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
+
+    assertThat(context.read("data.articles.pageInfo.hasPreviousPage", Boolean.class)).isTrue();
+    assertThat(context.read("data.articles.pageInfo.hasNextPage", Boolean.class)).isFalse();
     ArgumentCaptor<CursorPageParameter<DateTime>> captor =
         ArgumentCaptor.forClass(CursorPageParameter.class);
-    Boolean hasPrevious =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.hasPreviousPage");
-    Boolean hasNext =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.hasNextPage");
-
-    assertThat(hasPrevious).isTrue();
-    assertThat(hasNext).isFalse();
-    verify(articleQueryService, atLeastOnce())
+    verify(articleQueryService)
         .findRecentArticlesWithCursor(
             eq("java"), eq("author"), eq("fan"), captor.capture(), eq(null));
     assertThat(captor.getValue().getDirection()).isEqualTo(Direction.PREV);
@@ -245,15 +244,17 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
               + cursor
               + "\") { edges { node { slug } } pageInfo { hasPreviousPage } } } } }";
 
-      List<String> slugs =
-          dgsQueryExecutor.executeAndExtractJsonPath(
-              query, "data.profile.profile." + field + ".edges[*].node.slug");
-      Boolean hasPrevious =
-          dgsQueryExecutor.executeAndExtractJsonPath(
-              query, "data.profile.profile." + field + ".pageInfo.hasPreviousPage");
+      DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-      assertThat(slugs).as(field).containsExactly(data.getSlug());
-      assertThat(hasPrevious).as(field).isTrue();
+      assertThat(
+              context.<List<String>>read("data.profile.profile." + field + ".edges[*].node.slug"))
+          .as(field)
+          .containsExactly(data.getSlug());
+      assertThat(
+              context.read(
+                  "data.profile.profile." + field + ".pageInfo.hasPreviousPage", Boolean.class))
+          .as(field)
+          .isTrue();
     }
   }
 
@@ -293,7 +294,7 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
     assertThat(hasPrevious).isTrue();
     ArgumentCaptor<CursorPageParameter<DateTime>> captor =
         ArgumentCaptor.forClass(CursorPageParameter.class);
-    verify(articleQueryService, atLeastOnce()).findUserFeedWithCursor(eq(author), captor.capture());
+    verify(articleQueryService).findUserFeedWithCursor(eq(author), captor.capture());
     assertThat(captor.getValue().getDirection()).isEqualTo(Direction.PREV);
     assertThat(captor.getValue().getCursor().getMillis())
         .isEqualTo(data.getUpdatedAt().getMillis());
@@ -309,15 +310,12 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
         "{ articles(first: 10) { edges { node { slug } }"
             + " pageInfo { startCursor endCursor hasNextPage } } }";
 
-    List<Object> edges = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.edges");
-    String startCursor =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.startCursor");
-    String endCursor =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.endCursor");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(edges).isEmpty();
-    assertThat(startCursor).isNull();
-    assertThat(endCursor).isNull();
+    assertThat(context.<List<Object>>read("data.articles.edges")).isEmpty();
+    assertThat(context.read("data.articles.pageInfo.startCursor", String.class)).isNull();
+    assertThat(context.read("data.articles.pageInfo.endCursor", String.class)).isNull();
+    assertThat(context.read("data.articles.pageInfo.hasNextPage", Boolean.class)).isFalse();
   }
 
   @Test
@@ -355,12 +353,11 @@ class ArticleDatafetcherTest extends GraphQLTestBase {
 
     String query = "{ feed(first: 5) { edges { node { slug } } pageInfo { hasNextPage } } }";
 
-    List<String> slugs =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.feed.edges[*].node.slug");
-    Boolean hasNext =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.feed.pageInfo.hasNextPage");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(slugs).containsExactly(data.getSlug());
-    assertThat(hasNext).isTrue();
+    assertThat(context.<List<String>>read("data.feed.edges[*].node.slug"))
+        .containsExactly(data.getSlug());
+    assertThat(context.read("data.feed.pageInfo.hasNextPage", Boolean.class)).isTrue();
+    verify(articleQueryService).findUserFeedWithCursor(eq(author), any());
   }
 }

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,364 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.Article;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, ArticleDatafetcher.class, ProfileDatafetcher.class})
+class ArticleDatafetcherTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ArticleQueryService articleQueryService;
+  @MockBean private UserRepository userRepository;
+  // Collaborator for ProfileDatafetcher, imported to resolve the nested author.
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private final User author = new User("a@example.com", "author", "123", "author bio", "a.png");
+
+  private void stubAuthorProfile() {
+    when(profileQueryService.findByUsername(eq("author"), any()))
+        .thenReturn(
+            Optional.of(new ProfileData(author.getId(), "author", "author bio", "a.png", false)));
+  }
+
+  @Test
+  void should_find_article_by_slug_with_nested_author() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("1", author);
+    when(articleQueryService.findBySlug(eq(data.getSlug()), any())).thenReturn(Optional.of(data));
+    stubAuthorProfile();
+
+    String query =
+        "{ article(slug: \""
+            + data.getSlug()
+            + "\") { slug title body favorited favoritesCount author { username bio } } }";
+
+    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(query, "data.article.slug"))
+        .isEqualTo(data.getSlug());
+    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(query, "data.article.title"))
+        .isEqualTo(data.getTitle());
+    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(query, "data.article.body"))
+        .isEqualTo(data.getBody());
+    assertThat(
+            dgsQueryExecutor.<String>executeAndExtractJsonPath(
+                query, "data.article.author.username"))
+        .isEqualTo("author");
+  }
+
+  @Test
+  void should_error_when_article_not_found_by_slug() {
+    anonymous();
+    when(articleQueryService.findBySlug(eq("missing"), any())).thenReturn(Optional.empty());
+
+    ExecutionResult result = dgsQueryExecutor.execute("{ article(slug: \"missing\") { slug } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_return_articles_connection_with_nested_author() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("2", author);
+    CursorPager<ArticleData> pager =
+        new CursorPager<>(Collections.singletonList(data), Direction.NEXT, false);
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(pager);
+    stubAuthorProfile();
+
+    String query =
+        "{ articles(first: 10) { edges { node { slug author { username } } }"
+            + " pageInfo { hasNextPage hasPreviousPage } } }";
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.edges[*].node.slug");
+    List<String> usernames =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            query, "data.articles.edges[*].node.author.username");
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.hasNextPage");
+
+    assertThat(slugs).containsExactly(data.getSlug());
+    assertThat(usernames).containsExactly("author");
+    assertThat(hasNext).isFalse();
+  }
+
+  @Test
+  void should_error_articles_when_neither_first_nor_last() {
+    anonymous();
+
+    ExecutionResult result = dgsQueryExecutor.execute("{ articles { edges { node { slug } } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_return_articles_backwards_when_paging_with_last_and_before() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("2b", author);
+    CursorPager<ArticleData> pager =
+        new CursorPager<>(Collections.singletonList(data), Direction.PREV, true);
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(pager);
+
+    String query =
+        "{ articles(last: 5, before: \""
+            + data.getCursor()
+            + "\", withTag: \"java\", authoredBy: \"author\", favoritedBy: \"fan\")"
+            + " { edges { cursor node { slug } } pageInfo { hasPreviousPage hasNextPage } } }";
+
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    Boolean hasPrevious =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.hasPreviousPage");
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.hasNextPage");
+
+    assertThat(hasPrevious).isTrue();
+    assertThat(hasNext).isFalse();
+    verify(articleQueryService, atLeastOnce())
+        .findRecentArticlesWithCursor(
+            eq("java"), eq("author"), eq("fan"), captor.capture(), eq(null));
+    assertThat(captor.getValue().getDirection()).isEqualTo(Direction.PREV);
+    assertThat(captor.getValue().getLimit()).isEqualTo(5);
+  }
+
+  @Test
+  void should_return_articles_authored_by_profile() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("4", author);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            eq(null), eq("author"), eq(null), any(), any()))
+        .thenReturn(new CursorPager<>(Collections.singletonList(data), Direction.NEXT, false));
+    stubAuthorProfile();
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"author\") { profile { articles(first: 10)"
+                + " { edges { node { slug } } } } } }",
+            "data.profile.profile.articles.edges[*].node.slug");
+
+    assertThat(slugs).containsExactly(data.getSlug());
+  }
+
+  @Test
+  void should_return_articles_favorited_by_profile() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("5", author);
+    when(articleQueryService.findRecentArticlesWithCursor(
+            eq(null), eq(null), eq("author"), any(), any()))
+        .thenReturn(new CursorPager<>(Collections.singletonList(data), Direction.NEXT, false));
+    stubAuthorProfile();
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"author\") { profile { favorites(first: 10)"
+                + " { edges { node { slug } } } } } }",
+            "data.profile.profile.favorites.edges[*].node.slug");
+
+    assertThat(slugs).containsExactly(data.getSlug());
+  }
+
+  @Test
+  void should_return_feed_of_a_profile() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("6", author);
+    when(userRepository.findByUsername(eq("author"))).thenReturn(Optional.of(author));
+    when(articleQueryService.findUserFeedWithCursor(eq(author), any()))
+        .thenReturn(new CursorPager<>(Collections.singletonList(data), Direction.NEXT, false));
+    stubAuthorProfile();
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ profile(username: \"author\") { profile { feed(first: 10)"
+                + " { edges { node { slug } } } } } }",
+            "data.profile.profile.feed.edges[*].node.slug");
+
+    assertThat(slugs).containsExactly(data.getSlug());
+  }
+
+  @Test
+  void should_error_profile_feed_when_user_missing() {
+    anonymous();
+    when(userRepository.findByUsername(eq("author"))).thenReturn(Optional.empty());
+    stubAuthorProfile();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ profile(username: \"author\") { profile { feed(first: 10)"
+                + " { edges { node { slug } } } } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_page_profile_articles_favorites_and_feed_backwards() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("8", author);
+    CursorPager<ArticleData> pager =
+        new CursorPager<>(Collections.singletonList(data), Direction.PREV, true);
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(pager);
+    when(articleQueryService.findUserFeedWithCursor(eq(author), any())).thenReturn(pager);
+    when(userRepository.findByUsername(eq("author"))).thenReturn(Optional.of(author));
+    stubAuthorProfile();
+
+    String cursor = data.getCursor().toString();
+    for (String field : new String[] {"articles", "favorites", "feed"}) {
+      String query =
+          "{ profile(username: \"author\") { profile { "
+              + field
+              + "(last: 2, before: \""
+              + cursor
+              + "\") { edges { node { slug } } pageInfo { hasPreviousPage } } } } }";
+
+      List<String> slugs =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              query, "data.profile.profile." + field + ".edges[*].node.slug");
+      Boolean hasPrevious =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              query, "data.profile.profile." + field + ".pageInfo.hasPreviousPage");
+
+      assertThat(slugs).as(field).containsExactly(data.getSlug());
+      assertThat(hasPrevious).as(field).isTrue();
+    }
+  }
+
+  @Test
+  void should_error_when_pagination_arguments_are_missing() {
+    anonymous();
+    stubAuthorProfile();
+
+    assertThat(dgsQueryExecutor.execute("{ feed { edges { node { slug } } } }").getErrors())
+        .isNotEmpty();
+    for (String field : new String[] {"articles", "favorites", "feed"}) {
+      ExecutionResult result =
+          dgsQueryExecutor.execute(
+              "{ profile(username: \"author\") { profile { "
+                  + field
+                  + " { edges { node { slug } } } } } }");
+      assertThat(result.getErrors()).as(field).isNotEmpty();
+    }
+  }
+
+  @Test
+  void should_page_feed_backwards_for_current_user() {
+    authenticate(author);
+    ArticleData data = TestHelper.articleDataFixture("9", author);
+    when(articleQueryService.findUserFeedWithCursor(eq(author), any()))
+        .thenReturn(new CursorPager<>(Collections.singletonList(data), Direction.PREV, true));
+
+    String query =
+        "{ feed(last: 2, before: \""
+            + data.getCursor()
+            + "\") { edges { node { slug } } pageInfo { hasPreviousPage } } }";
+
+    Boolean hasPrevious =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.feed.pageInfo.hasPreviousPage");
+
+    assertThat(hasPrevious).isTrue();
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(articleQueryService, atLeastOnce()).findUserFeedWithCursor(eq(author), captor.capture());
+    assertThat(captor.getValue().getDirection()).isEqualTo(Direction.PREV);
+    assertThat(captor.getValue().getCursor().getMillis())
+        .isEqualTo(data.getUpdatedAt().getMillis());
+  }
+
+  @Test
+  void should_return_null_cursors_when_no_articles_match() {
+    anonymous();
+    when(articleQueryService.findRecentArticlesWithCursor(any(), any(), any(), any(), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    String query =
+        "{ articles(first: 10) { edges { node { slug } }"
+            + " pageInfo { startCursor endCursor hasNextPage } } }";
+
+    List<Object> edges = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.edges");
+    String startCursor =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.startCursor");
+    String endCursor =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.articles.pageInfo.endCursor");
+
+    assertThat(edges).isEmpty();
+    assertThat(startCursor).isNull();
+    assertThat(endCursor).isNull();
+  }
+
+  @Test
+  void should_resolve_article_of_a_comment_from_local_context() {
+    anonymous();
+    ArticleData data = TestHelper.articleDataFixture("7", author);
+    when(articleQueryService.findById(eq("article-id"), eq(null))).thenReturn(Optional.of(data));
+    CommentData comment =
+        new CommentData(
+            "comment-id",
+            "body",
+            "article-id",
+            new DateTime(),
+            new DateTime(),
+            new ProfileData(author.getId(), "author", "", "", false));
+
+    ArticleDatafetcher datafetcher = new ArticleDatafetcher(articleQueryService, userRepository);
+    DataFetcherResult<Article> result =
+        datafetcher.getCommentArticle(
+            DataFetchingEnvironmentImpl.newDataFetchingEnvironment().localContext(comment).build());
+
+    assertThat(result.getData().getSlug()).isEqualTo(data.getSlug());
+    assertThat(result.getData().getTitle()).isEqualTo(data.getTitle());
+    Map<String, Object> localContext = (Map<String, Object>) result.getLocalContext();
+    assertThat(localContext).containsKey(data.getSlug());
+  }
+
+  @Test
+  void should_return_feed_for_current_user() {
+    authenticate(author);
+    ArticleData data = TestHelper.articleDataFixture("3", author);
+    CursorPager<ArticleData> pager =
+        new CursorPager<>(Collections.singletonList(data), Direction.NEXT, true);
+    when(articleQueryService.findUserFeedWithCursor(eq(author), any())).thenReturn(pager);
+
+    String query = "{ feed(first: 5) { edges { node { slug } } pageInfo { hasNextPage } } }";
+
+    List<String> slugs =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.feed.edges[*].node.slug");
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.feed.pageInfo.hasNextPage");
+
+    assertThat(slugs).containsExactly(data.getSlug());
+    assertThat(hasNext).isTrue();
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -42,7 +42,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
       DgsAutoConfiguration.class,
       ArticleDatafetcher.class,
       ProfileDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class ArticleDatafetcherTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.article.ArticleCommandService;
 import io.spring.application.article.NewArticleParam;
@@ -21,6 +23,7 @@ import io.spring.core.favorite.ArticleFavorite;
 import io.spring.core.favorite.ArticleFavoriteRepository;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.AuthenticationException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -122,7 +125,7 @@ class ArticleMutationTest extends GraphQLTestBase {
             "mutation { createArticle(input: {title: \"Title\", description: \"Desc\","
                 + " body: \"Body\"}) { article { slug } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
   }
 
   @Test
@@ -134,7 +137,7 @@ class ArticleMutationTest extends GraphQLTestBase {
             "mutation { createArticle(input: {title: \"T\", description: \"D\", body: \"B\"})"
                 + " { __typename } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, AuthenticationException.class);
     verify(articleCommandService, never()).createArticle(any(), any());
   }
 
@@ -169,7 +172,7 @@ class ArticleMutationTest extends GraphQLTestBase {
                 + article.getSlug()
                 + "\", changes: {title: \"New\"}) { __typename } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, NoAuthorizationException.class);
     verify(articleCommandService, never()).updateArticle(any(), any());
   }
 
@@ -182,7 +185,7 @@ class ArticleMutationTest extends GraphQLTestBase {
         dgsQueryExecutor.execute(
             "mutation { updateArticle(slug: \"missing\", changes: {title: \"New\"}) { __typename } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
   }
 
   @Test
@@ -244,7 +247,7 @@ class ArticleMutationTest extends GraphQLTestBase {
         dgsQueryExecutor.execute(
             "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, NoAuthorizationException.class);
     verify(articleRepository, never()).remove(any());
   }
 }

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -10,11 +10,11 @@ import static org.mockito.Mockito.when;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
-import io.spring.TestHelper;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.article.ArticleCommandService;
 import io.spring.application.article.NewArticleParam;
 import io.spring.application.data.ArticleData;
+import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
 import io.spring.core.article.ArticleRepository;
 import io.spring.core.favorite.ArticleFavorite;
@@ -22,7 +22,7 @@ import io.spring.core.favorite.ArticleFavoriteRepository;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -75,28 +75,37 @@ class ArticleMutationTest extends GraphQLTestBase {
   void should_resolve_payload_article_from_mutation_local_context() {
     authenticate(author);
     Article created = article();
-    ArticleData data = TestHelper.getArticleDataFromArticleAndUser(created, author);
+    ArticleData data =
+        new ArticleData(
+            created.getId(),
+            created.getSlug(),
+            created.getTitle(),
+            created.getDescription(),
+            created.getBody(),
+            false,
+            3,
+            created.getCreatedAt(),
+            created.getUpdatedAt(),
+            Arrays.asList("java"),
+            new ProfileData(author.getId(), author.getUsername(), "", "", false));
     when(articleCommandService.createArticle(any(NewArticleParam.class), eq(author)))
         .thenReturn(created);
     when(articleQueryService.findById(eq(created.getId()), eq(author)))
         .thenReturn(Optional.of(data));
 
-    String query =
-        "mutation { createArticle(input: {title: \"Title\", description: \"Desc\", body: \"Body\"})"
-            + " { article { slug title description body tagList } } }";
+    Map<String, Object> article =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { createArticle(input: {title: \"Title\", description: \"Desc\","
+                + " body: \"Body\", tagList: [\"java\"]})"
+                + " { article { slug title description body tagList favoritesCount } } }",
+            "data.createArticle.article");
 
-    assertThat(
-            dgsQueryExecutor.<String>executeAndExtractJsonPath(
-                query, "data.createArticle.article.slug"))
-        .isEqualTo(created.getSlug());
-    assertThat(
-            dgsQueryExecutor.<String>executeAndExtractJsonPath(
-                query, "data.createArticle.article.title"))
-        .isEqualTo("Title");
-    assertThat(
-            dgsQueryExecutor.<List<String>>executeAndExtractJsonPath(
-                query, "data.createArticle.article.tagList"))
-        .containsExactly("joda");
+    assertThat(article.get("slug")).isEqualTo(created.getSlug());
+    assertThat(article.get("title")).isEqualTo("Title");
+    assertThat(article.get("description")).isEqualTo("Desc");
+    assertThat(article.get("body")).isEqualTo("Body");
+    assertThat(article.get("tagList")).isEqualTo(Arrays.asList("java"));
+    assertThat(article.get("favoritesCount")).isEqualTo(3);
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -39,7 +39,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
       DgsAutoConfiguration.class,
       ArticleMutation.class,
       ArticleDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class ArticleMutationTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -24,6 +24,7 @@ import io.spring.core.favorite.ArticleFavoriteRepository;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
 import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -34,7 +35,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(
-    classes = {DgsAutoConfiguration.class, ArticleMutation.class, ArticleDatafetcher.class})
+    classes = {
+      DgsAutoConfiguration.class,
+      ArticleMutation.class,
+      ArticleDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class ArticleMutationTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,241 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, ArticleMutation.class, ArticleDatafetcher.class})
+class ArticleMutationTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ArticleCommandService articleCommandService;
+  @MockBean private ArticleFavoriteRepository articleFavoriteRepository;
+  @MockBean private ArticleRepository articleRepository;
+  // Collaborators of ArticleDatafetcher, imported to resolve ArticlePayload.article.
+  @MockBean private ArticleQueryService articleQueryService;
+  @MockBean private UserRepository userRepository;
+
+  private final User author = new User("a@example.com", "author", "123", "", "");
+  private final User other = new User("o@example.com", "other", "123", "", "");
+
+  private Article article() {
+    return new Article("Title", "Desc", "Body", Arrays.asList("java"), author.getId());
+  }
+
+  @Test
+  void should_create_article_for_authenticated_user() {
+    authenticate(author);
+    Article created = article();
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(author)))
+        .thenReturn(created);
+
+    String query =
+        "mutation { createArticle(input: {title: \"Title\", description: \"Desc\", body: \"Body\","
+            + " tagList: [\"java\"]}) { __typename } }";
+
+    String typename =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.createArticle.__typename");
+
+    assertThat(typename).isEqualTo("ArticlePayload");
+    ArgumentCaptor<NewArticleParam> captor = ArgumentCaptor.forClass(NewArticleParam.class);
+    verify(articleCommandService).createArticle(captor.capture(), eq(author));
+    assertThat(captor.getValue().getTitle()).isEqualTo("Title");
+    assertThat(captor.getValue().getTagList()).containsExactly("java");
+  }
+
+  @Test
+  void should_resolve_payload_article_from_mutation_local_context() {
+    authenticate(author);
+    Article created = article();
+    ArticleData data = TestHelper.getArticleDataFromArticleAndUser(created, author);
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(author)))
+        .thenReturn(created);
+    when(articleQueryService.findById(eq(created.getId()), eq(author)))
+        .thenReturn(Optional.of(data));
+
+    String query =
+        "mutation { createArticle(input: {title: \"Title\", description: \"Desc\", body: \"Body\"})"
+            + " { article { slug title description body tagList } } }";
+
+    assertThat(
+            dgsQueryExecutor.<String>executeAndExtractJsonPath(
+                query, "data.createArticle.article.slug"))
+        .isEqualTo(created.getSlug());
+    assertThat(
+            dgsQueryExecutor.<String>executeAndExtractJsonPath(
+                query, "data.createArticle.article.title"))
+        .isEqualTo("Title");
+    assertThat(
+            dgsQueryExecutor.<List<String>>executeAndExtractJsonPath(
+                query, "data.createArticle.article.tagList"))
+        .containsExactly("joda");
+  }
+
+  @Test
+  void should_error_resolving_payload_article_when_article_disappeared() {
+    authenticate(author);
+    Article created = article();
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(author)))
+        .thenReturn(created);
+    when(articleQueryService.findById(eq(created.getId()), eq(author)))
+        .thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { createArticle(input: {title: \"Title\", description: \"Desc\","
+                + " body: \"Body\"}) { article { slug } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_error_creating_article_when_unauthenticated() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { createArticle(input: {title: \"T\", description: \"D\", body: \"B\"})"
+                + " { __typename } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(articleCommandService, never()).createArticle(any(), any());
+  }
+
+  @Test
+  void should_update_article_when_author() {
+    authenticate(author);
+    Article article = article();
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any())).thenReturn(article);
+
+    String query =
+        "mutation { updateArticle(slug: \""
+            + article.getSlug()
+            + "\", changes: {title: \"New Title\"}) { __typename } }";
+
+    String typename =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.updateArticle.__typename");
+
+    assertThat(typename).isEqualTo("ArticlePayload");
+    verify(articleCommandService).updateArticle(eq(article), any());
+  }
+
+  @Test
+  void should_reject_update_when_not_author() {
+    authenticate(other);
+    Article article = article();
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { updateArticle(slug: \""
+                + article.getSlug()
+                + "\", changes: {title: \"New\"}) { __typename } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(articleCommandService, never()).updateArticle(any(), any());
+  }
+
+  @Test
+  void should_error_update_when_article_missing() {
+    authenticate(author);
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { updateArticle(slug: \"missing\", changes: {title: \"New\"}) { __typename } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_favorite_article() {
+    authenticate(author);
+    Article article = article();
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    String query =
+        "mutation { favoriteArticle(slug: \"" + article.getSlug() + "\") { __typename } }";
+    String typename =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.favoriteArticle.__typename");
+
+    assertThat(typename).isEqualTo("ArticlePayload");
+    ArgumentCaptor<ArticleFavorite> captor = ArgumentCaptor.forClass(ArticleFavorite.class);
+    verify(articleFavoriteRepository).save(captor.capture());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+    assertThat(captor.getValue().getUserId()).isEqualTo(author.getId());
+  }
+
+  @Test
+  void should_unfavorite_article_when_favorite_exists() {
+    authenticate(author);
+    Article article = article();
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), author.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(author.getId())))
+        .thenReturn(Optional.of(favorite));
+
+    String query =
+        "mutation { unfavoriteArticle(slug: \"" + article.getSlug() + "\") { __typename } }";
+    dgsQueryExecutor.executeAndExtractJsonPath(query, "data.unfavoriteArticle.__typename");
+
+    verify(articleFavoriteRepository).remove(eq(favorite));
+  }
+
+  @Test
+  void should_delete_article_when_author() {
+    authenticate(author);
+    Article article = article();
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    Boolean success =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }",
+            "data.deleteArticle.success");
+
+    assertThat(success).isTrue();
+    verify(articleRepository).remove(eq(article));
+  }
+
+  @Test
+  void should_reject_delete_when_not_author() {
+    authenticate(other);
+    Article article = article();
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(articleRepository, never()).remove(any());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -3,10 +3,10 @@ package io.spring.graphql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.jayway.jsonpath.DocumentContext;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
@@ -22,6 +22,7 @@ import io.spring.application.data.CommentData;
 import io.spring.application.data.ProfileData;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +39,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
       DgsAutoConfiguration.class,
       CommentDatafetcher.class,
       ArticleDatafetcher.class,
-      ProfileDatafetcher.class
+      ProfileDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
     })
 class CommentDatafetcherTest extends GraphQLTestBase {
 
@@ -86,22 +88,16 @@ class CommentDatafetcherTest extends GraphQLTestBase {
             + "\") { comments(first: 10) { edges { cursor node { id body author { username } } }"
             + " pageInfo { hasNextPage } } } }";
 
-    List<String> bodies =
-        dgsQueryExecutor.executeAndExtractJsonPath(
-            query, "data.article.comments.edges[*].node.body");
-    List<String> ids =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.article.comments.edges[*].node.id");
-    List<String> authors =
-        dgsQueryExecutor.executeAndExtractJsonPath(
-            query, "data.article.comments.edges[*].node.author.username");
-    Boolean hasNext =
-        dgsQueryExecutor.executeAndExtractJsonPath(
-            query, "data.article.comments.pageInfo.hasNextPage");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(bodies).containsExactly("first comment", "second comment");
-    assertThat(ids).containsExactly("c1", "c2");
-    assertThat(authors).containsExactly("author", "author");
-    assertThat(hasNext).isFalse();
+    assertThat(context.<List<String>>read("data.article.comments.edges[*].node.body"))
+        .containsExactly("first comment", "second comment");
+    assertThat(context.<List<String>>read("data.article.comments.edges[*].node.id"))
+        .containsExactly("c1", "c2");
+    assertThat(context.<List<String>>read("data.article.comments.edges[*].node.author.username"))
+        .containsExactly("author", "author");
+    assertThat(context.read("data.article.comments.pageInfo.hasNextPage", Boolean.class)).isFalse();
+    verify(commentQueryService).findByArticleIdWithCursor(eq(article.getId()), eq(null), any());
   }
 
   @Test
@@ -126,7 +122,7 @@ class CommentDatafetcherTest extends GraphQLTestBase {
     assertThat(hasPrevious).isTrue();
     ArgumentCaptor<CursorPageParameter<DateTime>> captor =
         ArgumentCaptor.forClass(CursorPageParameter.class);
-    verify(commentQueryService, atLeastOnce())
+    verify(commentQueryService)
         .findByArticleIdWithCursor(eq(article.getId()), eq(author), captor.capture());
     assertThat(captor.getValue().getDirection()).isEqualTo(Direction.PREV);
     assertThat(captor.getValue().getLimit()).isEqualTo(3);
@@ -161,13 +157,10 @@ class CommentDatafetcherTest extends GraphQLTestBase {
             + "\") { comments(first: 10) { edges { node { id } }"
             + " pageInfo { startCursor endCursor } } } }";
 
-    List<Object> edges =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.article.comments.edges");
-    String startCursor =
-        dgsQueryExecutor.executeAndExtractJsonPath(
-            query, "data.article.comments.pageInfo.startCursor");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(edges).isEmpty();
-    assertThat(startCursor).isNull();
+    assertThat(context.<List<Object>>read("data.article.comments.edges")).isEmpty();
+    assertThat(context.read("data.article.comments.pageInfo.startCursor", String.class)).isNull();
+    assertThat(context.read("data.article.comments.pageInfo.endCursor", String.class)).isNull();
   }
 }

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -145,7 +145,7 @@ class CommentDatafetcherTest extends GraphQLTestBase {
                 + article.getSlug()
                 + "\") { comments { edges { node { id } } } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, IllegalArgumentException.class);
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,173 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.TestHelper;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      CommentDatafetcher.class,
+      ArticleDatafetcher.class,
+      ProfileDatafetcher.class
+    })
+class CommentDatafetcherTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private CommentQueryService commentQueryService;
+  // Collaborators of the datafetchers imported to reach Article.comments.
+  @MockBean private ArticleQueryService articleQueryService;
+  @MockBean private UserRepository userRepository;
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private final User author = new User("a@example.com", "author", "123", "bio", "a.png");
+
+  private CommentData commentData(String id, String body) {
+    DateTime createdAt = new DateTime(1_600_000_000_000L);
+    return new CommentData(
+        id,
+        body,
+        "article-id",
+        createdAt,
+        createdAt,
+        new ProfileData(author.getId(), "author", "bio", "a.png", false));
+  }
+
+  private ArticleData stubArticle() {
+    ArticleData data = TestHelper.articleDataFixture("1", author);
+    when(articleQueryService.findBySlug(eq(data.getSlug()), any())).thenReturn(Optional.of(data));
+    when(profileQueryService.findByUsername(eq("author"), any()))
+        .thenReturn(Optional.of(new ProfileData(author.getId(), "author", "bio", "a.png", false)));
+    return data;
+  }
+
+  @Test
+  void should_return_comments_of_an_article_with_author() {
+    anonymous();
+    ArticleData article = stubArticle();
+    CommentData first = commentData("c1", "first comment");
+    CommentData second = commentData("c2", "second comment");
+    when(commentQueryService.findByArticleIdWithCursor(eq(article.getId()), eq(null), any()))
+        .thenReturn(new CursorPager<>(Arrays.asList(first, second), Direction.NEXT, false));
+
+    String query =
+        "{ article(slug: \""
+            + article.getSlug()
+            + "\") { comments(first: 10) { edges { cursor node { id body author { username } } }"
+            + " pageInfo { hasNextPage } } } }";
+
+    List<String> bodies =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            query, "data.article.comments.edges[*].node.body");
+    List<String> ids =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.article.comments.edges[*].node.id");
+    List<String> authors =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            query, "data.article.comments.edges[*].node.author.username");
+    Boolean hasNext =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            query, "data.article.comments.pageInfo.hasNextPage");
+
+    assertThat(bodies).containsExactly("first comment", "second comment");
+    assertThat(ids).containsExactly("c1", "c2");
+    assertThat(authors).containsExactly("author", "author");
+    assertThat(hasNext).isFalse();
+  }
+
+  @Test
+  void should_pass_current_user_and_prev_direction_when_paging_backwards() {
+    authenticate(author);
+    ArticleData article = stubArticle();
+    CommentData comment = commentData("c1", "a comment");
+    when(commentQueryService.findByArticleIdWithCursor(eq(article.getId()), eq(author), any()))
+        .thenReturn(new CursorPager<>(Collections.singletonList(comment), Direction.PREV, true));
+
+    String query =
+        "{ article(slug: \""
+            + article.getSlug()
+            + "\") { comments(last: 3, before: \""
+            + comment.getCursor()
+            + "\") { edges { node { id } } pageInfo { hasPreviousPage } } } }";
+
+    Boolean hasPrevious =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            query, "data.article.comments.pageInfo.hasPreviousPage");
+
+    assertThat(hasPrevious).isTrue();
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(commentQueryService, atLeastOnce())
+        .findByArticleIdWithCursor(eq(article.getId()), eq(author), captor.capture());
+    assertThat(captor.getValue().getDirection()).isEqualTo(Direction.PREV);
+    assertThat(captor.getValue().getLimit()).isEqualTo(3);
+    assertThat(captor.getValue().getCursor().getMillis())
+        .isEqualTo(comment.getCreatedAt().getMillis());
+  }
+
+  @Test
+  void should_error_when_neither_first_nor_last_given() {
+    anonymous();
+    ArticleData article = stubArticle();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ article(slug: \""
+                + article.getSlug()
+                + "\") { comments { edges { node { id } } } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_return_empty_connection_when_article_has_no_comments() {
+    anonymous();
+    ArticleData article = stubArticle();
+    when(commentQueryService.findByArticleIdWithCursor(eq(article.getId()), eq(null), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    String query =
+        "{ article(slug: \""
+            + article.getSlug()
+            + "\") { comments(first: 10) { edges { node { id } }"
+            + " pageInfo { startCursor endCursor } } } }";
+
+    List<Object> edges =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.article.comments.edges");
+    String startCursor =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            query, "data.article.comments.pageInfo.startCursor");
+
+    assertThat(edges).isEmpty();
+    assertThat(startCursor).isNull();
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -40,7 +40,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
       CommentDatafetcher.class,
       ArticleDatafetcher.class,
       ProfileDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class CommentDatafetcherTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.jayway.jsonpath.DocumentContext;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
@@ -21,6 +22,7 @@ import io.spring.core.comment.Comment;
 import io.spring.core.comment.CommentRepository;
 import io.spring.core.user.User;
 import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.Arrays;
 import java.util.Optional;
 import org.joda.time.DateTime;
@@ -31,7 +33,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(
-    classes = {DgsAutoConfiguration.class, CommentMutation.class, CommentDatafetcher.class})
+    classes = {
+      DgsAutoConfiguration.class,
+      CommentMutation.class,
+      CommentDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class CommentMutationTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
@@ -67,13 +74,12 @@ class CommentMutationTest extends GraphQLTestBase {
             + article.getSlug()
             + "\", body: \"great post\") { comment { id body } } }";
 
-    String body = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.addComment.comment.body");
-    String id = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.addComment.comment.id");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(body).isEqualTo("great post");
-    assertThat(id).isEqualTo("comment-id");
+    assertThat(context.read("data.addComment.comment.body", String.class)).isEqualTo("great post");
+    assertThat(context.read("data.addComment.comment.id", String.class)).isEqualTo("comment-id");
     ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
-    verify(commentRepository, org.mockito.Mockito.atLeastOnce()).save(captor.capture());
+    verify(commentRepository).save(captor.capture());
     assertThat(captor.getValue().getBody()).isEqualTo("great post");
     assertThat(captor.getValue().getUserId()).isEqualTo(author.getId());
     assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,163 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.CommentQueryService;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, CommentMutation.class, CommentDatafetcher.class})
+class CommentMutationTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ArticleRepository articleRepository;
+  @MockBean private CommentRepository commentRepository;
+  @MockBean private CommentQueryService commentQueryService;
+
+  private final User author = new User("a@example.com", "author", "123", "", "");
+  private final User other = new User("o@example.com", "other", "123", "", "");
+
+  private Article article() {
+    return new Article("Title", "Desc", "Body", Arrays.asList("java"), author.getId());
+  }
+
+  @Test
+  void should_add_comment_for_authenticated_user() {
+    authenticate(author);
+    Article article = article();
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    CommentData commentData =
+        new CommentData(
+            "comment-id",
+            "great post",
+            article.getId(),
+            new DateTime(),
+            new DateTime(),
+            new ProfileData(author.getId(), "author", "", "", false));
+    when(commentQueryService.findById(any(), eq(author))).thenReturn(Optional.of(commentData));
+
+    String query =
+        "mutation { addComment(slug: \""
+            + article.getSlug()
+            + "\", body: \"great post\") { comment { id body } } }";
+
+    String body = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.addComment.comment.body");
+    String id = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.addComment.comment.id");
+
+    assertThat(body).isEqualTo("great post");
+    assertThat(id).isEqualTo("comment-id");
+    ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+    verify(commentRepository, org.mockito.Mockito.atLeastOnce()).save(captor.capture());
+    assertThat(captor.getValue().getBody()).isEqualTo("great post");
+    assertThat(captor.getValue().getUserId()).isEqualTo(author.getId());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+  }
+
+  @Test
+  void should_error_adding_comment_when_unauthenticated() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { addComment(slug: \"s\", body: \"x\") { comment { id } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(commentRepository, never()).save(any());
+  }
+
+  @Test
+  void should_error_adding_comment_when_article_missing() {
+    authenticate(author);
+    when(articleRepository.findBySlug(eq("missing"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { addComment(slug: \"missing\", body: \"x\") { comment { id } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(commentRepository, never()).save(any());
+  }
+
+  @Test
+  void should_delete_comment_when_author() {
+    authenticate(author);
+    Article article = article();
+    Comment comment = new Comment("body", author.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    Boolean success =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \""
+                + comment.getId()
+                + "\") { success } }",
+            "data.deleteComment.success");
+
+    assertThat(success).isTrue();
+    verify(commentRepository).remove(eq(comment));
+  }
+
+  @Test
+  void should_reject_delete_comment_when_not_authorized() {
+    authenticate(other);
+    Article article = article();
+    Comment comment = new Comment("body", author.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \""
+                + comment.getId()
+                + "\") { success } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(commentRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_error_delete_comment_when_missing() {
+    authenticate(author);
+    Article article = article();
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq("ghost"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \"ghost\") { success } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(commentRepository, never()).remove(any());
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -37,7 +37,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
       DgsAutoConfiguration.class,
       CommentMutation.class,
       CommentDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class CommentMutationTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
+import io.spring.api.exception.NoAuthorizationException;
+import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.CommentQueryService;
 import io.spring.application.data.CommentData;
 import io.spring.application.data.ProfileData;
@@ -18,6 +20,7 @@ import io.spring.core.article.ArticleRepository;
 import io.spring.core.comment.Comment;
 import io.spring.core.comment.CommentRepository;
 import io.spring.core.user.User;
+import io.spring.graphql.exception.AuthenticationException;
 import java.util.Arrays;
 import java.util.Optional;
 import org.joda.time.DateTime;
@@ -84,7 +87,7 @@ class CommentMutationTest extends GraphQLTestBase {
         dgsQueryExecutor.execute(
             "mutation { addComment(slug: \"s\", body: \"x\") { comment { id } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, AuthenticationException.class);
     verify(commentRepository, never()).save(any());
   }
 
@@ -97,7 +100,7 @@ class CommentMutationTest extends GraphQLTestBase {
         dgsQueryExecutor.execute(
             "mutation { addComment(slug: \"missing\", body: \"x\") { comment { id } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
     verify(commentRepository, never()).save(any());
   }
 
@@ -140,7 +143,7 @@ class CommentMutationTest extends GraphQLTestBase {
                 + comment.getId()
                 + "\") { success } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, NoAuthorizationException.class);
     verify(commentRepository, never()).remove(any());
   }
 
@@ -157,7 +160,7 @@ class CommentMutationTest extends GraphQLTestBase {
                 + article.getSlug()
                 + "\", id: \"ghost\") { success } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
     verify(commentRepository, never()).remove(any());
   }
 }

--- a/src/test/java/io/spring/graphql/GraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphQLTestBase.java
@@ -1,5 +1,8 @@
 package io.spring.graphql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import graphql.ExecutionResult;
 import io.spring.core.user.User;
 import java.util.Collections;
 import org.junit.jupiter.api.AfterEach;
@@ -26,6 +29,16 @@ public abstract class GraphQLTestBase {
     SecurityContextHolder.getContext()
         .setAuthentication(
             new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  /**
+   * Asserts the query produced exactly one error and that it was raised by the given exception,
+   * rather than by an unrelated validation or parse failure in the query document.
+   */
+  protected void assertSingleErrorFrom(
+      ExecutionResult result, Class<? extends Throwable> exceptionType) {
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains(exceptionType.getName());
   }
 
   /** Mimics what Spring Security puts in the context for an unauthenticated request. */

--- a/src/test/java/io/spring/graphql/GraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphQLTestBase.java
@@ -1,0 +1,36 @@
+package io.spring.graphql;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/** Shared security context handling for the DGS datafetcher and mutation tests. */
+public abstract class GraphQLTestBase {
+
+  @BeforeEach
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  protected void authenticate(User user) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+  }
+
+  /** Mimics what Spring Security puts in the context for an unauthenticated request. */
+  protected void anonymous() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+  }
+}

--- a/src/test/java/io/spring/graphql/GraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphQLTestBase.java
@@ -30,6 +30,9 @@ public abstract class GraphQLTestBase {
   @AfterEach
   void clearSecurityContextAfterTest() {
     SecurityContextHolder.clearContext();
+    if (exceptionHandler != null) {
+      exceptionHandler.clear();
+    }
   }
 
   protected void authenticate(User user) {

--- a/src/test/java/io/spring/graphql/GraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphQLTestBase.java
@@ -13,8 +13,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public abstract class GraphQLTestBase {
 
   @BeforeEach
+  void clearSecurityContextBeforeTest() {
+    SecurityContextHolder.clearContext();
+  }
+
   @AfterEach
-  void clearSecurityContext() {
+  void clearSecurityContextAfterTest() {
     SecurityContextHolder.clearContext();
   }
 

--- a/src/test/java/io/spring/graphql/GraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphQLTestBase.java
@@ -7,6 +7,7 @@ import io.spring.core.user.User;
 import java.util.Collections;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -15,9 +16,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
 /** Shared security context handling for the DGS datafetcher and mutation tests. */
 public abstract class GraphQLTestBase {
 
+  @Autowired(required = false)
+  private RecordingExceptionHandler exceptionHandler;
+
   @BeforeEach
   void clearSecurityContextBeforeTest() {
     SecurityContextHolder.clearContext();
+    if (exceptionHandler != null) {
+      exceptionHandler.clear();
+    }
   }
 
   @AfterEach
@@ -33,12 +40,19 @@ public abstract class GraphQLTestBase {
 
   /**
    * Asserts the query produced exactly one error and that it was raised by the given exception,
-   * rather than by an unrelated validation or parse failure in the query document.
+   * rather than by an unrelated validation or parse failure in the query document. The exception is
+   * read from {@link RecordingExceptionHandler} rather than from the error message, so the
+   * assertion does not depend on how DGS renders errors. Recorded exceptions are dropped afterwards
+   * so a test may assert over several executions.
    */
   protected void assertSingleErrorFrom(
       ExecutionResult result, Class<? extends Throwable> exceptionType) {
     assertThat(result.getErrors()).hasSize(1);
-    assertThat(result.getErrors().get(0).getMessage()).contains(exceptionType.getName());
+    assertThat(exceptionHandler)
+        .as("RecordingExceptionHandler must be part of the test's @SpringBootTest classes")
+        .isNotNull();
+    assertThat(exceptionHandler.raised()).singleElement().isInstanceOf(exceptionType);
+    exceptionHandler.clear();
   }
 
   /** Mimics what Spring Security puts in the context for an unauthenticated request. */

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -12,6 +12,7 @@ import io.spring.application.data.ProfileData;
 import io.spring.application.data.UserData;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 
 @SpringBootTest(
-    classes = {DgsAutoConfiguration.class, MeDatafetcher.class, ProfileDatafetcher.class})
+    classes = {
+      DgsAutoConfiguration.class,
+      MeDatafetcher.class,
+      ProfileDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class MeDatafetcherTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.when;
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException;
+import graphql.ExecutionResult;
 import io.spring.application.ProfileQueryService;
 import io.spring.application.UserQueryService;
 import io.spring.application.data.ProfileData;
@@ -13,6 +15,7 @@ import io.spring.application.data.UserData;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -77,6 +80,38 @@ class MeDatafetcherTest extends GraphQLTestBase {
     assertThat(profile.get("bio")).isEqualTo("my bio");
     assertThat(profile.get("image")).isEqualTo("i.png");
     assertThat(profile.get("following")).isEqualTo(false);
+  }
+
+  @Test
+  void should_error_when_the_authorization_header_is_missing() {
+    authenticate(user);
+
+    ExecutionResult result = dgsQueryExecutor.execute("{ me { email username token } }");
+
+    assertSingleErrorFrom(result, DgsInvalidInputArgumentException.class);
+  }
+
+  /**
+   * {@code getMe} reads the token as {@code authorization.split(" ")[1]} without validating the
+   * header, so a header carrying no scheme blows up instead of being rejected as unauthenticated.
+   * Pinned here so a fix to that parsing is a deliberate change.
+   */
+  @Test
+  void should_currently_fail_when_the_authorization_header_has_no_scheme() {
+    authenticate(user);
+    UserData userData = new UserData(user.getId(), user.getEmail(), user.getUsername(), "", "");
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.of(userData));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "jwt-token-value");
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ me { email username token } }",
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            headers);
+
+    assertSingleErrorFrom(result, ArrayIndexOutOfBoundsException.class);
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,87 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, MeDatafetcher.class, ProfileDatafetcher.class})
+class MeDatafetcherTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserQueryService userQueryService;
+  @MockBean private JwtService jwtService;
+  // Collaborator of ProfileDatafetcher, imported to resolve User.profile.
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private final User user =
+      new User("me@example.com", "me", "123", "my bio", "https://image/me.png");
+
+  @Test
+  void should_return_current_user_with_token_from_header() {
+    authenticate(user);
+    UserData userData = new UserData(user.getId(), user.getEmail(), user.getUsername(), "", "");
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.of(userData));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token-value");
+    Map<String, Object> me =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ me { email username token } }", "data.me", headers);
+
+    assertThat(me.get("email")).isEqualTo(user.getEmail());
+    assertThat(me.get("username")).isEqualTo(user.getUsername());
+    assertThat(me.get("token")).isEqualTo("jwt-token-value");
+  }
+
+  @Test
+  void should_resolve_profile_of_the_current_user() {
+    authenticate(user);
+    UserData userData =
+        new UserData(user.getId(), user.getEmail(), user.getUsername(), "my bio", "i.png");
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.of(userData));
+    when(profileQueryService.findByUsername(eq("me"), eq(user)))
+        .thenReturn(Optional.of(new ProfileData(user.getId(), "me", "my bio", "i.png", false)));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token-value");
+    Map<String, Object> profile =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ me { profile { username bio image following } } }", "data.me.profile", headers);
+
+    assertThat(profile.get("username")).isEqualTo("me");
+    assertThat(profile.get("bio")).isEqualTo("my bio");
+    assertThat(profile.get("image")).isEqualTo("i.png");
+    assertThat(profile.get("following")).isEqualTo(false);
+  }
+
+  @Test
+  void should_return_null_me_when_not_authenticated() {
+    anonymous();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token-value");
+    Object me =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ me { email username token } }", "data.me", headers);
+
+    assertThat(me).isNull();
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -26,7 +26,8 @@ import org.springframework.http.HttpHeaders;
       DgsAutoConfiguration.class,
       MeDatafetcher.class,
       ProfileDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class MeDatafetcherTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,75 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, ProfileDatafetcher.class})
+class ProfileDatafetcherTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private static final String QUERY =
+      "{ profile(username: \"targetuser\") { profile { username bio image following } } }";
+
+  @Test
+  void should_query_profile_for_authenticated_user() {
+    User current = new User("me@example.com", "me", "123", "", "");
+    authenticate(current);
+    ProfileData profileData =
+        new ProfileData("target-id", "targetuser", "a bio", "https://image/t.png", true);
+    when(profileQueryService.findByUsername(eq("targetuser"), eq(current)))
+        .thenReturn(Optional.of(profileData));
+
+    String path = "data.profile.profile";
+    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(QUERY, path + ".username"))
+        .isEqualTo("targetuser");
+    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(QUERY, path + ".bio"))
+        .isEqualTo("a bio");
+    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(QUERY, path + ".image"))
+        .isEqualTo("https://image/t.png");
+    assertThat(dgsQueryExecutor.<Boolean>executeAndExtractJsonPath(QUERY, path + ".following"))
+        .isTrue();
+  }
+
+  @Test
+  void should_query_profile_for_anonymous_user_with_null_current() {
+    anonymous();
+    ProfileData profileData =
+        new ProfileData("target-id", "targetuser", "a bio", "https://image/t.png", false);
+    when(profileQueryService.findByUsername(eq("targetuser"), eq(null)))
+        .thenReturn(Optional.of(profileData));
+
+    Boolean following =
+        dgsQueryExecutor.executeAndExtractJsonPath(QUERY, "data.profile.profile.following");
+    assertThat(following).isFalse();
+  }
+
+  @Test
+  void should_return_error_when_profile_not_found() {
+    anonymous();
+    when(profileQueryService.findByUsername(eq("targetuser"), any())).thenReturn(Optional.empty());
+
+    ExecutionResult result = dgsQueryExecutor.execute(QUERY);
+
+    assertThat(result.getErrors()).isNotEmpty();
+    Map<String, Object> data = result.getData();
+    assertThat(data.get("profile")).isNull();
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.jayway.jsonpath.DocumentContext;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
@@ -12,6 +13,7 @@ import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ProfileQueryService;
 import io.spring.application.data.ProfileData;
 import io.spring.core.user.User;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -19,7 +21,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@SpringBootTest(classes = {DgsAutoConfiguration.class, ProfileDatafetcher.class})
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      ProfileDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class ProfileDatafetcherTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
@@ -38,15 +45,13 @@ class ProfileDatafetcherTest extends GraphQLTestBase {
     when(profileQueryService.findByUsername(eq("targetuser"), eq(current)))
         .thenReturn(Optional.of(profileData));
 
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(QUERY);
+
     String path = "data.profile.profile";
-    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(QUERY, path + ".username"))
-        .isEqualTo("targetuser");
-    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(QUERY, path + ".bio"))
-        .isEqualTo("a bio");
-    assertThat(dgsQueryExecutor.<String>executeAndExtractJsonPath(QUERY, path + ".image"))
-        .isEqualTo("https://image/t.png");
-    assertThat(dgsQueryExecutor.<Boolean>executeAndExtractJsonPath(QUERY, path + ".following"))
-        .isTrue();
+    assertThat(context.read(path + ".username", String.class)).isEqualTo("targetuser");
+    assertThat(context.read(path + ".bio", String.class)).isEqualTo("a bio");
+    assertThat(context.read(path + ".image", String.class)).isEqualTo("https://image/t.png");
+    assertThat(context.read(path + ".following", Boolean.class)).isTrue();
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
+import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ProfileQueryService;
 import io.spring.application.data.ProfileData;
 import io.spring.core.user.User;
@@ -68,7 +69,7 @@ class ProfileDatafetcherTest extends GraphQLTestBase {
 
     ExecutionResult result = dgsQueryExecutor.execute(QUERY);
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
     Map<String, Object> data = result.getData();
     assertThat(data.get("profile")).isNull();
   }

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -25,7 +25,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
     classes = {
       DgsAutoConfiguration.class,
       ProfileDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class ProfileDatafetcherTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/RecordingExceptionHandler.java
+++ b/src/test/java/io/spring/graphql/RecordingExceptionHandler.java
@@ -7,14 +7,16 @@ import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Component;
 
 /**
  * Records the exception a datafetcher raised and then delegates to the production handler, so the
  * GraphQL response is exactly what the application would return while tests can still assert on the
  * exception itself instead of on the DGS error message format.
+ *
+ * <p>Deliberately not a {@code @Component}: the tests that need it register it through
+ * {@code @SpringBootTest(classes = ...)}, which keeps it out of contexts that component-scan {@code
+ * io.spring} and would otherwise displace the production handler.
  */
-@Component
 @Primary
 public class RecordingExceptionHandler implements DataFetcherExceptionHandler {
 

--- a/src/test/java/io/spring/graphql/RecordingExceptionHandler.java
+++ b/src/test/java/io/spring/graphql/RecordingExceptionHandler.java
@@ -1,0 +1,42 @@
+package io.spring.graphql;
+
+import graphql.execution.DataFetcherExceptionHandler;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * Records the exception a datafetcher raised and then delegates to the production handler, so the
+ * GraphQL response is exactly what the application would return while tests can still assert on the
+ * exception itself instead of on the DGS error message format.
+ */
+@Component
+@Primary
+public class RecordingExceptionHandler implements DataFetcherExceptionHandler {
+
+  private final GraphQLCustomizeExceptionHandler delegate;
+  private final List<Throwable> raised = new CopyOnWriteArrayList<>();
+
+  public RecordingExceptionHandler(GraphQLCustomizeExceptionHandler delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public DataFetcherExceptionHandlerResult onException(
+      DataFetcherExceptionHandlerParameters handlerParameters) {
+    raised.add(handlerParameters.getException());
+    return delegate.onException(handlerParameters);
+  }
+
+  List<Throwable> raised() {
+    return raised;
+  }
+
+  void clear() {
+    raised.clear();
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -30,7 +30,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
     classes = {
       DgsAutoConfiguration.class,
       RelationMutation.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class RelationMutationTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.jayway.jsonpath.DocumentContext;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
@@ -17,6 +18,7 @@ import io.spring.core.user.FollowRelation;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
 import io.spring.graphql.exception.AuthenticationException;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -24,7 +26,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@SpringBootTest(classes = {DgsAutoConfiguration.class, RelationMutation.class})
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      RelationMutation.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class RelationMutationTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
@@ -46,16 +53,14 @@ class RelationMutationTest extends GraphQLTestBase {
     String query =
         "mutation { followUser(username: \"targetuser\") { profile { username following } } }";
 
-    String username =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.followUser.profile.username");
-    Boolean following =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.followUser.profile.following");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(username).isEqualTo("targetuser");
-    assertThat(following).isTrue();
+    assertThat(context.read("data.followUser.profile.username", String.class))
+        .isEqualTo("targetuser");
+    assertThat(context.read("data.followUser.profile.following", Boolean.class)).isTrue();
 
     ArgumentCaptor<FollowRelation> captor = ArgumentCaptor.forClass(FollowRelation.class);
-    verify(userRepository, org.mockito.Mockito.atLeastOnce()).saveRelation(captor.capture());
+    verify(userRepository).saveRelation(captor.capture());
     assertThat(captor.getValue().getUserId()).isEqualTo(current.getId());
     assertThat(captor.getValue().getTargetId()).isEqualTo(target.getId());
   }
@@ -99,11 +104,12 @@ class RelationMutationTest extends GraphQLTestBase {
     String query =
         "mutation { unfollowUser(username: \"targetuser\") { profile { username following } } }";
 
-    Boolean following =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.unfollowUser.profile.following");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(following).isFalse();
-    verify(userRepository, org.mockito.Mockito.atLeastOnce()).removeRelation(eq(relation));
+    assertThat(context.read("data.unfollowUser.profile.username", String.class))
+        .isEqualTo("targetuser");
+    assertThat(context.read("data.unfollowUser.profile.following", Boolean.class)).isFalse();
+    verify(userRepository).removeRelation(eq(relation));
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -10,11 +10,13 @@ import static org.mockito.Mockito.when;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
+import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ProfileQueryService;
 import io.spring.application.data.ProfileData;
 import io.spring.core.user.FollowRelation;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.AuthenticationException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -66,7 +68,7 @@ class RelationMutationTest extends GraphQLTestBase {
         dgsQueryExecutor.execute(
             "mutation { followUser(username: \"targetuser\") { profile { username } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, AuthenticationException.class);
     verify(userRepository, never()).saveRelation(any());
   }
 
@@ -79,7 +81,7 @@ class RelationMutationTest extends GraphQLTestBase {
         dgsQueryExecutor.execute(
             "mutation { followUser(username: \"ghost\") { profile { username } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
     verify(userRepository, never()).saveRelation(any());
   }
 
@@ -115,7 +117,7 @@ class RelationMutationTest extends GraphQLTestBase {
         dgsQueryExecutor.execute(
             "mutation { unfollowUser(username: \"targetuser\") { profile { username } } }");
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertSingleErrorFrom(result, ResourceNotFoundException.class);
     verify(userRepository, never()).removeRelation(any());
   }
 }

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,121 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, RelationMutation.class})
+class RelationMutationTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserRepository userRepository;
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private final User current = new User("me@example.com", "me", "123", "", "");
+  private final User target = new User("t@example.com", "targetuser", "123", "t bio", "t.png");
+
+  @Test
+  void should_follow_user_and_persist_relation() {
+    authenticate(current);
+    when(userRepository.findByUsername(eq("targetuser"))).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername(eq("targetuser"), eq(current)))
+        .thenReturn(
+            Optional.of(new ProfileData(target.getId(), "targetuser", "t bio", "t.png", true)));
+
+    String query =
+        "mutation { followUser(username: \"targetuser\") { profile { username following } } }";
+
+    String username =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.followUser.profile.username");
+    Boolean following =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.followUser.profile.following");
+
+    assertThat(username).isEqualTo("targetuser");
+    assertThat(following).isTrue();
+
+    ArgumentCaptor<FollowRelation> captor = ArgumentCaptor.forClass(FollowRelation.class);
+    verify(userRepository, org.mockito.Mockito.atLeastOnce()).saveRelation(captor.capture());
+    assertThat(captor.getValue().getUserId()).isEqualTo(current.getId());
+    assertThat(captor.getValue().getTargetId()).isEqualTo(target.getId());
+  }
+
+  @Test
+  void should_error_when_following_unauthenticated() {
+    anonymous();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { followUser(username: \"targetuser\") { profile { username } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  void should_error_when_following_missing_user() {
+    authenticate(current);
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { followUser(username: \"ghost\") { profile { username } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  void should_unfollow_user_and_remove_relation() {
+    authenticate(current);
+    FollowRelation relation = new FollowRelation(current.getId(), target.getId());
+    when(userRepository.findByUsername(eq("targetuser"))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(current.getId()), eq(target.getId())))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername(eq("targetuser"), eq(current)))
+        .thenReturn(
+            Optional.of(new ProfileData(target.getId(), "targetuser", "t bio", "t.png", false)));
+
+    String query =
+        "mutation { unfollowUser(username: \"targetuser\") { profile { username following } } }";
+
+    Boolean following =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.unfollowUser.profile.following");
+
+    assertThat(following).isFalse();
+    verify(userRepository, org.mockito.Mockito.atLeastOnce()).removeRelation(eq(relation));
+  }
+
+  @Test
+  void should_error_when_unfollowing_without_existing_relation() {
+    authenticate(current);
+    when(userRepository.findByUsername(eq("targetuser"))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(current.getId()), eq(target.getId())))
+        .thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfollowUser(username: \"targetuser\") { profile { username } } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    verify(userRepository, never()).removeRelation(any());
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,39 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class SecurityUtilTest extends GraphQLTestBase {
+
+  @Test
+  void should_return_the_authenticated_principal() {
+    User user = new User("me@example.com", "me", "123", "", "");
+    authenticate(user);
+
+    assertThat(SecurityUtil.getCurrentUser()).contains(user);
+  }
+
+  @Test
+  void should_return_empty_for_anonymous_authentication() {
+    anonymous();
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  void should_return_empty_when_principal_is_missing() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(null, null, Collections.emptyList()));
+
+    Optional<User> currentUser = SecurityUtil.getCurrentUser();
+
+    assertThat(currentUser).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import io.spring.application.TagsQueryService;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -14,7 +15,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@SpringBootTest(classes = {DgsAutoConfiguration.class, TagDatafetcher.class})
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      TagDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class TagDatafetcherTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -19,7 +19,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
     classes = {
       DgsAutoConfiguration.class,
       TagDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class TagDatafetcherTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,41 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, TagDatafetcher.class})
+class TagDatafetcherTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @Test
+  void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("java", "spring", "graphql"));
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertThat(tags).containsExactly("java", "spring", "graphql");
+  }
+
+  @Test
+  void should_return_empty_list_when_no_tags_exist() {
+    when(tagsQueryService.allTags()).thenReturn(Collections.emptyList());
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertThat(tags).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -15,7 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(classes = {DgsAutoConfiguration.class, TagDatafetcher.class})
-class TagDatafetcherTest {
+class TagDatafetcherTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
 

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -8,11 +8,13 @@ import static org.mockito.Mockito.when;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
+import graphql.GraphQLError;
 import io.spring.application.user.RegisterParam;
 import io.spring.application.user.UpdateUserCommand;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -27,7 +29,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@SpringBootTest(classes = {DgsAutoConfiguration.class, UserMutation.class, MeDatafetcher.class})
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      UserMutation.class,
+      MeDatafetcher.class,
+      GraphQLCustomizeExceptionHandler.class
+    })
 class UserMutationTest extends GraphQLTestBase {
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
@@ -101,7 +109,10 @@ class UserMutationTest extends GraphQLTestBase {
 
     ExecutionResult result = dgsQueryExecutor.execute(query);
 
-    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("invalid email or password");
+    assertThat(error.getExtensions().get("errorType")).hasToString("UNAUTHENTICATED");
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,161 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, UserMutation.class, MeDatafetcher.class})
+class UserMutationTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserRepository userRepository;
+  @MockBean private PasswordEncoder encryptService;
+  @MockBean private io.spring.application.user.UserService userService;
+
+  // Collaborators for MeDatafetcher, imported to resolve UserPayload.user.
+  @MockBean private io.spring.application.UserQueryService userQueryService;
+  @MockBean private JwtService jwtService;
+
+  @Test
+  void should_create_user_and_resolve_payload_user() {
+    User created = new User("new@example.com", "newuser", "encoded", "", "");
+    when(userService.createUser(any(RegisterParam.class))).thenReturn(created);
+    when(jwtService.toToken(eq(created))).thenReturn("jwt-token");
+
+    String query =
+        "mutation { createUser(input: {email: \"new@example.com\", username: \"newuser\","
+            + " password: \"secret123\"}) { ... on UserPayload { user { email username token } } } }";
+
+    Map<String, Object> user =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.createUser.user");
+
+    assertThat(user.get("email")).isEqualTo("new@example.com");
+    assertThat(user.get("username")).isEqualTo("newuser");
+    assertThat(user.get("token")).isEqualTo("jwt-token");
+  }
+
+  @Test
+  void should_return_error_union_when_registration_violates_constraints() {
+    ConstraintViolationException cve =
+        new ConstraintViolationException(buildViolation("username", "already exist"));
+    when(userService.createUser(any(RegisterParam.class))).thenThrow(cve);
+
+    String query =
+        "mutation { createUser(input: {email: \"new@example.com\", username: \"taken\","
+            + " password: \"secret123\"}) { ... on Error { message errors { key value } } } }";
+
+    String message = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.createUser.message");
+    java.util.List<String> values =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.createUser.errors[0].value");
+
+    assertThat(message).isEqualTo("BAD_REQUEST");
+    assertThat(values).contains("already exist");
+  }
+
+  @Test
+  void should_login_with_valid_credentials() {
+    User user = new User("john@example.com", "john", "hashed", "", "");
+    when(userRepository.findByEmail(eq("john@example.com"))).thenReturn(Optional.of(user));
+    when(encryptService.matches(eq("secret"), eq("hashed"))).thenReturn(true);
+    when(jwtService.toToken(eq(user))).thenReturn("login-token");
+
+    String query =
+        "mutation { login(email: \"john@example.com\", password: \"secret\") { user { username token } } }";
+
+    Map<String, Object> data = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.login.user");
+
+    assertThat(data.get("username")).isEqualTo("john");
+    assertThat(data.get("token")).isEqualTo("login-token");
+  }
+
+  @Test
+  void should_fail_login_with_invalid_credentials() {
+    when(userRepository.findByEmail(eq("john@example.com"))).thenReturn(Optional.empty());
+
+    String query =
+        "mutation { login(email: \"john@example.com\", password: \"wrong\") { user { username } } }";
+
+    ExecutionResult result = dgsQueryExecutor.execute(query);
+
+    assertThat(result.getErrors()).isNotEmpty();
+  }
+
+  @Test
+  void should_update_authenticated_user() {
+    User current = new User("john@example.com", "john", "hashed", "old bio", "");
+    authenticate(current);
+    when(jwtService.toToken(eq(current))).thenReturn("updated-token");
+
+    String query =
+        "mutation { updateUser(changes: {email: \"changed@example.com\", bio: \"new bio\"})"
+            + " { user { email username token } } }";
+
+    Map<String, Object> user =
+        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.updateUser.user");
+
+    ArgumentCaptor<UpdateUserCommand> captor = ArgumentCaptor.forClass(UpdateUserCommand.class);
+    Mockito.verify(userService).updateUser(captor.capture());
+    assertThat(captor.getValue().getTargetUser()).isEqualTo(current);
+    assertThat(captor.getValue().getParam().getEmail()).isEqualTo("changed@example.com");
+    assertThat(captor.getValue().getParam().getBio()).isEqualTo("new bio");
+    // The token/username come from the (mocked, unchanged) current principal.
+    assertThat(user.get("username")).isEqualTo("john");
+    assertThat(user.get("token")).isEqualTo("updated-token");
+  }
+
+  @Test
+  void should_return_null_when_updating_unauthenticated_user() {
+    anonymous();
+
+    String query = "mutation { updateUser(changes: {bio: \"new bio\"}) { user { username } } }";
+
+    Object updateUser = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.updateUser");
+
+    assertThat(updateUser).isNull();
+  }
+
+  private Set<ConstraintViolation<?>> buildViolation(String field, String message) {
+    ConstraintViolation<?> violation = Mockito.mock(ConstraintViolation.class);
+    javax.validation.Path path = Mockito.mock(javax.validation.Path.class);
+    when(path.toString()).thenReturn(field);
+    when(violation.getPropertyPath()).thenReturn(path);
+    when(violation.getMessage()).thenReturn(message);
+    Mockito.<Class<?>>when(violation.getRootBeanClass()).thenReturn(User.class);
+    javax.validation.metadata.ConstraintDescriptor<?> descriptor =
+        Mockito.mock(javax.validation.metadata.ConstraintDescriptor.class);
+    when(violation.getConstraintDescriptor())
+        .thenReturn((javax.validation.metadata.ConstraintDescriptor) descriptor);
+    java.lang.annotation.Annotation annotation =
+        Mockito.mock(java.lang.annotation.Annotation.class);
+    Mockito.<Class<? extends java.lang.annotation.Annotation>>when(annotation.annotationType())
+        .thenReturn((Class) javax.validation.constraints.NotNull.class);
+    when(descriptor.getAnnotation()).thenReturn((java.lang.annotation.Annotation) annotation);
+    Set<ConstraintViolation<?>> violations = new HashSet<>();
+    violations.add(violation);
+    return violations;
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.jayway.jsonpath.DocumentContext;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import graphql.ExecutionResult;
@@ -76,12 +77,12 @@ class UserMutationTest extends GraphQLTestBase {
         "mutation { createUser(input: {email: \"new@example.com\", username: \"taken\","
             + " password: \"secret123\"}) { ... on Error { message errors { key value } } } }";
 
-    String message = dgsQueryExecutor.executeAndExtractJsonPath(query, "data.createUser.message");
-    java.util.List<String> values =
-        dgsQueryExecutor.executeAndExtractJsonPath(query, "data.createUser.errors[0].value");
+    DocumentContext context = dgsQueryExecutor.executeAndGetDocumentContext(query);
 
-    assertThat(message).isEqualTo("BAD_REQUEST");
-    assertThat(values).contains("already exist");
+    assertThat(context.read("data.createUser.message", String.class)).isEqualTo("BAD_REQUEST");
+    assertThat(context.read("data.createUser.errors[0].key", String.class)).isEqualTo("username");
+    assertThat(context.<java.util.List<String>>read("data.createUser.errors[0].value"))
+        .contains("already exist");
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -35,7 +35,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
       DgsAutoConfiguration.class,
       UserMutation.class,
       MeDatafetcher.class,
-      GraphQLCustomizeExceptionHandler.class
+      GraphQLCustomizeExceptionHandler.class,
+      RecordingExceptionHandler.class
     })
 class UserMutationTest extends GraphQLTestBase {
 

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -1,0 +1,147 @@
+package io.spring.graphql.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import graphql.GraphQLError;
+import graphql.Scalars;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.core.user.User;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.ErrorItem;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Path;
+import javax.validation.constraints.NotBlank;
+import javax.validation.metadata.ConstraintDescriptor;
+import org.junit.jupiter.api.Test;
+
+class GraphQLCustomizeExceptionHandlerTest {
+
+  private final GraphQLCustomizeExceptionHandler handler = new GraphQLCustomizeExceptionHandler();
+
+  @Test
+  void should_map_invalid_authentication_to_unauthenticated_error() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new InvalidAuthenticationException()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("invalid email or password");
+    assertThat(error.getPath()).containsExactly("login");
+    assertThat(error.getExtensions().get("errorType")).hasToString("UNAUTHENTICATED");
+  }
+
+  @Test
+  void should_map_constraint_violations_to_bad_request_extensions() {
+    ConstraintViolationException cve =
+        new ConstraintViolationException(
+            "invalid",
+            violations(
+                violation("createUser.arg0.email", "can't be empty"),
+                violation("createUser.arg0.username", "already exist")));
+
+    DataFetcherExceptionHandlerResult result = handler.onException(parametersFor(cve));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("invalid");
+    // The field errors are attached under their (stripped) property path.
+    Map<String, Object> extensions = error.getExtensions();
+    assertThat(extensions.get("email")).isEqualTo(Arrays.asList("can't be empty"));
+    assertThat(extensions.get("username")).isEqualTo(Arrays.asList("already exist"));
+  }
+
+  @Test
+  void should_fall_through_to_default_handler_for_unknown_exceptions() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new IllegalStateException("boom")));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).contains("boom");
+    // The DGS default handler classifies anything it does not know about as INTERNAL.
+    assertThat(error.getExtensions().get("errorType")).hasToString("INTERNAL");
+  }
+
+  @Test
+  void should_build_error_payload_data_from_constraint_violations() {
+    ConstraintViolationException cve =
+        new ConstraintViolationException(
+            violations(
+                violation("createUser.arg0.email", "can't be empty"),
+                violation("createUser.arg0.email", "should be an email")));
+
+    Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(cve);
+
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).hasSize(1);
+    ErrorItem item = error.getErrors().get(0);
+    assertThat(item.getKey()).isEqualTo("email");
+    assertThat(item.getValue()).containsExactlyInAnyOrder("can't be empty", "should be an email");
+  }
+
+  @Test
+  void should_keep_single_segment_property_path_as_is() {
+    ConstraintViolationException cve =
+        new ConstraintViolationException(violations(violation("password", "too short")));
+
+    Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(cve);
+
+    List<ErrorItem> items = error.getErrors();
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getKey()).isEqualTo("password");
+    assertThat(items.get(0).getValue()).containsExactly("too short");
+  }
+
+  private DataFetcherExceptionHandlerParameters parametersFor(Throwable throwable) {
+    ExecutionStepInfo stepInfo =
+        ExecutionStepInfo.newExecutionStepInfo()
+            .type(Scalars.GraphQLString)
+            .path(ResultPath.rootPath().segment("login"))
+            .build();
+    DataFetchingEnvironment environment =
+        DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+            .executionStepInfo(stepInfo)
+            .build();
+    return DataFetcherExceptionHandlerParameters.newExceptionParameters()
+        .dataFetchingEnvironment(environment)
+        .exception(throwable)
+        .build();
+  }
+
+  private Set<ConstraintViolation<?>> violations(ConstraintViolation<?>... violations) {
+    return new HashSet<>(Arrays.asList(violations));
+  }
+
+  private ConstraintViolation<?> violation(String propertyPath, String message) {
+    ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+    Path path = mock(Path.class);
+    when(path.toString()).thenReturn(propertyPath);
+    when(violation.getPropertyPath()).thenReturn(path);
+    when(violation.getMessage()).thenReturn(message);
+    org.mockito.Mockito.<Class<?>>when(violation.getRootBeanClass()).thenReturn(User.class);
+
+    ConstraintDescriptor<?> descriptor = mock(ConstraintDescriptor.class);
+    Annotation annotation = mock(NotBlank.class);
+    org.mockito.Mockito.<Class<? extends Annotation>>when(annotation.annotationType())
+        .thenReturn(NotBlank.class);
+    when(descriptor.getAnnotation()).thenReturn((Annotation) annotation);
+    org.mockito.Mockito.<ConstraintDescriptor<?>>when(violation.getConstraintDescriptor())
+        .thenReturn(descriptor);
+    return violation;
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -107,6 +107,18 @@ class GraphQLCustomizeExceptionHandlerTest {
     assertThat(items.get(0).getValue()).containsExactly("too short");
   }
 
+  @Test
+  void should_produce_an_empty_key_for_a_two_segment_property_path() {
+    ConstraintViolationException cve =
+        new ConstraintViolationException(violations(violation("createUser.email", "too short")));
+
+    Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(cve);
+
+    // getParam drops the first two segments, so a two-segment path leaves nothing behind.
+    assertThat(error.getErrors()).hasSize(1);
+    assertThat(error.getErrors().get(0).getKey()).isEmpty();
+  }
+
   private DataFetcherExceptionHandlerParameters parametersFor(Throwable throwable) {
     ExecutionStepInfo stepInfo =
         ExecutionStepInfo.newExecutionStepInfo()

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -107,16 +107,21 @@ class GraphQLCustomizeExceptionHandlerTest {
     assertThat(items.get(0).getValue()).containsExactly("too short");
   }
 
+  /**
+   * Known defect, pinned here so a fix is a deliberate change: {@code getParam} drops the first two
+   * segments of a multi-segment path, so a two-segment path leaves an empty key behind even though
+   * the schema declares {@code ErrorItem.key} as non-null and clients cannot use it.
+   */
   @Test
-  void should_produce_an_empty_key_for_a_two_segment_property_path() {
+  void should_currently_produce_an_empty_key_for_a_two_segment_property_path() {
     ConstraintViolationException cve =
         new ConstraintViolationException(violations(violation("createUser.email", "too short")));
 
     Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(cve);
 
-    // getParam drops the first two segments, so a two-segment path leaves nothing behind.
     assertThat(error.getErrors()).hasSize(1);
     assertThat(error.getErrors().get(0).getKey()).isEmpty();
+    assertThat(error.getErrors().get(0).getValue()).containsExactly("too short");
   }
 
   private DataFetcherExceptionHandlerParameters parametersFor(Throwable throwable) {


### PR DESCRIPTION
## Summary

`io.spring.graphql` was the largest coverage gap in the repo. This adds 63 tests under `src/test/java/io/spring/graphql/**`. No production code is touched.

| package | before | after |
| --- | --- | --- |
| `io/spring/graphql` | 4.9% (81/1644) | **99.8%** (1641/1644) |
| `io/spring/graphql/exception` | 3.0% (8/263) | **100%** (263/263) |

The only remaining uncovered instructions are `SecurityUtil`'s implicit constructor.

Each test class boots a minimal DGS context and drives the real schema through `DgsQueryExecutor`, with query/command services and repositories as `@MockBean`:

```java
@SpringBootTest(classes = {DgsAutoConfiguration.class, ArticleDatafetcher.class, ProfileDatafetcher.class})
```

`GraphQLTestBase` owns the `SecurityContextHolder` lifecycle — `authenticate(user)` installs a `UsernamePasswordAuthenticationToken` whose principal is the `User` domain object (what `SecurityUtil.getCurrentUser()` casts to), `anonymous()` installs an `AnonymousAuthenticationToken`, and the context is cleared before and after every test.

Two things worth flagging for a reviewer:

- **Nested resolution needs the collaborating datafetcher in the context.** `Article.author`, `Article.comments`, `ArticlePayload.article`, `CommentPayload.comment` and `UserPayload.user` are resolved by *other* `@DgsData` methods off `DataFetcherResult.localContext`, so e.g. `ArticleMutationTest` imports `ArticleDatafetcher` to assert `createArticle(...) { article { slug tagList } }`, and `CommentDatafetcherTest` imports `ArticleDatafetcher` to reach `article(slug:...) { comments(first:10) { ... } }`. That path is what actually exercises the `Map<String, ArticleData>` local-context handoff.
- **`ArticleDatafetcher.getCommentArticle` is tested directly**, not through a query: every producer of a `Comment`'s local context (`getComment`, `articleComments`) sets a `Map<String, CommentData>`, whereas `getCommentArticle` reads `CommentData` from `getLocalContext()`. The test builds a `DataFetchingEnvironmentImpl` with a `CommentData` local context so the method's own contract is covered without changing production code.

Branch coverage per class includes the unauthenticated branch (`AuthenticationException` / null return), `ResourceNotFoundException`, `NoAuthorizationException` (update/delete article, delete comment by a non-author), the `IllegalArgumentException` when neither `first` nor `last` is given, and the `PREV`/`before` paging direction — asserted by capturing the `CursorPageParameter` and checking `direction`, `limit` and `cursor`.

For `GraphQLCustomizeExceptionHandler`, the tests assert `InvalidAuthenticationException` → `UNAUTHENTICATED`, `ConstraintViolationException` → bad-request error whose extensions carry the field errors keyed by stripped property path (`createUser.arg0.email` → `email`), `getErrorsAsData` grouping multiple messages per field into one `ErrorItem`, and that an `IllegalStateException` falls through to the DGS default handler (`INTERNAL`).

`./gradlew spotlessApply test jacocoTestReport` is green.


Link to Devin session: https://app.devin.ai/sessions/c93a32af0db244ffba41b9fb77574078
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/914?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->