### PR TITLE
test: add unit tests for core domain entities and AuthorizationService

### DIFF
--- a/src/test/java/io/spring/core/article/TagTest.java
+++ b/src/test/java/io/spring/core/article/TagTest.java
@@ -1,0 +1,79 @@
+package io.spring.core.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class TagTest {
+
+  @Test
+  public void should_generate_id_and_keep_name_from_constructor() {
+    Tag tag = new Tag("java");
+
+    assertThat(tag.getId()).isNotNull();
+    assertThat(UUID.fromString(tag.getId()).toString()).isEqualTo(tag.getId());
+    assertThat(tag.getName()).isEqualTo("java");
+  }
+
+  @Test
+  public void should_generate_different_id_for_each_tag() {
+    assertThat(new Tag("java").getId()).isNotEqualTo(new Tag("java").getId());
+  }
+
+  @Test
+  public void should_leave_all_fields_null_with_no_args_constructor() {
+    Tag tag = new Tag();
+
+    assertThat(tag.getId()).isNull();
+    assertThat(tag.getName()).isNull();
+  }
+
+  @Test
+  public void should_set_fields_with_setters() {
+    Tag tag = new Tag();
+
+    tag.setId("id");
+    tag.setName("java");
+
+    assertThat(tag.getId()).isEqualTo("id");
+    assertThat(tag.getName()).isEqualTo("java");
+  }
+
+  @Test
+  public void should_use_only_name_for_equals_and_hashcode() {
+    Tag tag = new Tag("java");
+    Tag sameNameDifferentId = new Tag("java");
+
+    assertThat(sameNameDifferentId.getId()).isNotEqualTo(tag.getId());
+    assertThat(sameNameDifferentId).isEqualTo(tag);
+    assertThat(sameNameDifferentId.hashCode()).isEqualTo(tag.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_names_are_different() {
+    assertThat(new Tag("java")).isNotEqualTo(new Tag("spring"));
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_types() {
+    Tag tag = new Tag("java");
+
+    assertThat(tag).isNotEqualTo(null);
+    assertThat(tag).isNotEqualTo("java");
+    assertThat(tag).isEqualTo(tag);
+  }
+
+  @Test
+  public void should_be_equal_when_both_names_are_null() {
+    assertThat(new Tag()).isEqualTo(new Tag());
+    assertThat(new Tag().hashCode()).isEqualTo(new Tag().hashCode());
+  }
+
+  @Test
+  public void should_expose_id_and_name_in_to_string() {
+    Tag tag = new Tag("java");
+
+    assertThat(tag.toString()).contains(tag.getId()).contains("java");
+  }
+}

--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -1,0 +1,77 @@
+package io.spring.core.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class CommentTest {
+
+  @Test
+  public void should_generate_id_and_created_at_and_keep_all_fields_from_constructor() {
+    DateTime before = new DateTime();
+    Comment comment = new Comment("content", "userId", "articleId");
+
+    assertThat(comment.getId()).isNotNull();
+    assertThat(UUID.fromString(comment.getId()).toString()).isEqualTo(comment.getId());
+    assertThat(comment.getBody()).isEqualTo("content");
+    assertThat(comment.getUserId()).isEqualTo("userId");
+    assertThat(comment.getArticleId()).isEqualTo("articleId");
+    assertThat(comment.getCreatedAt()).isNotNull();
+    assertThat(comment.getCreatedAt().isBefore(before)).isFalse();
+  }
+
+  @Test
+  public void should_generate_different_id_for_each_comment() {
+    Comment one = new Comment("content", "userId", "articleId");
+    Comment another = new Comment("content", "userId", "articleId");
+
+    assertThat(one.getId()).isNotEqualTo(another.getId());
+  }
+
+  @Test
+  public void should_leave_all_fields_null_with_no_args_constructor() {
+    Comment comment = new Comment();
+
+    assertThat(comment.getId()).isNull();
+    assertThat(comment.getBody()).isNull();
+    assertThat(comment.getUserId()).isNull();
+    assertThat(comment.getArticleId()).isNull();
+    assertThat(comment.getCreatedAt()).isNull();
+  }
+
+  @Test
+  public void should_use_only_id_for_equals_and_hashcode() {
+    Comment comment = new Comment("content", "userId", "articleId");
+    Comment sameIdDifferentContent = new Comment("other content", "otherUser", "otherArticle");
+    ReflectionTestUtils.setField(sameIdDifferentContent, "id", comment.getId());
+
+    assertThat(sameIdDifferentContent).isEqualTo(comment);
+    assertThat(sameIdDifferentContent.hashCode()).isEqualTo(comment.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_are_different() {
+    Comment one = new Comment("content", "userId", "articleId");
+    Comment another = new Comment("content", "userId", "articleId");
+
+    assertThat(one).isNotEqualTo(another);
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_types() {
+    Comment comment = new Comment("content", "userId", "articleId");
+
+    assertThat(comment).isNotEqualTo(null);
+    assertThat(comment).isNotEqualTo("content");
+    assertThat(comment).isEqualTo(comment);
+  }
+
+  @Test
+  public void should_be_equal_when_both_ids_are_null() {
+    assertThat(new Comment()).isEqualTo(new Comment());
+    assertThat(new Comment().hashCode()).isEqualTo(new Comment().hashCode());
+  }
+}

--- a/src/test/java/io/spring/core/comment/CommentTest.java
+++ b/src/test/java/io/spring/core/comment/CommentTest.java
@@ -13,6 +13,7 @@ public class CommentTest {
   public void should_generate_id_and_created_at_and_keep_all_fields_from_constructor() {
     DateTime before = new DateTime();
     Comment comment = new Comment("content", "userId", "articleId");
+    DateTime after = new DateTime();
 
     assertThat(comment.getId()).isNotNull();
     assertThat(UUID.fromString(comment.getId()).toString()).isEqualTo(comment.getId());
@@ -20,7 +21,7 @@ public class CommentTest {
     assertThat(comment.getUserId()).isEqualTo("userId");
     assertThat(comment.getArticleId()).isEqualTo("articleId");
     assertThat(comment.getCreatedAt()).isNotNull();
-    assertThat(comment.getCreatedAt().isBefore(before)).isFalse();
+    assertThat(comment.getCreatedAt().getMillis()).isBetween(before.getMillis(), after.getMillis());
   }
 
   @Test

--- a/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
+++ b/src/test/java/io/spring/core/favorite/ArticleFavoriteTest.java
@@ -1,0 +1,57 @@
+package io.spring.core.favorite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ArticleFavoriteTest {
+
+  @Test
+  public void should_keep_both_ids_from_constructor() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+
+    assertThat(favorite.getArticleId()).isEqualTo("articleId");
+    assertThat(favorite.getUserId()).isEqualTo("userId");
+  }
+
+  @Test
+  public void should_leave_both_ids_null_with_no_args_constructor() {
+    ArticleFavorite favorite = new ArticleFavorite();
+
+    assertThat(favorite.getArticleId()).isNull();
+    assertThat(favorite.getUserId()).isNull();
+  }
+
+  @Test
+  public void should_use_all_fields_for_equals_and_hashcode() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+    ArticleFavorite same = new ArticleFavorite("articleId", "userId");
+
+    assertThat(same).isEqualTo(favorite);
+    assertThat(same.hashCode()).isEqualTo(favorite.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_any_field_differs() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+
+    assertThat(new ArticleFavorite("otherArticleId", "userId")).isNotEqualTo(favorite);
+    assertThat(new ArticleFavorite("articleId", "otherUserId")).isNotEqualTo(favorite);
+    assertThat(new ArticleFavorite()).isNotEqualTo(favorite);
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_types() {
+    ArticleFavorite favorite = new ArticleFavorite("articleId", "userId");
+
+    assertThat(favorite).isNotEqualTo(null);
+    assertThat(favorite).isNotEqualTo("articleId");
+    assertThat(favorite).isEqualTo(favorite);
+  }
+
+  @Test
+  public void should_be_equal_when_both_favorites_are_empty() {
+    assertThat(new ArticleFavorite()).isEqualTo(new ArticleFavorite());
+    assertThat(new ArticleFavorite().hashCode()).isEqualTo(new ArticleFavorite().hashCode());
+  }
+}

--- a/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
+++ b/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
@@ -40,6 +40,11 @@ public class AuthorizationServiceTest {
     assertThat(AuthorizationService.canWriteArticle(author, authorless)).isFalse();
   }
 
+  /**
+   * Characterization of the current implementation: {@code user.getId().equals(...)} dereferences a
+   * null id. It is not a desired guarantee -- adding defensive null handling to {@link
+   * AuthorizationService} should come with an update to this test.
+   */
   @Test
   public void should_throw_when_checking_article_permission_for_an_id_less_user() {
     assertThatExceptionOfType(NullPointerException.class)
@@ -83,6 +88,7 @@ public class AuthorizationServiceTest {
     assertThat(AuthorizationService.canWriteComment(otherUser, authorless, comment)).isFalse();
   }
 
+  /** Characterization of the current implementation, see the article permission case above. */
   @Test
   public void should_throw_when_checking_comment_permission_for_an_id_less_user() {
     Comment comment = new Comment("body", otherUser.getId(), article.getId());

--- a/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
+++ b/src/test/java/io/spring/core/service/AuthorizationServiceTest.java
@@ -1,0 +1,98 @@
+package io.spring.core.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.spring.core.article.Article;
+import io.spring.core.comment.Comment;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationServiceTest {
+
+  private User author;
+  private User otherUser;
+  private Article article;
+
+  @BeforeEach
+  public void setUp() {
+    author = new User("author@test.com", "author", "123", "", "");
+    otherUser = new User("other@test.com", "other", "123", "", "");
+    article = new Article("title", "desc", "body", Arrays.asList("java"), author.getId());
+  }
+
+  @Test
+  public void should_allow_the_article_author_to_write_the_article() {
+    assertThat(AuthorizationService.canWriteArticle(author, article)).isTrue();
+  }
+
+  @Test
+  public void should_not_allow_another_user_to_write_the_article() {
+    assertThat(AuthorizationService.canWriteArticle(otherUser, article)).isFalse();
+  }
+
+  @Test
+  public void should_not_allow_writing_an_article_without_an_author() {
+    Article authorless = new Article("title", "desc", "body", Arrays.asList("java"), null);
+
+    assertThat(AuthorizationService.canWriteArticle(author, authorless)).isFalse();
+  }
+
+  @Test
+  public void should_throw_when_checking_article_permission_for_an_id_less_user() {
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> AuthorizationService.canWriteArticle(new User(), article));
+  }
+
+  @Test
+  public void should_allow_the_comment_author_to_write_the_comment() {
+    Comment comment = new Comment("body", otherUser.getId(), article.getId());
+
+    assertThat(AuthorizationService.canWriteComment(otherUser, article, comment)).isTrue();
+  }
+
+  @Test
+  public void should_allow_the_article_author_to_write_someone_else_comment() {
+    Comment comment = new Comment("body", otherUser.getId(), article.getId());
+
+    assertThat(AuthorizationService.canWriteComment(author, article, comment)).isTrue();
+  }
+
+  @Test
+  public void should_allow_the_author_of_both_the_article_and_the_comment() {
+    Comment comment = new Comment("body", author.getId(), article.getId());
+
+    assertThat(AuthorizationService.canWriteComment(author, article, comment)).isTrue();
+  }
+
+  @Test
+  public void should_not_allow_an_unrelated_user_to_write_the_comment() {
+    User unrelatedUser = new User("unrelated@test.com", "unrelated", "123", "", "");
+    Comment comment = new Comment("body", otherUser.getId(), article.getId());
+
+    assertThat(AuthorizationService.canWriteComment(unrelatedUser, article, comment)).isFalse();
+  }
+
+  @Test
+  public void should_not_allow_writing_a_comment_without_an_article_author_and_comment_author() {
+    Article authorless = new Article("title", "desc", "body", Arrays.asList("java"), null);
+    Comment comment = new Comment("body", null, authorless.getId());
+
+    assertThat(AuthorizationService.canWriteComment(otherUser, authorless, comment)).isFalse();
+  }
+
+  @Test
+  public void should_throw_when_checking_comment_permission_for_an_id_less_user() {
+    Comment comment = new Comment("body", otherUser.getId(), article.getId());
+
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> AuthorizationService.canWriteComment(new User(), article, comment));
+  }
+
+  @Test
+  public void should_be_instantiable() {
+    assertThat(new AuthorizationService()).isNotNull();
+  }
+}

--- a/src/test/java/io/spring/core/user/FollowRelationTest.java
+++ b/src/test/java/io/spring/core/user/FollowRelationTest.java
@@ -1,0 +1,69 @@
+package io.spring.core.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class FollowRelationTest {
+
+  @Test
+  public void should_keep_both_ids_from_constructor() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+
+    assertThat(relation.getUserId()).isEqualTo("userId");
+    assertThat(relation.getTargetId()).isEqualTo("targetId");
+  }
+
+  @Test
+  public void should_leave_both_ids_null_with_no_args_constructor() {
+    FollowRelation relation = new FollowRelation();
+
+    assertThat(relation.getUserId()).isNull();
+    assertThat(relation.getTargetId()).isNull();
+  }
+
+  @Test
+  public void should_set_ids_with_setters() {
+    FollowRelation relation = new FollowRelation();
+
+    relation.setUserId("userId");
+    relation.setTargetId("targetId");
+
+    assertThat(relation.getUserId()).isEqualTo("userId");
+    assertThat(relation.getTargetId()).isEqualTo("targetId");
+  }
+
+  @Test
+  public void should_use_all_fields_for_equals_and_hashcode() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+    FollowRelation same = new FollowRelation("userId", "targetId");
+
+    assertThat(same).isEqualTo(relation);
+    assertThat(same.hashCode()).isEqualTo(relation.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_any_field_differs() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+
+    assertThat(new FollowRelation("otherUserId", "targetId")).isNotEqualTo(relation);
+    assertThat(new FollowRelation("userId", "otherTargetId")).isNotEqualTo(relation);
+    assertThat(new FollowRelation()).isNotEqualTo(relation);
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_types() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+
+    assertThat(relation).isNotEqualTo(null);
+    assertThat(relation).isNotEqualTo("userId");
+    assertThat(relation).isEqualTo(relation);
+  }
+
+  @Test
+  public void should_expose_both_ids_in_to_string() {
+    FollowRelation relation = new FollowRelation("userId", "targetId");
+
+    assertThat(relation.toString()).contains("userId").contains("targetId");
+  }
+}

--- a/src/test/java/io/spring/core/user/FollowRelationTest.java
+++ b/src/test/java/io/spring/core/user/FollowRelationTest.java
@@ -62,8 +62,8 @@ public class FollowRelationTest {
 
   @Test
   public void should_expose_both_ids_in_to_string() {
-    FollowRelation relation = new FollowRelation("userId", "targetId");
+    FollowRelation relation = new FollowRelation("u-1", "t-2");
 
-    assertThat(relation.toString()).contains("userId").contains("targetId");
+    assertThat(relation.toString()).contains("u-1").contains("t-2");
   }
 }

--- a/src/test/java/io/spring/core/user/UserTest.java
+++ b/src/test/java/io/spring/core/user/UserTest.java
@@ -1,0 +1,130 @@
+package io.spring.core.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class UserTest {
+
+  @Test
+  public void should_generate_id_and_keep_all_fields_from_constructor() {
+    User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+    assertThat(user.getId()).isNotNull();
+    assertThat(UUID.fromString(user.getId()).toString()).isEqualTo(user.getId());
+    assertThat(user.getEmail()).isEqualTo("jake@jake.jake");
+    assertThat(user.getUsername()).isEqualTo("jake");
+    assertThat(user.getPassword()).isEqualTo("123");
+    assertThat(user.getBio()).isEqualTo("bio");
+    assertThat(user.getImage()).isEqualTo("image");
+  }
+
+  @Test
+  public void should_generate_different_id_for_each_user() {
+    User one = new User("jake@jake.jake", "jake", "123", "", "");
+    User another = new User("jake@jake.jake", "jake", "123", "", "");
+
+    assertThat(one.getId()).isNotEqualTo(another.getId());
+  }
+
+  @Test
+  public void should_leave_all_fields_null_with_no_args_constructor() {
+    User user = new User();
+
+    assertThat(user.getId()).isNull();
+    assertThat(user.getEmail()).isNull();
+    assertThat(user.getUsername()).isNull();
+    assertThat(user.getPassword()).isNull();
+    assertThat(user.getBio()).isNull();
+    assertThat(user.getImage()).isNull();
+  }
+
+  @Test
+  public void should_update_all_fields_when_all_values_are_present() {
+    User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+    String id = user.getId();
+
+    user.update("new@email.com", "newname", "newpassword", "new bio", "new image");
+
+    assertThat(user.getId()).isEqualTo(id);
+    assertThat(user.getEmail()).isEqualTo("new@email.com");
+    assertThat(user.getUsername()).isEqualTo("newname");
+    assertThat(user.getPassword()).isEqualTo("newpassword");
+    assertThat(user.getBio()).isEqualTo("new bio");
+    assertThat(user.getImage()).isEqualTo("new image");
+  }
+
+  @Test
+  public void should_keep_original_values_when_updating_with_null() {
+    User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+    user.update(null, null, null, null, null);
+
+    assertThat(user.getEmail()).isEqualTo("jake@jake.jake");
+    assertThat(user.getUsername()).isEqualTo("jake");
+    assertThat(user.getPassword()).isEqualTo("123");
+    assertThat(user.getBio()).isEqualTo("bio");
+    assertThat(user.getImage()).isEqualTo("image");
+  }
+
+  @Test
+  public void should_keep_original_values_when_updating_with_empty_string() {
+    User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+    user.update("", "", "", "", "");
+
+    assertThat(user.getEmail()).isEqualTo("jake@jake.jake");
+    assertThat(user.getUsername()).isEqualTo("jake");
+    assertThat(user.getPassword()).isEqualTo("123");
+    assertThat(user.getBio()).isEqualTo("bio");
+    assertThat(user.getImage()).isEqualTo("image");
+  }
+
+  @Test
+  public void should_update_only_the_fields_with_a_value() {
+    User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+    user.update("", "newname", null, "", "new image");
+
+    assertThat(user.getEmail()).isEqualTo("jake@jake.jake");
+    assertThat(user.getUsername()).isEqualTo("newname");
+    assertThat(user.getPassword()).isEqualTo("123");
+    assertThat(user.getBio()).isEqualTo("bio");
+    assertThat(user.getImage()).isEqualTo("new image");
+  }
+
+  @Test
+  public void should_use_only_id_for_equals_and_hashcode() {
+    User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+    User sameIdDifferentContent = new User();
+    ReflectionTestUtils.setField(sameIdDifferentContent, "id", user.getId());
+
+    assertThat(sameIdDifferentContent).isEqualTo(user);
+    assertThat(sameIdDifferentContent.hashCode()).isEqualTo(user.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_ids_are_different() {
+    User one = new User("jake@jake.jake", "jake", "123", "bio", "image");
+    User another = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+    assertThat(one).isNotEqualTo(another);
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_types() {
+    User user = new User("jake@jake.jake", "jake", "123", "bio", "image");
+
+    assertThat(user).isNotEqualTo(null);
+    assertThat(user).isNotEqualTo("jake");
+    assertThat(user).isEqualTo(user);
+  }
+
+  @Test
+  public void should_be_equal_when_both_ids_are_null() {
+    assertThat(new User()).isEqualTo(new User());
+    assertThat(new User().hashCode()).isEqualTo(new User().hashCode());
+  }
+}


### PR DESCRIPTION
## Summary

51 new plain JUnit 5 + AssertJ unit tests (no Spring context, no DB) under `src/test/java/io/spring/core/` for `User`, `FollowRelation`, `Comment`, `ArticleFavorite`, `Tag` and `AuthorizationService`. No production code and no existing tests were touched.

The interesting part is pinning down the *actual* Lombok `@EqualsAndHashCode` semantics rather than the intuitive ones — each entity uses a different field subset, and the tests assert that as-is:

| type | equality basis | asserted behaviour |
| --- | --- | --- |
| `User` | `of = {"id"}` | two users with identical email/username/password are **not** equal; a blank `new User()` whose `id` is forced to match **is** equal |
| `Comment` | `of = "id"` | same — different body/userId/articleId, same id ⇒ equal |
| `Tag` | `of = "name"` | `new Tag("java").equals(new Tag("java"))` is **true** despite different generated `id`s |
| `FollowRelation` | `@Data`, all fields | both ids matter |
| `ArticleFavorite` | `@EqualsAndHashCode`, all fields | both ids matter |

Same-id-but-different-state instances are built with `ReflectionTestUtils.setField(x, "id", ...)` since the entities expose no id setter.

`AuthorizationServiceTest` covers every branch of both methods, including the null edges the code does *not* guard:

```
canWriteArticle(author, article)        -> true
canWriteArticle(otherUser, article)     -> false
canWriteArticle(author, article(userId=null)) -> false   // equals(null) short-circuits
canWriteArticle(new User(), article)    -> NullPointerException  // user.getId() is null

canWriteComment(commentAuthor, ...)     -> true
canWriteComment(articleAuthor, ...)     -> true   // moderating someone else's comment
canWriteComment(unrelatedUser, ...)     -> false
canWriteComment(new User(), ...)        -> NullPointerException
```

The NPE cases document current behaviour (`user.getId().equals(...)` dereferences a null id); they are assertions about the code as it stands, not a request to change it.

## Notes

- `./gradlew test` passes in full (`io.spring.core.*`: 56 tests, 0 failures).
- `spotlessCheck` reports one violation, `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java`, which is **pre-existing on `master`** and outside this stream's scope, so it was deliberately left unfixed. Every file added here is google-java-format clean.
- `gradle.properties` (which is supposed to carry the `--add-exports` flags google-java-format needs on JDK 17) is not present in the repo, so spotless was run with those flags passed on the command line instead of committing a build-config change.


Link to Devin session: https://app.devin.ai/sessions/619708f2cbb74d35a47bdb453b5e7b2b
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/920?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->