### PR TITLE
test: cover DGS GraphQL datafetchers, mutations and exception handling

### DIFF
--- a/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ArticleDatafetcherTest.java
@@ -1,0 +1,404 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.Article;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, ArticleDatafetcher.class, ProfileDatafetcher.class})
+public class ArticleDatafetcherTest extends GraphQLTestBase {
+
+  private static final DateTime TIME = new DateTime(2022, 2, 2, 10, 0, DateTimeZone.UTC);
+  private static final String TIME_ISO = "2022-02-02T10:00:00.000Z";
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @Autowired private ArticleDatafetcher articleDatafetcher;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private ProfileQueryService profileQueryService;
+
+  @Test
+  void should_return_user_feed_paginated_forward() {
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(articleData("one")), Direction.NEXT, true));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ feed(first: 10, after: \"1000\") { edges { cursor node { slug title body description"
+                + " favorited favoritesCount tagList createdAt updatedAt } } pageInfo { hasNextPage"
+                + " hasPreviousPage startCursor endCursor } } }");
+
+    assertThat(context.read("$.data.feed.edges[0].node.slug", String.class)).isEqualTo("title-one");
+    assertThat(context.read("$.data.feed.edges[0].node.title", String.class))
+        .isEqualTo("title one");
+    assertThat(context.read("$.data.feed.edges[0].node.favorited", Boolean.class)).isTrue();
+    assertThat(context.read("$.data.feed.edges[0].node.favoritesCount", Integer.class))
+        .isEqualTo(3);
+    assertThat(context.read("$.data.feed.edges[0].node.createdAt", String.class))
+        .isEqualTo(TIME_ISO);
+    assertThat(context.read("$.data.feed.edges[0].node.updatedAt", String.class))
+        .isEqualTo(TIME_ISO);
+    assertThat(context.read("$.data.feed.edges[0].cursor", String.class))
+        .isEqualTo(String.valueOf(TIME.getMillis()));
+    assertThat(context.read("$.data.feed.pageInfo.hasNextPage", Boolean.class)).isTrue();
+    assertThat(context.read("$.data.feed.pageInfo.hasPreviousPage", Boolean.class)).isFalse();
+    assertThat(context.read("$.data.feed.pageInfo.startCursor", String.class))
+        .isEqualTo(String.valueOf(TIME.getMillis()));
+    assertThat(context.read("$.data.feed.pageInfo.endCursor", String.class))
+        .isEqualTo(String.valueOf(TIME.getMillis()));
+
+    CursorPageParameter<DateTime> pageParameter = captureFeedPageParameter();
+    assertThat(pageParameter.getLimit()).isEqualTo(10);
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.NEXT);
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(1000L);
+  }
+
+  @Test
+  void should_return_user_feed_paginated_backward() {
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.PREV, true));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ feed(last: 3, before: \"2000\") { edges { cursor } pageInfo { hasNextPage"
+                + " hasPreviousPage startCursor endCursor } } }");
+
+    assertThat(context.read("$.data.feed.edges", List.class)).isEmpty();
+    assertThat(context.read("$.data.feed.pageInfo.hasPreviousPage", Boolean.class)).isTrue();
+    assertThat(context.read("$.data.feed.pageInfo.hasNextPage", Boolean.class)).isFalse();
+    assertThat(context.read("$.data.feed.pageInfo.startCursor", String.class)).isNull();
+    assertThat(context.read("$.data.feed.pageInfo.endCursor", String.class)).isNull();
+
+    CursorPageParameter<DateTime> pageParameter = captureFeedPageParameter();
+    assertThat(pageParameter.getLimit()).isEqualTo(3);
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(2000L);
+  }
+
+  @Test
+  void should_query_feed_for_anonymous_user() {
+    logout();
+    when(articleQueryService.findUserFeedWithCursor(isNull(), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    ExecutionResult result = dgsQueryExecutor.execute("{ feed(first: 1) { edges { cursor } } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    verify(articleQueryService).findUserFeedWithCursor(isNull(), any());
+  }
+
+  @Test
+  void should_fail_feed_without_first_or_last() {
+    ExecutionResult result = dgsQueryExecutor.execute("{ feed { edges { cursor } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("first 和 last 必须只存在一个");
+  }
+
+  @Test
+  void should_return_articles_filtered_by_tag_author_and_favorited_by() {
+    when(articleQueryService.findRecentArticlesWithCursor(
+            eq("joda"), eq("johnjacob"), eq("jane"), any(), eq(user)))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(articleData("two")), Direction.NEXT, false));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ articles(first: 5, after: \"1000\", authoredBy: \"johnjacob\", favoritedBy:"
+                + " \"jane\", withTag: \"joda\") { edges { node { slug title } } pageInfo {"
+                + " hasNextPage } } }");
+
+    assertThat(context.read("$.data.articles.edges[0].node.title", String.class))
+        .isEqualTo("title two");
+    assertThat(context.read("$.data.articles.pageInfo.hasNextPage", Boolean.class)).isFalse();
+
+    CursorPageParameter<DateTime> pageParameter = captureRecentArticlesPageParameter();
+    assertThat(pageParameter.getLimit()).isEqualTo(5);
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.NEXT);
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(1000L);
+  }
+
+  @Test
+  void should_return_articles_paginated_backward() {
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), isNull(), any(), eq(user)))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(articleData("three")), Direction.PREV, true));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ articles(last: 2, before: \"3000\") { edges { node { slug } } pageInfo {"
+                + " hasPreviousPage } } }");
+
+    assertThat(context.read("$.data.articles.pageInfo.hasPreviousPage", Boolean.class)).isTrue();
+    assertThat(context.read("$.data.articles.edges[0].node.slug", String.class))
+        .isEqualTo("title-three");
+
+    CursorPageParameter<DateTime> pageParameter = captureRecentArticlesPageParameter();
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageParameter.getLimit()).isEqualTo(2);
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(3000L);
+  }
+
+  @Test
+  void should_fail_articles_without_first_or_last() {
+    ExecutionResult result = dgsQueryExecutor.execute("{ articles { edges { cursor } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("first 和 last 必须只存在一个");
+  }
+
+  @Test
+  void should_find_article_by_slug() {
+    when(articleQueryService.findBySlug(eq("title-one"), eq(user)))
+        .thenReturn(Optional.of(articleData("one")));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ article(slug: \"title-one\") { slug title description body favoritesCount tagList }"
+                + " }");
+
+    assertThat(context.read("$.data.article.body", String.class)).isEqualTo("body one");
+    assertThat(context.read("$.data.article.description", String.class)).isEqualTo("desc one");
+    assertThat(context.read("$.data.article.favoritesCount", Integer.class)).isEqualTo(3);
+    assertThat(context.read("$.data.article.tagList", List.class)).containsExactly("joda");
+  }
+
+  @Test
+  void should_fail_to_find_unknown_article_by_slug() {
+    when(articleQueryService.findBySlug(eq("unknown"), eq(user))).thenReturn(Optional.empty());
+
+    ExecutionResult result = dgsQueryExecutor.execute("{ article(slug: \"unknown\") { slug } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_return_profile_feed() {
+    when(profileQueryService.findByUsername(eq("johnjacob"), eq(user)))
+        .thenReturn(Optional.of(profileData));
+    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(articleData("feed")), Direction.NEXT, false));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ profile(username: \"johnjacob\") { profile { username feed(first: 2, after:"
+                + " \"5000\") { edges { node { slug } } } } } }");
+
+    assertThat(context.read("$.data.profile.profile.feed.edges[0].node.slug", String.class))
+        .isEqualTo("title-feed");
+
+    CursorPageParameter<DateTime> pageParameter = captureFeedPageParameter();
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(5000L);
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.NEXT);
+  }
+
+  @Test
+  void should_return_profile_feed_paginated_backward() {
+    when(profileQueryService.findByUsername(eq("johnjacob"), eq(user)))
+        .thenReturn(Optional.of(profileData));
+    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
+    when(articleQueryService.findUserFeedWithCursor(eq(user), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.PREV, false));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ profile(username: \"johnjacob\") { profile { feed(last: 4, before: \"6000\") {"
+                + " edges { cursor } } } } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    CursorPageParameter<DateTime> pageParameter = captureFeedPageParameter();
+    assertThat(pageParameter.getLimit()).isEqualTo(4);
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(6000L);
+  }
+
+  @Test
+  void should_fail_profile_feed_for_unknown_user() {
+    when(profileQueryService.findByUsername(eq("ghost"), eq(user)))
+        .thenReturn(
+            Optional.of(new ProfileData("other-id", "ghost", "bio", DEFAULT_AVATAR, false)));
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ profile(username: \"ghost\") { profile { feed(first: 2) { edges { cursor } } } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_fail_profile_feed_without_first_or_last() {
+    when(profileQueryService.findByUsername(eq("johnjacob"), eq(user)))
+        .thenReturn(Optional.of(profileData));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ profile(username: \"johnjacob\") { profile { feed { edges { cursor } } } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("first 和 last 必须只存在一个");
+  }
+
+  @Test
+  void should_return_profile_articles_and_favorites() {
+    when(profileQueryService.findByUsername(eq("johnjacob"), eq(user)))
+        .thenReturn(Optional.of(profileData));
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), eq("johnjacob"), isNull(), any(), eq(user)))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(articleData("authored")), Direction.NEXT, false));
+    when(articleQueryService.findRecentArticlesWithCursor(
+            isNull(), isNull(), eq("johnjacob"), any(), eq(user)))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(articleData("favorited")), Direction.PREV, false));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ profile(username: \"johnjacob\") { profile { articles(first: 2) { edges { node {"
+                + " slug } } } favorites(last: 2, before: \"4000\") { edges { node { slug } } } } }"
+                + " }");
+
+    assertThat(context.read("$.data.profile.profile.articles.edges[0].node.slug", String.class))
+        .isEqualTo("title-authored");
+    assertThat(context.read("$.data.profile.profile.favorites.edges[0].node.slug", String.class))
+        .isEqualTo("title-favorited");
+  }
+
+  @Test
+  void should_fail_profile_articles_without_first_or_last() {
+    when(profileQueryService.findByUsername(eq("johnjacob"), eq(user)))
+        .thenReturn(Optional.of(profileData));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ profile(username: \"johnjacob\") { profile { articles { edges { cursor } } } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("first 和 last 必须只存在一个");
+  }
+
+  @Test
+  void should_fail_profile_favorites_without_first_or_last() {
+    when(profileQueryService.findByUsername(eq("johnjacob"), eq(user)))
+        .thenReturn(Optional.of(profileData));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ profile(username: \"johnjacob\") { profile { favorites { edges { cursor } } } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("first 和 last 必须只存在一个");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void should_build_article_from_comment_local_context() {
+    ArticleData articleData = articleData("commented");
+    CommentData commentData =
+        new CommentData("comment-id", "comment body", articleData.getId(), TIME, TIME, profileData);
+    when(articleQueryService.findById(eq(articleData.getId()), eq(user)))
+        .thenReturn(Optional.of(articleData));
+    DataFetchingEnvironment dfe = mock(DataFetchingEnvironment.class);
+    when(dfe.<CommentData>getLocalContext()).thenReturn(commentData);
+
+    DataFetcherResult<Article> result = articleDatafetcher.getCommentArticle(dfe);
+
+    assertThat(result.getData().getSlug()).isEqualTo("title-commented");
+    assertThat(result.getData().getBody()).isEqualTo("body commented");
+    Map<String, Object> localContext = (Map<String, Object>) result.<Object>getLocalContext();
+    assertThat(localContext).containsKey(articleData.getSlug());
+  }
+
+  @Test
+  void should_fail_to_build_article_from_comment_of_missing_article() {
+    CommentData commentData =
+        new CommentData("comment-id", "comment body", "missing-id", TIME, TIME, profileData);
+    when(articleQueryService.findById(eq("missing-id"), eq(user))).thenReturn(Optional.empty());
+    DataFetchingEnvironment dfe = mock(DataFetchingEnvironment.class);
+    when(dfe.<CommentData>getLocalContext()).thenReturn(commentData);
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> articleDatafetcher.getCommentArticle(dfe))
+        .isInstanceOf(io.spring.api.exception.ResourceNotFoundException.class);
+  }
+
+  private CursorPageParameter<DateTime> captureFeedPageParameter() {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(articleQueryService).findUserFeedWithCursor(any(), captor.capture());
+    return captor.getValue();
+  }
+
+  private CursorPageParameter<DateTime> captureRecentArticlesPageParameter() {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(articleQueryService)
+        .findRecentArticlesWithCursor(any(), any(), any(), captor.capture(), any());
+    return captor.getValue();
+  }
+
+  private ArticleData articleData(String seed) {
+    return new ArticleData(
+        seed + "-id",
+        "title-" + seed,
+        "title " + seed,
+        "desc " + seed,
+        "body " + seed,
+        true,
+        3,
+        TIME,
+        TIME,
+        Arrays.asList("joda"),
+        profileData);
+  }
+}

