### PR TITLE
test: add TagsApi REST controller test

### DIFF
--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -6,7 +6,9 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
@@ -15,6 +17,7 @@ import io.spring.api.security.WebSecurityConfig;
 import io.spring.application.TagsQueryService;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.UserRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,6 +75,23 @@ public class TagsApiTest {
     when(tagsQueryService.allTags()).thenReturn(asList("reactjs"));
 
     given()
+        .when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", contains("reactjs"));
+
+    verifyNoInteractions(jwtService, userRepository);
+  }
+
+  @Test
+  public void should_get_tags_with_invalid_token() {
+    when(tagsQueryService.allTags()).thenReturn(asList("reactjs"));
+    when(jwtService.getSubFromToken(eq("invalid-token"))).thenReturn(Optional.empty());
+
+    given()
+        .header("Authorization", "Token invalid-token")
         .when()
         .get("/tags")
         .prettyPeek()

--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -1,0 +1,82 @@
+package io.spring.api;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.JacksonCustomizations;
+import io.spring.api.security.WebSecurityConfig;
+import io.spring.application.TagsQueryService;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TagsApi.class)
+@Import({WebSecurityConfig.class, JacksonCustomizations.class})
+public class TagsApiTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private JwtService jwtService;
+
+  @BeforeEach
+  public void setUp() {
+    RestAssuredMockMvc.mockMvc(mvc);
+  }
+
+  @Test
+  public void should_get_tags_success() {
+    when(tagsQueryService.allTags()).thenReturn(asList("reactjs", "angularjs"));
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", hasSize(2))
+        .body("tags", contains("reactjs", "angularjs"));
+
+    verify(tagsQueryService).allTags();
+  }
+
+  @Test
+  public void should_get_empty_tags_success() {
+    when(tagsQueryService.allTags()).thenReturn(emptyList());
+
+    RestAssuredMockMvc.when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", empty());
+  }
+
+  @Test
+  public void should_get_tags_without_authorization_header() {
+    when(tagsQueryService.allTags()).thenReturn(asList("reactjs"));
+
+    given()
+        .when()
+        .get("/tags")
+        .prettyPeek()
+        .then()
+        .statusCode(200)
+        .body("tags", contains("reactjs"));
+  }
+}

--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -98,5 +98,8 @@ public class TagsApiTest {
         .then()
         .statusCode(200)
         .body("tags", contains("reactjs"));
+
+    verify(jwtService).getSubFromToken(eq("invalid-token"));
+    verifyNoInteractions(userRepository);
   }
 }


### PR DESCRIPTION
## Summary
`TagsApi` was the only REST controller without a test. Adds `src/test/java/io/spring/api/TagsApiTest.java` (one new file, no other changes) following the `@WebMvcTest` + `@Import({WebSecurityConfig.class, JacksonCustomizations.class})` + `RestAssuredMockMvc` pattern from `ProfileApiTest`.

Covers `GET /tags`: 200 with `{"tags": ["reactjs","angularjs"]}` shape, the empty-list case (`tags` serialized as `[]`, not omitted), and that the endpoint works with no `Authorization` header (it is `permitAll` in `WebSecurityConfig`).

The test does not extend `TestWithCurrentUser` since no current user is involved, but it still declares `@MockBean UserRepository` / `@MockBean JwtService` because the imported `WebSecurityConfig` registers `JwtTokenFilter`, which `@Autowired`s both.

Notes for reviewers (not changed here, out of scope):
- `spotlessCheck` fails on `master` for a pre-existing violation in `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java`; `spotlessApply` reformats that file, and I reverted it to keep this PR to a single file. The new test file itself is spotless-clean.
- The repo has no `gradle.properties`, so on JDK 17 `spotlessApply`/`spotlessCheck` need `-Dorg.gradle.jvmargs="--add-exports jdk.compiler/com.sun.tools.javac.{api,file,parser,tree,util}=ALL-UNNAMED"` (or `-x spotlessJava`).

`./gradlew test` passes: 71 tests, 0 failures.


Link to Devin session: https://app.devin.ai/sessions/77b5a977136e496fab05603af72821c4
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/919?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->