### PR TITLE
Upgrade from Java 11 to Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,11 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 spotless {
     java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # google-java-format (used by Spotless) needs access to internal javac APIs,
 # which are not exported by default on JDK 16+.
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m \
+    --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
     --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
     --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
     --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+# google-java-format (used by Spotless) needs access to internal javac APIs,
+# which are not exported by default on JDK 16+.
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 # which are not exported by default on JDK 16+.
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m \
     --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
     --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
     --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
     --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Builds and runs the project on Java 17. No production code changes were needed — Spring Boot 2.6.3, DGS 4.9.21/codegen 5.0.6, MyBatis, Flyway, JJWT, joda-time and sqlite-jdbc all work as-is on 17, and Lombok (1.18.22 via Spring Boot's BOM) compiles fine.

Two non-obvious bits:

1. `sourceCompatibility`/`targetCompatibility` were replaced with the toolchain block rather than just bumped to `'17'`:

```groovy
java {
    toolchain { languageVersion = JavaLanguageVersion.of(17) }
}
```

Gradle 7.4's Groovy cannot run on a JDK 21 daemon at all (`Unsupported class file major version 65`), so the daemon must be JDK 11 or 17. With a plain `targetCompatibility = '17'` the build then fails on a JDK 11 daemon; the toolchain makes Gradle locate a JDK 17 for compilation regardless of which of those JDKs launches the daemon. Verified: JDK 11 daemon and JDK 17 daemon both produce class file major version 61.

2. New `gradle.properties` setting `org.gradle.jvmargs` to `-Xmx1g -XX:MaxMetaspaceSize=512m` plus `--add-exports jdk.compiler/com.sun.tools.javac.{api,file,parser,tree,util}=ALL-UNNAMED`. Spotless runs google-java-format inside the daemon JVM; on a JDK 17 daemon it dies with `IllegalAccessError: class com.google.googlejavaformat.java.JavaInput ... cannot access class com.sun.tools.javac.parser.Tokens$TokenKind`. The heap/metaspace values are explicit because setting `org.gradle.jvmargs` replaces Gradle's built-in daemon defaults rather than appending to them. Harmless on JDK 11.

Also: one pre-existing google-java-format violation in `DefaultJwtServiceTest` (fixed via `spotlessApply`), and the README's "You'll need Java 11" now says 17.

`./gradlew clean build` passes (full test suite) and `./gradlew bootRun` starts, with `GET /tags` returning 200.


Link to Devin session: https://app.devin.ai/sessions/ea559c0c73a44335a7beb8eafebec40e
Requested by: @Thomas-Blake
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/941?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->