--- a/src/test/java/io/spring/graphql/ArticleMutationTest.java
+++ b/src/test/java/io/spring/graphql/ArticleMutationTest.java
@@ -1,0 +1,307 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.article.ArticleCommandService;
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.article.UpdateArticleParam;
+import io.spring.application.data.ArticleData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.favorite.ArticleFavorite;
+import io.spring.core.favorite.ArticleFavoriteRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, ArticleMutation.class, ArticleDatafetcher.class})
+public class ArticleMutationTest extends GraphQLTestBase {
+
+  private static final DateTime TIME = new DateTime(2022, 2, 2, 10, 0, DateTimeZone.UTC);
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ArticleCommandService articleCommandService;
+
+  @MockBean private ArticleFavoriteRepository articleFavoriteRepository;
+
+  @MockBean private ArticleRepository articleRepository;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private io.spring.core.user.UserRepository userRepository;
+
+  @Test
+  void should_create_article() {
+    Article article = article(user);
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(user)))
+        .thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), eq(user)))
+        .thenReturn(Optional.of(articleData(article)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { createArticle(input: {title: \"a title\", description: \"a description\","
+                + " body: \"a body\", tagList: [\"joda\"]}) { article { slug title body tagList } }"
+                + " }");
+
+    assertThat(context.read("$.data.createArticle.article.slug", String.class))
+        .isEqualTo(article.getSlug());
+    assertThat(context.read("$.data.createArticle.article.title", String.class))
+        .isEqualTo("a title");
+
+    ArgumentCaptor<NewArticleParam> captor = ArgumentCaptor.forClass(NewArticleParam.class);
+    verify(articleCommandService).createArticle(captor.capture(), eq(user));
+    assertThat(captor.getValue().getTitle()).isEqualTo("a title");
+    assertThat(captor.getValue().getDescription()).isEqualTo("a description");
+    assertThat(captor.getValue().getBody()).isEqualTo("a body");
+    assertThat(captor.getValue().getTagList()).containsExactly("joda");
+  }
+
+  @Test
+  void should_default_tag_list_to_empty_when_absent() {
+    Article article = article(user);
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(user)))
+        .thenReturn(article);
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { createArticle(input: {title: \"a title\", description: \"a description\","
+                + " body: \"a body\"}) { __typename } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    ArgumentCaptor<NewArticleParam> captor = ArgumentCaptor.forClass(NewArticleParam.class);
+    verify(articleCommandService).createArticle(captor.capture(), eq(user));
+    assertThat(captor.getValue().getTagList()).isEmpty();
+  }
+
+  @Test
+  void should_not_create_article_for_anonymous_user() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { createArticle(input: {title: \"a title\", description: \"a description\","
+                + " body: \"a body\"}) { __typename } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(articleCommandService, never()).createArticle(any(), any());
+  }
+
+  @Test
+  void should_update_own_article() {
+    Article article = article(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleCommandService.updateArticle(eq(article), any(UpdateArticleParam.class)))
+        .thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), eq(user)))
+        .thenReturn(Optional.of(articleData(article)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { updateArticle(slug: \""
+                + article.getSlug()
+                + "\", changes: {title: \"new title\", body: \"new body\", description: \"new"
+                + " description\"}) { article { slug } } }");
+
+    assertThat(context.read("$.data.updateArticle.article.slug", String.class))
+        .isEqualTo(article.getSlug());
+
+    ArgumentCaptor<UpdateArticleParam> captor = ArgumentCaptor.forClass(UpdateArticleParam.class);
+    verify(articleCommandService).updateArticle(eq(article), captor.capture());
+    assertThat(captor.getValue().getTitle()).isEqualTo("new title");
+    assertThat(captor.getValue().getBody()).isEqualTo("new body");
+    assertThat(captor.getValue().getDescription()).isEqualTo("new description");
+  }
+
+  @Test
+  void should_not_update_article_of_another_user() {
+    Article article = article(new User("other@jacob.com", "other", "123", "", DEFAULT_AVATAR));
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { updateArticle(slug: \""
+                + article.getSlug()
+                + "\", changes: {title: \"new title\"}) { __typename } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("NoAuthorizationException");
+    verify(articleCommandService, never()).updateArticle(any(), any());
+  }
+
+  @Test
+  void should_not_update_unknown_article() {
+    when(articleRepository.findBySlug(eq("unknown"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { updateArticle(slug: \"unknown\", changes: {title: \"new title\"}) {"
+                + " __typename } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_favorite_article() {
+    Article article = article(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleQueryService.findById(eq(article.getId()), eq(user)))
+        .thenReturn(Optional.of(articleData(article)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { favoriteArticle(slug: \""
+                + article.getSlug()
+                + "\") { article { slug favorited } } }");
+
+    assertThat(context.read("$.data.favoriteArticle.article.slug", String.class))
+        .isEqualTo(article.getSlug());
+
+    ArgumentCaptor<ArticleFavorite> captor = ArgumentCaptor.forClass(ArticleFavorite.class);
+    verify(articleFavoriteRepository).save(captor.capture());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+  }
+
+  @Test
+  void should_not_favorite_unknown_article() {
+    when(articleRepository.findBySlug(eq("unknown"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute("mutation { favoriteArticle(slug: \"unknown\") { __typename } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(articleFavoriteRepository, never()).save(any());
+  }
+
+  @Test
+  void should_unfavorite_article() {
+    Article article = article(user);
+    ArticleFavorite favorite = new ArticleFavorite(article.getId(), user.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.of(favorite));
+    when(articleQueryService.findById(eq(article.getId()), eq(user)))
+        .thenReturn(Optional.of(articleData(article)));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfavoriteArticle(slug: \""
+                + article.getSlug()
+                + "\") { article { slug } } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    verify(articleFavoriteRepository).remove(eq(favorite));
+  }
+
+  @Test
+  void should_ignore_unfavorite_when_favorite_is_absent() {
+    Article article = article(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(articleFavoriteRepository.find(eq(article.getId()), eq(user.getId())))
+        .thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfavoriteArticle(slug: \"" + article.getSlug() + "\") { __typename } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    verify(articleFavoriteRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_delete_own_article() {
+    Article article = article(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }");
+
+    assertThat(context.read("$.data.deleteArticle.success", Boolean.class)).isTrue();
+    verify(articleRepository).remove(eq(article));
+  }
+
+  @Test
+  void should_not_delete_article_of_another_user() {
+    Article article = article(new User("other@jacob.com", "other", "123", "", DEFAULT_AVATAR));
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteArticle(slug: \"" + article.getSlug() + "\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("NoAuthorizationException");
+    verify(articleRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_not_delete_article_for_anonymous_user() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute("mutation { deleteArticle(slug: \"a-title\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+  }
+
+  @Test
+  void should_fail_article_payload_when_article_is_gone() {
+    Article article = article(user);
+    when(articleCommandService.createArticle(any(NewArticleParam.class), eq(user)))
+        .thenReturn(article);
+    when(articleQueryService.findById(eq(article.getId()), eq(user))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { createArticle(input: {title: \"a title\", description: \"a description\","
+                + " body: \"a body\"}) { article { slug } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  private Article article(User author) {
+    return new Article(
+        "a title", "a description", "a body", Arrays.asList("joda"), author.getId(), TIME);
+  }
+
+  private ArticleData articleData(Article article) {
+    return new ArticleData(
+        article.getId(),
+        article.getSlug(),
+        article.getTitle(),
+        article.getDescription(),
+        article.getBody(),
+        false,
+        0,
+        TIME,
+        TIME,
+        Arrays.asList("joda"),
+        profileData);
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -1,0 +1,172 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPageParameter;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, CommentDatafetcher.class, ArticleDatafetcher.class})
+public class CommentDatafetcherTest extends GraphQLTestBase {
+
+  private static final DateTime TIME = new DateTime(2022, 2, 2, 10, 0, DateTimeZone.UTC);
+  private static final String TIME_ISO = "2022-02-02T10:00:00.000Z";
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private CommentQueryService commentQueryService;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private io.spring.core.user.UserRepository userRepository;
+
+  @Test
+  void should_return_article_comments_paginated_forward() {
+    ArticleData articleData = articleData();
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(user)))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(eq(articleData.getId()), eq(user), any()))
+        .thenReturn(
+            new CursorPager<>(Collections.singletonList(commentData("1")), Direction.NEXT, true));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ article(slug: \""
+                + articleData.getSlug()
+                + "\") { comments(first: 5, after: \"1000\") { edges { cursor node { id body"
+                + " createdAt updatedAt } } pageInfo { hasNextPage hasPreviousPage startCursor"
+                + " endCursor } } } }");
+
+    assertThat(context.read("$.data.article.comments.edges[0].node.id", String.class))
+        .isEqualTo("comment-1");
+    assertThat(context.read("$.data.article.comments.edges[0].node.body", String.class))
+        .isEqualTo("body 1");
+    assertThat(context.read("$.data.article.comments.edges[0].node.createdAt", String.class))
+        .isEqualTo(TIME_ISO);
+    assertThat(context.read("$.data.article.comments.edges[0].cursor", String.class))
+        .isEqualTo(String.valueOf(TIME.getMillis()));
+    assertThat(context.read("$.data.article.comments.pageInfo.hasNextPage", Boolean.class))
+        .isTrue();
+    assertThat(context.read("$.data.article.comments.pageInfo.endCursor", String.class))
+        .isEqualTo(String.valueOf(TIME.getMillis()));
+
+    CursorPageParameter<DateTime> pageParameter = capturePageParameter();
+    assertThat(pageParameter.getLimit()).isEqualTo(5);
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.NEXT);
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(1000L);
+  }
+
+  @Test
+  void should_return_article_comments_paginated_backward() {
+    ArticleData articleData = articleData();
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(user)))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(eq(articleData.getId()), eq(user), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.PREV, false));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ article(slug: \""
+                + articleData.getSlug()
+                + "\") { comments(last: 2, before: \"2000\") { edges { cursor } pageInfo {"
+                + " hasPreviousPage startCursor } } } }");
+
+    assertThat(context.read("$.data.article.comments.edges", List.class)).isEmpty();
+    assertThat(context.read("$.data.article.comments.pageInfo.hasPreviousPage", Boolean.class))
+        .isFalse();
+    assertThat(context.read("$.data.article.comments.pageInfo.startCursor", String.class)).isNull();
+
+    CursorPageParameter<DateTime> pageParameter = capturePageParameter();
+    assertThat(pageParameter.getLimit()).isEqualTo(2);
+    assertThat(pageParameter.getDirection()).isEqualTo(Direction.PREV);
+    assertThat(pageParameter.getCursor().getMillis()).isEqualTo(2000L);
+  }
+
+  @Test
+  void should_query_comments_for_anonymous_user() {
+    logout();
+    ArticleData articleData = articleData();
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), isNull()))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(eq(articleData.getId()), isNull(), any()))
+        .thenReturn(new CursorPager<>(Collections.emptyList(), Direction.NEXT, false));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ article(slug: \""
+                + articleData.getSlug()
+                + "\") { comments(first: 1) { edges { cursor } } } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    verify(commentQueryService).findByArticleIdWithCursor(eq(articleData.getId()), isNull(), any());
+  }
+
+  @Test
+  void should_fail_comments_without_first_or_last() {
+    ArticleData articleData = articleData();
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(user)))
+        .thenReturn(Optional.of(articleData));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "{ article(slug: \""
+                + articleData.getSlug()
+                + "\") { comments { edges { cursor } } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("first 和 last 必须只存在一个");
+  }
+
+  private CursorPageParameter<DateTime> capturePageParameter() {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<CursorPageParameter<DateTime>> captor =
+        ArgumentCaptor.forClass(CursorPageParameter.class);
+    verify(commentQueryService).findByArticleIdWithCursor(any(), any(), captor.capture());
+    return captor.getValue();
+  }
+
+  private ArticleData articleData() {
+    return new ArticleData(
+        "article-id",
+        "a-title",
+        "a title",
+        "a description",
+        "a body",
+        false,
+        0,
+        TIME,
+        TIME,
+        Arrays.asList("joda"),
+        profileData);
+  }
+
+  private CommentData commentData(String seed) {
+    return new CommentData(
+        "comment-" + seed, "body " + seed, "article-id", TIME, TIME, profileData);
+  }
+}

--- a/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/CommentDatafetcherTest.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 public class CommentDatafetcherTest extends GraphQLTestBase {
 
   private static final DateTime TIME = new DateTime(2022, 2, 2, 10, 0, DateTimeZone.UTC);
+  private static final DateTime UPDATE_TIME = new DateTime(2022, 3, 3, 11, 0, DateTimeZone.UTC);
   private static final String TIME_ISO = "2022-02-02T10:00:00.000Z";
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
@@ -67,6 +68,10 @@ public class CommentDatafetcherTest extends GraphQLTestBase {
     assertThat(context.read("$.data.article.comments.edges[0].node.body", String.class))
         .isEqualTo("body 1");
     assertThat(context.read("$.data.article.comments.edges[0].node.createdAt", String.class))
+        .isEqualTo(TIME_ISO);
+    // buildCommentResult prints createdAt into both timestamp fields, so the fixture's distinct
+    // updatedAt (UPDATE_TIME) never reaches the response.
+    assertThat(context.read("$.data.article.comments.edges[0].node.updatedAt", String.class))
         .isEqualTo(TIME_ISO);
     assertThat(context.read("$.data.article.comments.edges[0].cursor", String.class))
         .isEqualTo(String.valueOf(TIME.getMillis()));
@@ -167,6 +172,6 @@ public class CommentDatafetcherTest extends GraphQLTestBase {
 
   private CommentData commentData(String seed) {
     return new CommentData(
-        "comment-" + seed, "body " + seed, "article-id", TIME, TIME, profileData);
+        "comment-" + seed, "body " + seed, "article-id", TIME, UPDATE_TIME, profileData);
   }
 }

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -33,6 +33,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 public class CommentMutationTest extends GraphQLTestBase {
 
   private static final DateTime TIME = new DateTime(2022, 2, 2, 10, 0, DateTimeZone.UTC);
+  private static final DateTime UPDATE_TIME = new DateTime(2022, 3, 3, 11, 0, DateTimeZone.UTC);
   private static final String TIME_ISO = "2022-02-02T10:00:00.000Z";
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
@@ -51,7 +52,7 @@ public class CommentMutationTest extends GraphQLTestBase {
         .thenReturn(
             Optional.of(
                 new CommentData(
-                    "comment-id", "a comment", article.getId(), TIME, TIME, profileData)));
+                    "comment-id", "a comment", article.getId(), TIME, UPDATE_TIME, profileData)));
 
     DocumentContext context =
         dgsQueryExecutor.executeAndGetDocumentContext(
@@ -62,6 +63,10 @@ public class CommentMutationTest extends GraphQLTestBase {
     assertThat(context.read("$.data.addComment.comment.id", String.class)).isEqualTo("comment-id");
     assertThat(context.read("$.data.addComment.comment.body", String.class)).isEqualTo("a comment");
     assertThat(context.read("$.data.addComment.comment.createdAt", String.class))
+        .isEqualTo(TIME_ISO);
+    // buildCommentResult prints createdAt into both timestamp fields, so the fixture's distinct
+    // updatedAt (UPDATE_TIME) never reaches the response.
+    assertThat(context.read("$.data.addComment.comment.updatedAt", String.class))
         .isEqualTo(TIME_ISO);
 
     ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);

--- a/src/test/java/io/spring/graphql/CommentMutationTest.java
+++ b/src/test/java/io/spring/graphql/CommentMutationTest.java
@@ -1,0 +1,190 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.CommentQueryService;
+import io.spring.application.data.CommentData;
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.comment.Comment;
+import io.spring.core.comment.CommentRepository;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(
+    classes = {DgsAutoConfiguration.class, CommentMutation.class, CommentDatafetcher.class})
+public class CommentMutationTest extends GraphQLTestBase {
+
+  private static final DateTime TIME = new DateTime(2022, 2, 2, 10, 0, DateTimeZone.UTC);
+  private static final String TIME_ISO = "2022-02-02T10:00:00.000Z";
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ArticleRepository articleRepository;
+
+  @MockBean private CommentRepository commentRepository;
+
+  @MockBean private CommentQueryService commentQueryService;
+
+  @Test
+  void should_add_comment_to_article() {
+    Article article = article(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(user)))
+        .thenReturn(
+            Optional.of(
+                new CommentData(
+                    "comment-id", "a comment", article.getId(), TIME, TIME, profileData)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { addComment(slug: \""
+                + article.getSlug()
+                + "\", body: \"a comment\") { comment { id body createdAt updatedAt } } }");
+
+    assertThat(context.read("$.data.addComment.comment.id", String.class)).isEqualTo("comment-id");
+    assertThat(context.read("$.data.addComment.comment.body", String.class)).isEqualTo("a comment");
+    assertThat(context.read("$.data.addComment.comment.createdAt", String.class))
+        .isEqualTo(TIME_ISO);
+
+    ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+    verify(commentRepository).save(captor.capture());
+    assertThat(captor.getValue().getBody()).isEqualTo("a comment");
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().getArticleId()).isEqualTo(article.getId());
+  }
+
+  @Test
+  void should_not_add_comment_for_anonymous_user() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { addComment(slug: \"a-title\", body: \"a comment\") { __typename } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+    verify(commentRepository, never()).save(any());
+  }
+
+  @Test
+  void should_not_add_comment_to_unknown_article() {
+    when(articleRepository.findBySlug(eq("unknown"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { addComment(slug: \"unknown\", body: \"a comment\") { __typename } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_fail_when_created_comment_cannot_be_read_back() {
+    Article article = article(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentQueryService.findById(any(), eq(user))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { addComment(slug: \""
+                + article.getSlug()
+                + "\", body: \"a comment\") { __typename } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_delete_own_comment() {
+    Article article = article(user);
+    Comment comment = new Comment("a comment", user.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \""
+                + comment.getId()
+                + "\") { success } }");
+
+    assertThat(context.read("$.data.deleteComment.success", Boolean.class)).isTrue();
+    verify(commentRepository).remove(eq(comment));
+  }
+
+  @Test
+  void should_not_delete_comment_of_another_user() {
+    User other = new User("other@jacob.com", "other", "123", "", DEFAULT_AVATAR);
+    Article article = article(other);
+    Comment comment = new Comment("a comment", other.getId(), article.getId());
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq(comment.getId())))
+        .thenReturn(Optional.of(comment));
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \""
+                + comment.getId()
+                + "\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("NoAuthorizationException");
+    verify(commentRepository, never()).remove(any());
+  }
+
+  @Test
+  void should_not_delete_unknown_comment() {
+    Article article = article(user);
+    when(articleRepository.findBySlug(eq(article.getSlug()))).thenReturn(Optional.of(article));
+    when(commentRepository.findById(eq(article.getId()), eq("unknown")))
+        .thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteComment(slug: \""
+                + article.getSlug()
+                + "\", id: \"unknown\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_not_delete_comment_for_anonymous_user() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { deleteComment(slug: \"a-title\", id: \"comment-id\") { success } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+  }
+
+  private Article article(User author) {
+    return new Article(
+        "a title", "a description", "a body", Arrays.asList("joda"), author.getId(), TIME);
+  }
+}

--- a/src/test/java/io/spring/graphql/GraphQLTestBase.java
+++ b/src/test/java/io/spring/graphql/GraphQLTestBase.java
@@ -1,0 +1,49 @@
+package io.spring.graphql;
+
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.User;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/** Common fixtures and security context helpers for the GraphQL layer tests. */
+public abstract class GraphQLTestBase {
+
+  protected static final String DEFAULT_AVATAR =
+      "https://static.productionready.io/images/smiley-cyrus.jpg";
+
+  protected User user;
+  protected ProfileData profileData;
+
+  @BeforeEach
+  void setUpCurrentUser() {
+    user = new User("john@jacob.com", "johnjacob", "123", "bio", DEFAULT_AVATAR);
+    profileData =
+        new ProfileData(user.getId(), user.getUsername(), user.getBio(), user.getImage(), false);
+    login(user);
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  protected void login(User currentUser) {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(currentUser, null, Collections.emptyList()));
+  }
+
+  protected void logout() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "anonymousKey",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/src/test/java/io/spring/graphql/MeDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/MeDatafetcherTest.java
@@ -1,0 +1,85 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, MeDatafetcher.class})
+public class MeDatafetcherTest extends GraphQLTestBase {
+
+  private static final String ME_QUERY = "{ me { email username token } }";
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserQueryService userQueryService;
+
+  @MockBean private JwtService jwtService;
+
+  @Test
+  void should_return_current_user_with_token_from_authorization_header() {
+    when(userQueryService.findById(eq(user.getId())))
+        .thenReturn(
+            Optional.of(
+                new UserData(
+                    user.getId(), user.getEmail(), user.getUsername(), "bio", DEFAULT_AVATAR)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            ME_QUERY, Collections.emptyMap(), authorizationHeaders("jwt-token"));
+
+    assertThat(context.read("$.data.me.email", String.class)).isEqualTo(user.getEmail());
+    assertThat(context.read("$.data.me.username", String.class)).isEqualTo(user.getUsername());
+    assertThat(context.read("$.data.me.token", String.class)).isEqualTo("jwt-token");
+  }
+
+  @Test
+  void should_return_null_for_anonymous_user() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            ME_QUERY,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            authorizationHeaders("jwt-token"));
+
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.<java.util.Map<String, Object>>getData()).containsEntry("me", null);
+  }
+
+  @Test
+  void should_fail_when_current_user_is_not_found() {
+    when(userQueryService.findById(eq(user.getId()))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            ME_QUERY,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            authorizationHeaders("jwt-token"));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  private HttpHeaders authorizationHeaders(String token) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token " + token);
+    return headers;
+  }
+}

--- a/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/ProfileDatafetcherTest.java
@@ -1,0 +1,182 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.CommentQueryService;
+import io.spring.application.CursorPager;
+import io.spring.application.CursorPager.Direction;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.UserQueryService;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.CommentData;
+import io.spring.application.data.ProfileData;
+import io.spring.application.data.UserData;
+import io.spring.core.service.JwtService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      ProfileDatafetcher.class,
+      ArticleDatafetcher.class,
+      CommentDatafetcher.class,
+      MeDatafetcher.class
+    })
+public class ProfileDatafetcherTest extends GraphQLTestBase {
+
+  private static final DateTime TIME = new DateTime(2022, 2, 2, 10, 0, DateTimeZone.UTC);
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private ProfileQueryService profileQueryService;
+
+  @MockBean private ArticleQueryService articleQueryService;
+
+  @MockBean private CommentQueryService commentQueryService;
+
+  @MockBean private UserQueryService userQueryService;
+
+  @MockBean private JwtService jwtService;
+
+  @MockBean private io.spring.core.user.UserRepository userRepository;
+
+  @Test
+  void should_query_profile_by_username() {
+    when(profileQueryService.findByUsername(eq("jane"), eq(user)))
+        .thenReturn(Optional.of(new ProfileData("jane-id", "jane", "jane bio", "jane.png", true)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ profile(username: \"jane\") { profile { username bio image following } } }");
+
+    assertThat(context.read("$.data.profile.profile.username", String.class)).isEqualTo("jane");
+    assertThat(context.read("$.data.profile.profile.bio", String.class)).isEqualTo("jane bio");
+    assertThat(context.read("$.data.profile.profile.image", String.class)).isEqualTo("jane.png");
+    assertThat(context.read("$.data.profile.profile.following", Boolean.class)).isTrue();
+  }
+
+  @Test
+  void should_query_profile_for_anonymous_user() {
+    logout();
+    when(profileQueryService.findByUsername(eq("jane"), isNull()))
+        .thenReturn(Optional.of(new ProfileData("jane-id", "jane", "jane bio", "jane.png", false)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ profile(username: \"jane\") { profile { username following } } }");
+
+    assertThat(context.read("$.data.profile.profile.following", Boolean.class)).isFalse();
+  }
+
+  @Test
+  void should_fail_to_query_unknown_profile() {
+    when(profileQueryService.findByUsername(eq("ghost"), eq(user))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute("{ profile(username: \"ghost\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_return_profile_of_current_user() {
+    when(userQueryService.findById(eq(user.getId())))
+        .thenReturn(
+            Optional.of(
+                new UserData(
+                    user.getId(), user.getEmail(), user.getUsername(), "bio", DEFAULT_AVATAR)));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), eq(user)))
+        .thenReturn(Optional.of(profileData));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Token jwt-token");
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ me { username profile { username bio following } } }",
+            Collections.emptyMap(),
+            headers);
+
+    assertThat(context.read("$.data.me.profile.username", String.class))
+        .isEqualTo(user.getUsername());
+    assertThat(context.read("$.data.me.profile.following", Boolean.class)).isFalse();
+  }
+
+  @Test
+  void should_return_article_author_profile() {
+    ArticleData articleData = articleData();
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(user)))
+        .thenReturn(Optional.of(articleData));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), eq(user)))
+        .thenReturn(Optional.of(profileData));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ article(slug: \""
+                + articleData.getSlug()
+                + "\") { slug author { username bio } } }");
+
+    assertThat(context.read("$.data.article.author.username", String.class))
+        .isEqualTo(user.getUsername());
+    assertThat(context.read("$.data.article.author.bio", String.class)).isEqualTo(user.getBio());
+  }
+
+  @Test
+  void should_return_comment_author_profile() {
+    ArticleData articleData = articleData();
+    when(articleQueryService.findBySlug(eq(articleData.getSlug()), eq(user)))
+        .thenReturn(Optional.of(articleData));
+    when(commentQueryService.findByArticleIdWithCursor(eq(articleData.getId()), eq(user), any()))
+        .thenReturn(
+            new CursorPager<>(
+                Collections.singletonList(
+                    new CommentData(
+                        "comment-id", "a comment", articleData.getId(), TIME, TIME, profileData)),
+                Direction.NEXT,
+                false));
+    when(profileQueryService.findByUsername(eq(user.getUsername()), eq(user)))
+        .thenReturn(Optional.of(profileData));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "{ article(slug: \""
+                + articleData.getSlug()
+                + "\") { comments(first: 1) { edges { node { id author { username } } } } } }");
+
+    assertThat(context.read("$.data.article.comments.edges[0].node.author.username", String.class))
+        .isEqualTo(user.getUsername());
+  }
+
+  private ArticleData articleData() {
+    return new ArticleData(
+        "article-id",
+        "a-title",
+        "a title",
+        "a description",
+        "a body",
+        false,
+        0,
+        TIME,
+        TIME,
+        Arrays.asList("joda"),
+        profileData);
+  }
+}

--- a/src/test/java/io/spring/graphql/RelationMutationTest.java
+++ b/src/test/java/io/spring/graphql/RelationMutationTest.java
@@ -1,0 +1,139 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import graphql.ExecutionResult;
+import io.spring.application.ProfileQueryService;
+import io.spring.application.data.ProfileData;
+import io.spring.core.user.FollowRelation;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, RelationMutation.class})
+public class RelationMutationTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private ProfileQueryService profileQueryService;
+
+  private final User target = new User("jane@jacob.com", "jane", "123", "jane bio", "jane.png");
+
+  @Test
+  void should_follow_user() {
+    when(userRepository.findByUsername(eq("jane"))).thenReturn(Optional.of(target));
+    when(profileQueryService.findByUsername(eq("jane"), eq(user)))
+        .thenReturn(
+            Optional.of(new ProfileData(target.getId(), "jane", "jane bio", "jane.png", true)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { followUser(username: \"jane\") { profile { username bio image following } }"
+                + " }");
+
+    assertThat(context.read("$.data.followUser.profile.username", String.class)).isEqualTo("jane");
+    assertThat(context.read("$.data.followUser.profile.following", Boolean.class)).isTrue();
+
+    ArgumentCaptor<FollowRelation> captor = ArgumentCaptor.forClass(FollowRelation.class);
+    verify(userRepository).saveRelation(captor.capture());
+    assertThat(captor.getValue().getUserId()).isEqualTo(user.getId());
+    assertThat(captor.getValue().getTargetId()).isEqualTo(target.getId());
+  }
+
+  @Test
+  void should_not_follow_unknown_user() {
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { followUser(username: \"ghost\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(userRepository, never()).saveRelation(any());
+  }
+
+  @Test
+  void should_not_follow_for_anonymous_user() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { followUser(username: \"jane\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+  }
+
+  @Test
+  void should_unfollow_user() {
+    FollowRelation relation = new FollowRelation(user.getId(), target.getId());
+    when(userRepository.findByUsername(eq("jane"))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.of(relation));
+    when(profileQueryService.findByUsername(eq("jane"), eq(user)))
+        .thenReturn(
+            Optional.of(new ProfileData(target.getId(), "jane", "jane bio", "jane.png", false)));
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { unfollowUser(username: \"jane\") { profile { username following } } }");
+
+    assertThat(context.read("$.data.unfollowUser.profile.following", Boolean.class)).isFalse();
+    verify(userRepository).removeRelation(eq(relation));
+  }
+
+  @Test
+  void should_not_unfollow_unknown_user() {
+    when(userRepository.findByUsername(eq("ghost"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfollowUser(username: \"ghost\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+  }
+
+  @Test
+  void should_not_unfollow_user_without_existing_relation() {
+    when(userRepository.findByUsername(eq("jane"))).thenReturn(Optional.of(target));
+    when(userRepository.findRelation(eq(user.getId()), eq(target.getId())))
+        .thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfollowUser(username: \"jane\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("ResourceNotFoundException");
+    verify(userRepository, never()).removeRelation(any());
+  }
+
+  @Test
+  void should_not_unfollow_for_anonymous_user() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { unfollowUser(username: \"jane\") { profile { username } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("AuthenticationException");
+  }
+}

--- a/src/test/java/io/spring/graphql/SecurityUtilTest.java
+++ b/src/test/java/io/spring/graphql/SecurityUtilTest.java
@@ -1,0 +1,62 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.spring.core.user.User;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtilTest {
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void should_return_current_user_from_populated_context() {
+    User user = new User("john@jacob.com", "johnjacob", "123", "bio", "image");
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList()));
+
+    Optional<User> currentUser = SecurityUtil.getCurrentUser();
+
+    assertThat(currentUser).hasValue(user);
+  }
+
+  @Test
+  void should_return_empty_for_anonymous_authentication() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "anonymousKey",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  void should_return_empty_when_principal_is_null() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new TestingAuthenticationToken(null, null));
+
+    assertThat(SecurityUtil.getCurrentUser()).isEmpty();
+  }
+
+  @Test
+  void should_fail_when_context_holds_no_authentication() {
+    SecurityContextHolder.clearContext();
+
+    assertThatThrownBy(SecurityUtil::getCurrentUser).isInstanceOf(NullPointerException.class);
+  }
+}

--- a/src/test/java/io/spring/graphql/TagDatafetcherTest.java
+++ b/src/test/java/io/spring/graphql/TagDatafetcherTest.java
@@ -1,0 +1,40 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {DgsAutoConfiguration.class, TagDatafetcher.class})
+public class TagDatafetcherTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private TagsQueryService tagsQueryService;
+
+  @Test
+  void should_return_all_tags() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList("joda", "spring"));
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertThat(tags).containsExactly("joda", "spring");
+  }
+
+  @Test
+  void should_return_empty_tag_list() {
+    when(tagsQueryService.allTags()).thenReturn(Arrays.asList());
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertThat(tags).isEmpty();
+  }
+}

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
 import javax.validation.constraints.NotBlank;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -174,9 +175,11 @@ public class UserMutationTest extends GraphQLTestBase {
   }
 
   private ConstraintViolationException constraintViolationException() {
-    Set<ConstraintViolation<RegistrationForm>> violations =
-        Validation.buildDefaultValidatorFactory().getValidator().validate(new RegistrationForm(""));
-    return new ConstraintViolationException(violations);
+    try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+      Set<ConstraintViolation<RegistrationForm>> violations =
+          factory.getValidator().validate(new RegistrationForm(""));
+      return new ConstraintViolationException(violations);
+    }
   }
 
   private static class RegistrationForm {

--- a/src/test/java/io/spring/graphql/UserMutationTest.java
+++ b/src/test/java/io/spring/graphql/UserMutationTest.java
@@ -1,0 +1,190 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.types.errors.ErrorType;
+import graphql.ExecutionResult;
+import io.spring.application.user.RegisterParam;
+import io.spring.application.user.UpdateUserCommand;
+import io.spring.application.user.UserService;
+import io.spring.core.service.JwtService;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.exception.GraphQLCustomizeExceptionHandler;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@SpringBootTest(
+    classes = {
+      DgsAutoConfiguration.class,
+      GraphQLCustomizeExceptionHandler.class,
+      UserMutation.class,
+      MeDatafetcher.class
+    })
+public class UserMutationTest extends GraphQLTestBase {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockBean private UserRepository userRepository;
+
+  @MockBean private PasswordEncoder encryptService;
+
+  @MockBean private UserService userService;
+
+  @MockBean private io.spring.application.UserQueryService userQueryService;
+
+  @MockBean private JwtService jwtService;
+
+  @Test
+  void should_create_user() {
+    when(userService.createUser(any(RegisterParam.class))).thenReturn(user);
+    when(jwtService.toToken(eq(user))).thenReturn("new-token");
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { createUser(input: {email: \"john@jacob.com\", username: \"johnjacob\","
+                + " password: \"123\"}) { ... on UserPayload { user { email username token } } } }");
+
+    assertThat(context.read("$.data.createUser.user.email", String.class))
+        .isEqualTo(user.getEmail());
+    assertThat(context.read("$.data.createUser.user.username", String.class))
+        .isEqualTo(user.getUsername());
+    assertThat(context.read("$.data.createUser.user.token", String.class)).isEqualTo("new-token");
+
+    ArgumentCaptor<RegisterParam> captor = ArgumentCaptor.forClass(RegisterParam.class);
+    verify(userService).createUser(captor.capture());
+    assertThat(captor.getValue().getEmail()).isEqualTo("john@jacob.com");
+    assertThat(captor.getValue().getUsername()).isEqualTo("johnjacob");
+    assertThat(captor.getValue().getPassword()).isEqualTo("123");
+  }
+
+  @Test
+  void should_return_error_result_when_registration_is_invalid() {
+    when(userService.createUser(any(RegisterParam.class)))
+        .thenThrow(constraintViolationException());
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { createUser(input: {email: \"john@jacob.com\", username: \"\", password:"
+                + " \"123\"}) { ... on Error { message errors { key value } } } }");
+
+    assertThat(context.read("$.data.createUser.message", String.class)).isEqualTo("BAD_REQUEST");
+    assertThat(context.read("$.data.createUser.errors[0].key", String.class)).isEqualTo("username");
+    assertThat(context.read("$.data.createUser.errors[0].value", List.class))
+        .containsExactly("can't be empty");
+  }
+
+  @Test
+  void should_login_with_valid_credentials() {
+    when(userRepository.findByEmail(eq(user.getEmail()))).thenReturn(Optional.of(user));
+    when(encryptService.matches(eq("123"), eq(user.getPassword()))).thenReturn(true);
+    when(jwtService.toToken(eq(user))).thenReturn("login-token");
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { login(email: \"john@jacob.com\", password: \"123\") { user { email"
+                + " username token } } }");
+
+    assertThat(context.read("$.data.login.user.username", String.class))
+        .isEqualTo(user.getUsername());
+    assertThat(context.read("$.data.login.user.token", String.class)).isEqualTo("login-token");
+  }
+
+  @Test
+  void should_fail_login_with_wrong_password() {
+    when(userRepository.findByEmail(eq(user.getEmail()))).thenReturn(Optional.of(user));
+    when(encryptService.matches(eq("wrong"), eq(user.getPassword()))).thenReturn(false);
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { login(email: \"john@jacob.com\", password: \"wrong\") { user { email } }"
+                + " }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("invalid email or password");
+    assertThat(result.getErrors().get(0).getExtensions())
+        .containsEntry("errorType", ErrorType.UNAUTHENTICATED.name());
+  }
+
+  @Test
+  void should_fail_login_with_unknown_email() {
+    when(userRepository.findByEmail(eq("ghost@jacob.com"))).thenReturn(Optional.empty());
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { login(email: \"ghost@jacob.com\", password: \"123\") { user { email } } }");
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getExtensions())
+        .containsEntry("errorType", ErrorType.UNAUTHENTICATED.name());
+  }
+
+  @Test
+  void should_update_current_user() {
+    when(jwtService.toToken(eq(user))).thenReturn("updated-token");
+
+    DocumentContext context =
+        dgsQueryExecutor.executeAndGetDocumentContext(
+            "mutation { updateUser(changes: {email: \"jane@jacob.com\", username: \"janejacob\","
+                + " bio: \"new bio\", image: \"new-image\", password: \"newpassword\"}) { user {"
+                + " email username token } } }");
+
+    assertThat(context.read("$.data.updateUser.user.token", String.class))
+        .isEqualTo("updated-token");
+
+    ArgumentCaptor<UpdateUserCommand> captor = ArgumentCaptor.forClass(UpdateUserCommand.class);
+    verify(userService).updateUser(captor.capture());
+    assertThat(captor.getValue().getTargetUser()).isEqualTo(user);
+    assertThat(captor.getValue().getParam().getEmail()).isEqualTo("jane@jacob.com");
+    assertThat(captor.getValue().getParam().getUsername()).isEqualTo("janejacob");
+    assertThat(captor.getValue().getParam().getBio()).isEqualTo("new bio");
+    assertThat(captor.getValue().getParam().getImage()).isEqualTo("new-image");
+    assertThat(captor.getValue().getParam().getPassword()).isEqualTo("newpassword");
+  }
+
+  @Test
+  void should_not_update_user_for_anonymous_request() {
+    logout();
+
+    ExecutionResult result =
+        dgsQueryExecutor.execute(
+            "mutation { updateUser(changes: {email: \"jane@jacob.com\"}) { user { email } } }");
+
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.<Map<String, Object>>getData()).containsEntry("updateUser", null);
+    verify(userService, org.mockito.Mockito.never()).updateUser(any());
+  }
+
+  private ConstraintViolationException constraintViolationException() {
+    Set<ConstraintViolation<RegistrationForm>> violations =
+        Validation.buildDefaultValidatorFactory().getValidator().validate(new RegistrationForm(""));
+    return new ConstraintViolationException(violations);
+  }
+
+  private static class RegistrationForm {
+    @NotBlank(message = "can't be empty")
+    private final String username;
+
+    RegistrationForm(String username) {
+      this.username = username;
+    }
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -55,8 +55,7 @@ public class GraphQLCustomizeExceptionHandlerTest {
     @SuppressWarnings("unchecked")
     Map<String, Object> extensions = (Map<String, Object>) error.getExtensions();
     assertThat(extensions).containsKeys("email", "username");
-    assertThat((List<String>) extensions.get("email"))
-        .containsExactly("must be a well-formed email address");
+    assertThat((List<String>) extensions.get("email")).containsExactly("must be a valid email");
     assertThat((List<String>) extensions.get("username")).containsExactly("can't be empty");
   }
 
@@ -118,7 +117,8 @@ public class GraphQLCustomizeExceptionHandlerTest {
   }
 
   private static class RegistrationForm {
-    @Email private final String email;
+    @Email(message = "must be a valid email")
+    private final String email;
 
     @NotBlank(message = "can't be empty")
     private final String username;

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -1,0 +1,130 @@
+package io.spring.graphql.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.types.errors.ErrorType;
+import graphql.GraphQLError;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLObjectType;
+import io.spring.api.exception.InvalidAuthenticationException;
+import io.spring.graphql.types.Error;
+import io.spring.graphql.types.ErrorItem;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+
+public class GraphQLCustomizeExceptionHandlerTest {
+
+  private final GraphQLCustomizeExceptionHandler handler = new GraphQLCustomizeExceptionHandler();
+
+  @Test
+  void should_map_invalid_authentication_to_unauthenticated_error() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new InvalidAuthenticationException()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getMessage()).isEqualTo("invalid email or password");
+    assertThat(error.getExtensions()).containsEntry("errorType", ErrorType.UNAUTHENTICATED.name());
+    assertThat(error.getPath()).containsExactly("login");
+  }
+
+  @Test
+  void should_map_constraint_violation_to_bad_request_error_with_field_extensions() {
+    ConstraintViolationException cve = constraintViolationException();
+
+    DataFetcherExceptionHandlerResult result = handler.onException(parametersFor(cve));
+
+    assertThat(result.getErrors()).hasSize(1);
+    GraphQLError error = result.getErrors().get(0);
+    assertThat(error.getExtensions()).containsEntry("errorType", ErrorType.BAD_REQUEST.name());
+    assertThat(error.getPath()).containsExactly("login");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> extensions = (Map<String, Object>) error.getExtensions();
+    assertThat(extensions).containsKeys("email", "username");
+    assertThat((List<String>) extensions.get("email"))
+        .containsExactly("must be a well-formed email address");
+    assertThat((List<String>) extensions.get("username")).containsExactly("can't be empty");
+  }
+
+  @Test
+  void should_delegate_unhandled_exceptions_to_default_handler() {
+    DataFetcherExceptionHandlerResult result =
+        handler.onException(parametersFor(new RuntimeException("boom")));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("boom");
+    assertThat(result.getErrors().get(0).getExtensions())
+        .containsEntry("errorType", ErrorType.INTERNAL.name());
+  }
+
+  @Test
+  void should_convert_constraint_violations_to_error_data() {
+    Error error = GraphQLCustomizeExceptionHandler.getErrorsAsData(constraintViolationException());
+
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors())
+        .extracting(ErrorItem::getKey)
+        .containsExactlyInAnyOrder("email", "username");
+    assertThat(error.getErrors())
+        .filteredOn(item -> item.getKey().equals("username"))
+        .flatExtracting(ErrorItem::getValue)
+        .containsExactly("can't be empty");
+  }
+
+  @Test
+  void should_convert_empty_constraint_violations_to_empty_error_data() {
+    Error error =
+        GraphQLCustomizeExceptionHandler.getErrorsAsData(
+            new ConstraintViolationException(java.util.Collections.emptySet()));
+
+    assertThat(error.getMessage()).isEqualTo("BAD_REQUEST");
+    assertThat(error.getErrors()).isEmpty();
+  }
+
+  private ConstraintViolationException constraintViolationException() {
+    Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    Set<ConstraintViolation<RegistrationForm>> violations =
+        validator.validate(new RegistrationForm("not-an-email", ""));
+    return new ConstraintViolationException(violations);
+  }
+
+  private DataFetcherExceptionHandlerParameters parametersFor(Throwable exception) {
+    ExecutionStepInfo stepInfo =
+        ExecutionStepInfo.newExecutionStepInfo()
+            .type(GraphQLObjectType.newObject().name("Query").build())
+            .path(ResultPath.parse("/login"))
+            .build();
+    DataFetchingEnvironment dataFetchingEnvironment = mock(DataFetchingEnvironment.class);
+    when(dataFetchingEnvironment.getExecutionStepInfo()).thenReturn(stepInfo);
+    return DataFetcherExceptionHandlerParameters.newExceptionParameters()
+        .dataFetchingEnvironment(dataFetchingEnvironment)
+        .exception(exception)
+        .build();
+  }
+
+  private static class RegistrationForm {
+    @Email private final String email;
+
+    @NotBlank(message = "can't be empty")
+    private final String username;
+
+    RegistrationForm(String email, String username) {
+      this.email = email;
+      this.username = username;
+    }
+  }
+}

--- a/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
+++ b/src/test/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandlerTest.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
-import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import org.junit.jupiter.api.Test;
@@ -96,10 +96,11 @@ public class GraphQLCustomizeExceptionHandlerTest {
   }
 
   private ConstraintViolationException constraintViolationException() {
-    Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-    Set<ConstraintViolation<RegistrationForm>> violations =
-        validator.validate(new RegistrationForm("not-an-email", ""));
-    return new ConstraintViolationException(violations);
+    try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+      Set<ConstraintViolation<RegistrationForm>> violations =
+          factory.getValidator().validate(new RegistrationForm("not-an-email", ""));
+      return new ConstraintViolationException(violations);
+    }
   }
 
   private DataFetcherExceptionHandlerParameters parametersFor(Throwable exception) {


### PR DESCRIPTION
## Summary

`src/main/java/io/spring/graphql` had zero tests. This adds 78 tests (11 new files, tests only — no production or build changes) driving every datafetcher and mutation through the real DGS runtime, plus plain unit tests for `SecurityUtil` and `GraphQLCustomizeExceptionHandler`.

Pattern: each test boots a minimal DGS context with only the components under test and mocks the query services/repositories, then runs real GraphQL documents against the schema in `src/main/resources/schema/schema.graphqls`:

```java
@SpringBootTest(classes = {DgsAutoConfiguration.class, ArticleMutation.class, ArticleDatafetcher.class})
class ArticleMutationTest extends GraphQLTestBase {   // base: fixtures + login()/logout()
  @Autowired DgsQueryExecutor dgsQueryExecutor;
  @MockBean ArticleCommandService articleCommandService;
  ...
}
```

`GraphQLTestBase` puts a `UsernamePasswordAuthenticationToken(user, ...)` in the `SecurityContextHolder` before each test (mirroring `io.spring.api.TestWithCurrentUser`) and offers `logout()`, which installs an `AnonymousAuthenticationToken` so the anonymous branches of `SecurityUtil.getCurrentUser()` are exercised (and `AuthenticationException` / null-payload paths asserted).

What is covered beyond the happy paths:
- relay pagination in both directions for `feed`, `articles`, `Profile.{feed,articles,favorites}` and `Article.comments` — the `CursorPageParameter` handed to the query service is captured and asserted (limit, `Direction.NEXT/PREV`, cursor millis parsed from `after`/`before`), along with `pageInfo` and edge cursors; the `first == null && last == null` guard is asserted per field.
- authorization branches: `NoAuthorizationException` on updating/deleting another user's article and deleting another user's comment; `ResourceNotFoundException` for unknown slugs/comments/relations.
- `createUser` returning the `Error` member of the `UserResult` union when `UserService` throws `ConstraintViolationException`, and `login` failure surfacing `errorType: UNAUTHENTICATED` through `GraphQLCustomizeExceptionHandler` (that test wires the handler into the DGS context, so the DGS-to-handler wiring is covered too, not just the handler in isolation).

One field is tested directly rather than through a query: `ArticleDatafetcher.getCommentArticle` (`Comment.article`) casts its local context to `CommentData`, but every parent that produces a `Comment` (`CommentDatafetcher.getComment` and `articleComments`) sets the local context to a `Map<String, CommentData>`, so selecting `Comment.article` in a document would `ClassCastException`. The test calls the method with a mocked `DataFetchingEnvironment` and documents the intended behaviour; the production code is left untouched per the scope of this PR.

## Verification

`./gradlew test` — 146 tests, all passing (78 new).

`./gradlew spotlessCheck` reports one violation, in the pre-existing `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java` (present on `master`, untouched here); all new files are google-java-format clean. Note that `gradle.properties` does not exist in this repo, so spotless needs the `--add-exports jdk.compiler/...` flags passed on the command line under JDK 16+.


Link to Devin session: https://app.devin.ai/sessions/eb571c1f03184631be2ce93dc5048ebb
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/922?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->