### PR TITLE
Upgrade to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
-    id "com.diffplug.spotless" version "6.2.1"
+    id "com.diffplug.spotless" version "6.25.0"
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Moves the build to Java 17 (`sourceCompatibility`/`targetCompatibility` `11` → `17`). No `javax` → `jakarta` work is needed on Spring Boot 2.6.3.

One non-obvious follow-on: Spotless `6.2.1` bundles google-java-format `1.13.0`, which crashes on JDK 16+ because it reflects into `jdk.compiler` internals:

```
IllegalAccessError: class com.google.googlejavaformat.java.JavaInput cannot access
class com.sun.tools.javac.parser.Tokens$TokenKind (in module jdk.compiler)
```

Bumping Spotless to `6.25.0` (google-java-format `1.19.2`, which adds the required `--add-exports` handling) fixes `spotlessCheck` without needing project-wide JVM args. The newer formatter reflows one over-long constructor call in `DefaultJwtServiceTest`, which is the only source change in the diff.

Gradle wrapper stays on `7.4` and DGS codegen `5.0.6` stays put — both run fine on JDK 17.

Verified on Temurin/OpenJDK 17: `./gradlew clean build` green (68 tests, 0 failures), emitted classes are major version 61, and `./gradlew bootRun` starts Tomcat on 8080 and serves `/articles` and `/tags`.


Link to Devin session: https://app.devin.ai/sessions/75e33f2639fd412882d3dd66582083a6
Requested by: @Thomas-Blake
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/926?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->