### PR TITLE
test: cover application command services, validators and UserQueryService

### DIFF
--- a/src/test/java/io/spring/application/UserQueryServiceTest.java
+++ b/src/test/java/io/spring/application/UserQueryServiceTest.java
@@ -1,0 +1,49 @@
+package io.spring.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.spring.application.data.UserData;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import({UserQueryService.class, MyBatisUserRepository.class})
+public class UserQueryServiceTest extends DbTestBase {
+
+  @Autowired private UserQueryService userQueryService;
+
+  @Autowired private UserRepository userRepository;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+    user = new User("aisensiy@gmail.com", "aisensiy", "123", "bio", "image");
+    userRepository.save(user);
+  }
+
+  @Test
+  public void should_fetch_user_by_id() {
+    Optional<UserData> optional = userQueryService.findById(user.getId());
+
+    assertThat(optional).isPresent();
+    UserData userData = optional.get();
+    assertThat(userData.getId()).isEqualTo(user.getId());
+    assertThat(userData.getEmail()).isEqualTo("aisensiy@gmail.com");
+    assertThat(userData.getUsername()).isEqualTo("aisensiy");
+    assertThat(userData.getBio()).isEqualTo("bio");
+    assertThat(userData.getImage()).isEqualTo("image");
+  }
+
+  @Test
+  public void should_get_empty_optional_for_unknown_id() {
+    assertThat(userQueryService.findById(UUID.randomUUID().toString())).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,0 +1,152 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.article.Tag;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleCommandServiceTest {
+
+  @Mock private ArticleRepository articleRepository;
+
+  @InjectMocks private ArticleCommandService articleCommandService;
+
+  private User creator;
+
+  @BeforeEach
+  public void setUp() {
+    creator = new User("aisensiy@gmail.com", "aisensiy", "123", "", "");
+  }
+
+  @Test
+  public void should_create_article_from_new_article_param() {
+    NewArticleParam newArticleParam =
+        NewArticleParam.builder()
+            .title("a new title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(newArticleParam, creator);
+
+    assertThat(article.getTitle()).isEqualTo("a new title");
+    assertThat(article.getDescription()).isEqualTo("desc");
+    assertThat(article.getBody()).isEqualTo("body");
+    assertThat(article.getUserId()).isEqualTo(creator.getId());
+    assertThat(tagNamesOf(article)).containsExactlyInAnyOrder("java", "spring");
+  }
+
+  @Test
+  public void should_create_article_with_slug_from_title() {
+    NewArticleParam newArticleParam =
+        NewArticleParam.builder()
+            .title("How To Train Your Dragon")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("dragons"))
+            .build();
+
+    Article article = articleCommandService.createArticle(newArticleParam, creator);
+
+    assertThat(article.getSlug()).isEqualTo("how-to-train-your-dragon");
+  }
+
+  @Test
+  public void should_deduplicate_tags_of_new_article() {
+    NewArticleParam newArticleParam =
+        NewArticleParam.builder()
+            .title("a new title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "java", "spring"))
+            .build();
+
+    Article article = articleCommandService.createArticle(newArticleParam, creator);
+
+    assertThat(tagNamesOf(article)).containsExactlyInAnyOrder("java", "spring");
+  }
+
+  @Test
+  public void should_save_created_article_into_repository() {
+    NewArticleParam newArticleParam =
+        NewArticleParam.builder()
+            .title("a new title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java"))
+            .build();
+
+    Article article = articleCommandService.createArticle(newArticleParam, creator);
+
+    ArgumentCaptor<Article> captor = ArgumentCaptor.forClass(Article.class);
+    verify(articleRepository, times(1)).save(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(article);
+  }
+
+  @Test
+  public void should_update_article_and_refresh_slug() {
+    Article article = existingArticle();
+    UpdateArticleParam updateArticleParam =
+        new UpdateArticleParam("new title", "new body", "new desc");
+
+    Article updated = articleCommandService.updateArticle(article, updateArticleParam);
+
+    assertThat(updated).isSameAs(article);
+    assertThat(article.getTitle()).isEqualTo("new title");
+    assertThat(article.getDescription()).isEqualTo("new desc");
+    assertThat(article.getBody()).isEqualTo("new body");
+    assertThat(article.getSlug()).isEqualTo("new-title");
+    verify(articleRepository, times(1)).save(article);
+  }
+
+  @Test
+  public void should_keep_original_values_when_update_param_is_empty() {
+    Article article = existingArticle();
+    String originalSlug = article.getSlug();
+
+    articleCommandService.updateArticle(article, new UpdateArticleParam("", "", ""));
+
+    assertThat(article.getTitle()).isEqualTo("old title");
+    assertThat(article.getDescription()).isEqualTo("old desc");
+    assertThat(article.getBody()).isEqualTo("old body");
+    assertThat(article.getSlug()).isEqualTo(originalSlug);
+    verify(articleRepository, times(1)).save(any(Article.class));
+  }
+
+  @Test
+  public void should_update_only_provided_fields() {
+    Article article = existingArticle();
+
+    articleCommandService.updateArticle(article, new UpdateArticleParam("", "brand new body", ""));
+
+    assertThat(article.getTitle()).isEqualTo("old title");
+    assertThat(article.getDescription()).isEqualTo("old desc");
+    assertThat(article.getBody()).isEqualTo("brand new body");
+    assertThat(article.getSlug()).isEqualTo("old-title");
+  }
+
+  private Article existingArticle() {
+    return new Article("old title", "old desc", "old body", Arrays.asList("java"), creator.getId());
+  }
+
+  private List<String> tagNamesOf(Article article) {
+    return article.getTags().stream().map(Tag::getName).collect(Collectors.toList());
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceTest.java
@@ -1,7 +1,6 @@
 package io.spring.application.article;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -127,7 +126,7 @@ public class ArticleCommandServiceTest {
     assertThat(article.getDescription()).isEqualTo("old desc");
     assertThat(article.getBody()).isEqualTo("old body");
     assertThat(article.getSlug()).isEqualTo(originalSlug);
-    verify(articleRepository, times(1)).save(any(Article.class));
+    verify(articleRepository, times(1)).save(article);
   }
 
   @Test

--- a/src/test/java/io/spring/application/article/ArticleCommandServiceValidationTest.java
+++ b/src/test/java/io/spring/application/article/ArticleCommandServiceValidationTest.java
@@ -1,0 +1,165 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+/**
+ * Drives {@link ArticleCommandService} through a real bean validation setup so the constraint
+ * annotations on {@link NewArticleParam} (including {@link DuplicatedArticleConstraint}) are
+ * actually exercised.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ArticleCommandServiceValidationTest.TestConfiguration.class)
+public class ArticleCommandServiceValidationTest {
+
+  @Autowired private ArticleCommandService articleCommandService;
+
+  @Autowired private ArticleRepository articleRepository;
+
+  @Autowired private ArticleQueryService articleQueryService;
+
+  private User creator;
+
+  @BeforeEach
+  public void setUp() {
+    reset(articleRepository, articleQueryService);
+    creator = new User("aisensiy@gmail.com", "aisensiy", "123", "", "");
+  }
+
+  @Test
+  public void should_create_article_when_param_is_valid() {
+    when(articleQueryService.findBySlug(anyString(), isNull())).thenReturn(Optional.empty());
+
+    Article article = articleCommandService.createArticle(validParam("a new title"), creator);
+
+    assertThat(article.getSlug()).isEqualTo("a-new-title");
+    verify(articleRepository).save(article);
+  }
+
+  @Test
+  public void should_reject_blank_title() {
+    when(articleQueryService.findBySlug(anyString(), isNull())).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(() -> articleCommandService.createArticle(validParam(""), creator))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("can't be empty"));
+
+    verify(articleRepository, never()).save(any(Article.class));
+  }
+
+  @Test
+  public void should_reject_duplicated_title() {
+    when(articleQueryService.findBySlug(anyString(), isNull()))
+        .thenReturn(Optional.of(new ArticleData()));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(() -> articleCommandService.createArticle(validParam("a new title"), creator))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("article name exists"));
+
+    verify(articleRepository, never()).save(any(Article.class));
+  }
+
+  @Test
+  public void should_reject_blank_description_and_body() {
+    when(articleQueryService.findBySlug(anyString(), isNull())).thenReturn(Optional.empty());
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("a new title")
+            .description("")
+            .body("")
+            .tagList(Arrays.asList("java"))
+            .build();
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(() -> articleCommandService.createArticle(param, creator))
+        .satisfies(e -> assertThat(e.getConstraintViolations()).hasSize(2));
+  }
+
+  @Test
+  public void should_update_article_without_validation_error() {
+    Article article =
+        new Article("old title", "old desc", "old body", Arrays.asList("java"), creator.getId());
+
+    articleCommandService.updateArticle(article, new UpdateArticleParam("new title", "", ""));
+
+    assertThat(article.getSlug()).isEqualTo("new-title");
+    verify(articleRepository).save(article);
+  }
+
+  private NewArticleParam validParam(String title) {
+    return NewArticleParam.builder()
+        .title(title)
+        .description("desc")
+        .body("body")
+        .tagList(Arrays.asList("java"))
+        .build();
+  }
+
+  private Set<String> messagesOf(ConstraintViolationException exception) {
+    return exception.getConstraintViolations().stream()
+        .map(ConstraintViolation::getMessage)
+        .collect(Collectors.toSet());
+  }
+
+  @Configuration
+  static class TestConfiguration {
+
+    @Bean
+    public ArticleRepository articleRepository() {
+      return mock(ArticleRepository.class);
+    }
+
+    @Bean
+    public ArticleQueryService articleQueryService() {
+      return mock(ArticleQueryService.class);
+    }
+
+    @Bean
+    public ArticleCommandService articleCommandService(ArticleRepository articleRepository) {
+      return new ArticleCommandService(articleRepository);
+    }
+
+    @Bean
+    public static LocalValidatorFactoryBean validator() {
+      return new LocalValidatorFactoryBean();
+    }
+
+    @Bean
+    public static MethodValidationPostProcessor methodValidationPostProcessor(
+        LocalValidatorFactoryBean validator) {
+      MethodValidationPostProcessor processor = new MethodValidationPostProcessor();
+      processor.setValidator(validator);
+      return processor;
+    }
+  }
+}

--- a/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
+++ b/src/test/java/io/spring/application/article/DuplicatedArticleValidatorTest.java
@@ -1,0 +1,49 @@
+package io.spring.application.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedArticleValidatorTest {
+
+  @Mock private ArticleQueryService articleQueryService;
+
+  @Mock private ConstraintValidatorContext context;
+
+  @InjectMocks private DuplicatedArticleValidator validator;
+
+  @Test
+  public void should_be_valid_when_no_article_with_the_same_slug_exists() {
+    when(articleQueryService.findBySlug(eq("a-new-title"), isNull())).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("a new title", context)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_article_with_the_same_slug_exists() {
+    when(articleQueryService.findBySlug(eq("a-new-title"), isNull()))
+        .thenReturn(Optional.of(new ArticleData()));
+
+    assertThat(validator.isValid("a new title", context)).isFalse();
+  }
+
+  @Test
+  public void should_lookup_by_slugified_title() {
+    when(articleQueryService.findBySlug(eq("how-to-train-your-dragon"), isNull()))
+        .thenReturn(Optional.of(new ArticleData()));
+
+    assertThat(validator.isValid("How To Train Your Dragon", context)).isFalse();
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedEmailValidatorTest.java
@@ -1,0 +1,48 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedEmailValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private ConstraintValidatorContext context;
+
+  @InjectMocks private DuplicatedEmailValidator validator;
+
+  @Test
+  public void should_be_valid_when_email_is_free() {
+    when(userRepository.findByEmail("aisensiy@gmail.com")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("aisensiy@gmail.com", context)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_email_is_taken() {
+    when(userRepository.findByEmail("aisensiy@gmail.com"))
+        .thenReturn(Optional.of(new User("aisensiy@gmail.com", "aisensiy", "123", "", "")));
+
+    assertThat(validator.isValid("aisensiy@gmail.com", context)).isFalse();
+  }
+
+  @Test
+  public void should_be_valid_and_skip_lookup_when_email_is_null_or_empty() {
+    assertThat(validator.isValid(null, context)).isTrue();
+    assertThat(validator.isValid("", context)).isTrue();
+
+    verifyNoInteractions(userRepository);
+  }
+}

--- a/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
+++ b/src/test/java/io/spring/application/user/DuplicatedUsernameValidatorTest.java
@@ -1,0 +1,48 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import javax.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DuplicatedUsernameValidatorTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private ConstraintValidatorContext context;
+
+  @InjectMocks private DuplicatedUsernameValidator validator;
+
+  @Test
+  public void should_be_valid_when_username_is_free() {
+    when(userRepository.findByUsername("aisensiy")).thenReturn(Optional.empty());
+
+    assertThat(validator.isValid("aisensiy", context)).isTrue();
+  }
+
+  @Test
+  public void should_be_invalid_when_username_is_taken() {
+    when(userRepository.findByUsername("aisensiy"))
+        .thenReturn(Optional.of(new User("aisensiy@gmail.com", "aisensiy", "123", "", "")));
+
+    assertThat(validator.isValid("aisensiy", context)).isFalse();
+  }
+
+  @Test
+  public void should_be_valid_and_skip_lookup_when_username_is_null_or_empty() {
+    assertThat(validator.isValid(null, context)).isTrue();
+    assertThat(validator.isValid("", context)).isTrue();
+
+    verifyNoInteractions(userRepository);
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceTest.java
@@ -1,0 +1,95 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+  private static final String DEFAULT_IMAGE = "https://static.productionready.io/images/smiley.jpg";
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private UserService userService;
+
+  @BeforeEach
+  public void setUp() {
+    userService = new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder);
+  }
+
+  @Test
+  public void should_create_user_with_encoded_password_and_default_image() {
+    when(passwordEncoder.encode("123")).thenReturn("encoded-123");
+
+    User user = userService.createUser(new RegisterParam("aisensiy@gmail.com", "aisensiy", "123"));
+
+    assertThat(user.getEmail()).isEqualTo("aisensiy@gmail.com");
+    assertThat(user.getUsername()).isEqualTo("aisensiy");
+    assertThat(user.getPassword()).isEqualTo("encoded-123");
+    assertThat(user.getBio()).isEmpty();
+    assertThat(user.getImage()).isEqualTo(DEFAULT_IMAGE);
+    assertThat(user.getId()).isNotEmpty();
+  }
+
+  @Test
+  public void should_save_created_user_into_repository() {
+    when(passwordEncoder.encode("123")).thenReturn("encoded-123");
+
+    User user = userService.createUser(new RegisterParam("aisensiy@gmail.com", "aisensiy", "123"));
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository, times(1)).save(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(user);
+  }
+
+  @Test
+  public void should_update_all_provided_fields_of_target_user() {
+    User targetUser = new User("old@email.com", "oldname", "123", "old bio", "old image");
+    UpdateUserParam param =
+        UpdateUserParam.builder()
+            .email("new@email.com")
+            .username("newname")
+            .password("newpassword")
+            .bio("new bio")
+            .image("new image")
+            .build();
+
+    userService.updateUser(new UpdateUserCommand(targetUser, param));
+
+    assertThat(targetUser.getEmail()).isEqualTo("new@email.com");
+    assertThat(targetUser.getUsername()).isEqualTo("newname");
+    assertThat(targetUser.getPassword()).isEqualTo("newpassword");
+    assertThat(targetUser.getBio()).isEqualTo("new bio");
+    assertThat(targetUser.getImage()).isEqualTo("new image");
+    verify(userRepository, times(1)).save(targetUser);
+  }
+
+  @Test
+  public void should_keep_original_values_for_empty_update_fields() {
+    User targetUser = new User("old@email.com", "oldname", "123", "old bio", "old image");
+
+    userService.updateUser(
+        new UpdateUserCommand(targetUser, UpdateUserParam.builder().bio("new bio").build()));
+
+    assertThat(targetUser.getEmail()).isEqualTo("old@email.com");
+    assertThat(targetUser.getUsername()).isEqualTo("oldname");
+    assertThat(targetUser.getPassword()).isEqualTo("123");
+    assertThat(targetUser.getBio()).isEqualTo("new bio");
+    assertThat(targetUser.getImage()).isEqualTo("old image");
+    verify(userRepository, times(1)).save(targetUser);
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceValidationTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceValidationTest.java
@@ -1,0 +1,230 @@
+package io.spring.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+/**
+ * Drives {@link UserService} through a real bean validation setup so the constraint annotations on
+ * {@link RegisterParam} and {@link UpdateUserCommand} are actually exercised.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = UserServiceValidationTest.TestConfiguration.class)
+public class UserServiceValidationTest {
+
+  private static final String DEFAULT_IMAGE = "https://static.productionready.io/images/smiley.jpg";
+
+  @Autowired private UserService userService;
+
+  @Autowired private UserRepository userRepository;
+
+  @BeforeEach
+  public void setUp() {
+    reset(userRepository);
+  }
+
+  @Test
+  public void should_create_user_when_register_param_is_valid() {
+    when(userRepository.findByEmail("aisensiy@gmail.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("aisensiy")).thenReturn(Optional.empty());
+
+    User user = userService.createUser(new RegisterParam("aisensiy@gmail.com", "aisensiy", "123"));
+
+    assertThat(user.getImage()).isEqualTo(DEFAULT_IMAGE);
+    verify(userRepository).save(user);
+  }
+
+  @Test
+  public void should_reject_register_param_with_invalid_email() {
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () -> userService.createUser(new RegisterParam("not-an-email", "aisensiy", "123")))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("should be an email"));
+
+    verify(userRepository, never()).save(any(User.class));
+  }
+
+  @Test
+  public void should_reject_register_param_with_duplicated_email() {
+    when(userRepository.findByEmail("aisensiy@gmail.com"))
+        .thenReturn(Optional.of(new User("aisensiy@gmail.com", "someone", "123", "", "")));
+    when(userRepository.findByUsername("aisensiy")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () ->
+                userService.createUser(new RegisterParam("aisensiy@gmail.com", "aisensiy", "123")))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("duplicated email"));
+
+    verify(userRepository, never()).save(any(User.class));
+  }
+
+  @Test
+  public void should_reject_register_param_with_duplicated_username() {
+    when(userRepository.findByEmail("aisensiy@gmail.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("aisensiy"))
+        .thenReturn(Optional.of(new User("someone@gmail.com", "aisensiy", "123", "", "")));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () ->
+                userService.createUser(new RegisterParam("aisensiy@gmail.com", "aisensiy", "123")))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("duplicated username"));
+
+    verify(userRepository, never()).save(any(User.class));
+  }
+
+  @Test
+  public void should_reject_register_param_with_empty_password() {
+    when(userRepository.findByEmail("aisensiy@gmail.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("aisensiy")).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () -> userService.createUser(new RegisterParam("aisensiy@gmail.com", "aisensiy", "")))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("can't be empty"));
+  }
+
+  @Test
+  public void should_update_user_when_new_email_and_username_are_free() {
+    User targetUser = new User("old@email.com", "oldname", "123", "", "");
+    when(userRepository.findByEmail("new@email.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("newname")).thenReturn(Optional.empty());
+
+    userService.updateUser(
+        new UpdateUserCommand(
+            targetUser,
+            UpdateUserParam.builder().email("new@email.com").username("newname").build()));
+
+    assertThat(targetUser.getEmail()).isEqualTo("new@email.com");
+    assertThat(targetUser.getUsername()).isEqualTo("newname");
+    verify(userRepository).save(targetUser);
+  }
+
+  @Test
+  public void should_allow_update_with_the_users_own_email_and_username() {
+    User targetUser = new User("old@email.com", "oldname", "123", "", "");
+    when(userRepository.findByEmail("old@email.com")).thenReturn(Optional.of(targetUser));
+    when(userRepository.findByUsername("oldname")).thenReturn(Optional.of(targetUser));
+
+    userService.updateUser(
+        new UpdateUserCommand(
+            targetUser,
+            UpdateUserParam.builder()
+                .email("old@email.com")
+                .username("oldname")
+                .bio("new bio")
+                .build()));
+
+    assertThat(targetUser.getBio()).isEqualTo("new bio");
+    verify(userRepository).save(targetUser);
+  }
+
+  @Test
+  public void should_reject_update_when_email_belongs_to_another_user() {
+    User targetUser = new User("old@email.com", "oldname", "123", "", "");
+    when(userRepository.findByEmail("taken@email.com"))
+        .thenReturn(Optional.of(new User("taken@email.com", "someone", "123", "", "")));
+    when(userRepository.findByUsername("oldname")).thenReturn(Optional.of(targetUser));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () ->
+                userService.updateUser(
+                    new UpdateUserCommand(
+                        targetUser,
+                        UpdateUserParam.builder()
+                            .email("taken@email.com")
+                            .username("oldname")
+                            .build())))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("email already exist"));
+
+    verify(userRepository, never()).save(any(User.class));
+  }
+
+  @Test
+  public void should_reject_update_when_username_belongs_to_another_user() {
+    User targetUser = new User("old@email.com", "oldname", "123", "", "");
+    when(userRepository.findByEmail("old@email.com")).thenReturn(Optional.of(targetUser));
+    when(userRepository.findByUsername("taken"))
+        .thenReturn(Optional.of(new User("someone@email.com", "taken", "123", "", "")));
+
+    assertThatExceptionOfType(ConstraintViolationException.class)
+        .isThrownBy(
+            () ->
+                userService.updateUser(
+                    new UpdateUserCommand(
+                        targetUser,
+                        UpdateUserParam.builder()
+                            .email("old@email.com")
+                            .username("taken")
+                            .build())))
+        .satisfies(e -> assertThat(messagesOf(e)).contains("username already exist"));
+
+    verify(userRepository, never()).save(any(User.class));
+  }
+
+  private Set<String> messagesOf(ConstraintViolationException exception) {
+    return exception.getConstraintViolations().stream()
+        .map(ConstraintViolation::getMessage)
+        .collect(Collectors.toSet());
+  }
+
+  @Configuration
+  static class TestConfiguration {
+
+    @Bean
+    public UserRepository userRepository() {
+      return mock(UserRepository.class);
+    }
+
+    @Bean
+    @SuppressWarnings("deprecation")
+    public PasswordEncoder passwordEncoder() {
+      return NoOpPasswordEncoder.getInstance();
+    }
+
+    @Bean
+    public UserService userService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+      return new UserService(userRepository, DEFAULT_IMAGE, passwordEncoder);
+    }
+
+    @Bean
+    public static LocalValidatorFactoryBean validator() {
+      return new LocalValidatorFactoryBean();
+    }
+
+    @Bean
+    public static MethodValidationPostProcessor methodValidationPostProcessor(
+        LocalValidatorFactoryBean validator) {
+      MethodValidationPostProcessor processor = new MethodValidationPostProcessor();
+      processor.setValidator(validator);
+      return processor;
+    }
+  }
+}

--- a/src/test/java/io/spring/application/user/UserServiceValidationTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceValidationTest.java
@@ -61,6 +61,9 @@ public class UserServiceValidationTest {
 
   @Test
   public void should_reject_register_param_with_invalid_email() {
+    when(userRepository.findByEmail("not-an-email")).thenReturn(Optional.empty());
+    when(userRepository.findByUsername("aisensiy")).thenReturn(Optional.empty());
+
     assertThatExceptionOfType(ConstraintViolationException.class)
         .isThrownBy(
             () -> userService.createUser(new RegisterParam("not-an-email", "aisensiy", "123")))

--- a/src/test/java/io/spring/application/user/UserServiceValidationTest.java
+++ b/src/test/java/io/spring/application/user/UserServiceValidationTest.java
@@ -111,6 +111,8 @@ public class UserServiceValidationTest {
         .isThrownBy(
             () -> userService.createUser(new RegisterParam("aisensiy@gmail.com", "aisensiy", "")))
         .satisfies(e -> assertThat(messagesOf(e)).contains("can't be empty"));
+
+    verify(userRepository, never()).save(any(User.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds tests for the previously untested application-layer write path (`ArticleCommandService`, `UserService`), the three `ConstraintValidator`s, and `UserQueryService`. Test-only change; no production code touched.

Two flavours of test per command service:

- **Mockito unit tests** (`ArticleCommandServiceTest`, `UserServiceTest`) — behaviour only: slug derivation, tag de-duplication, partial updates (`Util.isEmpty` semantics), password encoding + default image, and `repository.save(...)` capture.
- **Spring bean-validation tests** (`ArticleCommandServiceValidationTest`, `UserServiceValidationTest`) — the services are `@Validated` with `@Valid` params, so the constraint annotations only fire when method validation is in play. Each test builds a minimal context:

  ```java
  @Bean static LocalValidatorFactoryBean validator();            // SpringConstraintValidatorFactory -> autowires validators
  @Bean static MethodValidationPostProcessor mvpp(validator);    // proxies @Validated services
  @Bean ArticleRepository/UserRepository -> Mockito.mock(...)    // reset(...) in @BeforeEach
  ```

  This exercises `@DuplicatedArticleConstraint`, `@DuplicatedEmailConstraint`, `@DuplicatedUsernameConstraint` and the class-level `@UpdateUserConstraint` (`UpdateUserValidator`, including its `email already exist` / `username already exist` property-node violations) end-to-end and asserts the repository is never written on violation.

`DuplicatedArticleValidator` / `DuplicatedUsernameValidator` are package-private, so their tests live in the same packages and inject the mock into the `@Autowired` field via `@InjectMocks`. `UserQueryServiceTest` follows the existing query-service pattern (`DbTestBase` + MyBatis mappers) and covers both the found and `Optional.empty()` cases.

## Notes

- `./gradlew test` passes (104 tests, 0 failures).
- `./gradlew spotlessCheck` reports one violation, and it is pre-existing on `master` in `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java` (a long line spotless wants to wrap). That file is outside this stream's scope, so `spotlessApply`'s change to it was reverted here; every file added by this PR is spotless-clean.
- The repo has no `gradle.properties`, so on JDK 17 `spotlessApply`/`spotlessCheck` fail with `IllegalAccessError ... jdk.compiler does not export com.sun.tools.javac.parser`. I set the `--add-exports` flags in a machine-local `~/.gradle/gradle.properties` to run spotless; a committed `gradle.properties` would fix this for everyone but is outside this stream's scope.


Link to Devin session: https://app.devin.ai/sessions/801b951af6c64df190a28102fa9204ca
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/921?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->