### PR TITLE
build: add JaCoCo coverage reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'jacoco'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
 }
@@ -56,8 +57,45 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 }
 
+jacoco {
+    toolVersion = '0.8.7'
+}
+
+def jacocoExcludes = ['io/spring/graphql/types/**']
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: jacocoExcludes)
+        })
+    )
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.5
+            }
+        }
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: jacocoExcludes)
+        })
+    )
 }
 
 tasks.named('clean') {

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ tasks.named('jacocoTestReport') {
 }
 
 tasks.named('jacocoTestCoverageVerification') {
+    dependsOn test
     violationRules {
         rule {
             limit {

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,15 @@ jacoco {
 
 def jacocoExcludes = ['io/spring/graphql/types/**']
 
+// Keep the report and the verification measuring the same denominator.
+tasks.withType(JacocoReportBase).configureEach {
+    classDirectories.setFrom(
+        files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: jacocoExcludes)
+        })
+    )
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
@@ -74,11 +83,6 @@ tasks.named('jacocoTestReport') {
         xml.required = true
         html.required = true
     }
-    classDirectories.setFrom(
-        files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: jacocoExcludes)
-        })
-    )
 }
 
 tasks.named('jacocoTestCoverageVerification') {
@@ -92,11 +96,6 @@ tasks.named('jacocoTestCoverageVerification') {
             }
         }
     }
-    classDirectories.setFrom(
-        files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: jacocoExcludes)
-        })
-    )
 }
 
 tasks.named('clean') {


### PR DESCRIPTION
## Summary
Adds the `jacoco` plugin so coverage is produced automatically by `test`, with the DGS-generated `io.spring.graphql.types.*` classes stripped out of the denominator so the numbers reflect hand-written code only. Only `build.gradle` changes.

- `test` is `finalizedBy jacocoTestReport`; `jacocoTestReport` `dependsOn test` and emits both XML and HTML.
- Both `jacocoTestReport` and `jacocoTestCoverageVerification` filter `classDirectories` through `fileTree(dir: it, exclude: ['io/spring/graphql/types/**'])`.
- `jacocoTestCoverageVerification` enforces LINE COVEREDRATIO ≥ 0.5 but is **not** wired into `check` — it stays a manually-invoked task, so nothing new can fail the build. (`./gradlew check --dry-run` shows only `jacocoTestReport`, pulled in as the `test` finalizer.)

Regenerate the report:

```
./gradlew clean test jacocoTestReport
# build/reports/jacoco/test/html/index.html
# build/reports/jacoco/test/jacocoTestReport.xml
```

Current coverage on this branch (generated report, generated GraphQL types excluded):

| counter | covered/total | % |
| --- | --- | --- |
| LINE | 738/1400 | **52.7%** |
| BRANCH | 146/650 | **22.5%** |
| INSTRUCTION | 3477/7504 | 46.3% |
| METHOD | 347/527 | 65.8% |
| CLASS | 86/119 | 72.3% |

`./gradlew jacocoTestCoverageVerification` passes at the 0.5 line threshold today.

## Notes (pre-existing, not touched — out of scope for this PR)
- The repo has **no `gradle.properties`**, so the `--add-exports` flags google-java-format needs on JDK 16+ are absent: `./gradlew spotlessCheck` fails on JDK 17 with `IllegalAccessError: ... jdk.compiler does not export com.sun.tools.javac.parser`. Workaround used here: pass `-Dorg.gradle.jvmargs="--add-exports jdk.compiler/com.sun.tools.javac.{api,file,parser,tree,util}=ALL-UNNAMED"`.
- With those flags, `spotlessCheck` reports a pre-existing violation on `master` in `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java` (line-wrapping in `setUp()`). This branch adds no Java sources, so it is unaffected by this change.
- `./gradlew clean test jacocoTestReport` is green.


Link to Devin session: https://app.devin.ai/sessions/5ae3cb3d9012453396e6adb542dc5d46
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/918?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->