### PR TITLE
feature: upgrade Java from 11 to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ tasks.named('clean') {
     }
 }
 
+tasks.named('bootBuildImage') {
+    environment = ['BP_JVM_VERSION': '17']
+}
+
 tasks.named('generateJava') {
     schemaPaths = ["${projectDir}/src/main/resources/schema"] // List of directories containing schema files
     packageName = 'io.spring.graphql' // The package name to use to generate sources

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ tasks.named('clean') {
 }
 
 tasks.named('bootBuildImage') {
-    environment.put('BP_JVM_VERSION', '17')
+    environment.put('BP_JVM_VERSION', java.toolchain.languageVersion.get().toString())
 }
 
 tasks.named('generateJava') {

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,12 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 spotless {
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ tasks.named('clean') {
 }
 
 tasks.named('bootBuildImage') {
-    environment.put('BP_JVM_VERSION', java.toolchain.languageVersion.get().toString())
+    environment.put('BP_JVM_VERSION', project.java.toolchain.languageVersion.get().toString())
 }
 
 tasks.named('generateJava') {

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ tasks.named('clean') {
 }
 
 tasks.named('bootBuildImage') {
-    environment = ['BP_JVM_VERSION': '17']
+    environment.put('BP_JVM_VERSION', '17')
 }
 
 tasks.named('generateJava') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+# google-java-format (used by spotless) needs access to internal javac APIs on JDK 16+
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Targets Java 17 via a Gradle toolchain instead of `sourceCompatibility`/`targetCompatibility = '11'`:

```diff
-sourceCompatibility = '11'
-targetCompatibility = '11'
+java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }
```

No dependency bumps were needed — Spring Boot 2.6.3, DGS 4.9.21 + codegen 5.0.6, MyBatis 2.2.2, sqlite-jdbc 3.36.0.3 and the Boot-managed Lombok (1.18.22) all build and run on 17, and the Gradle wrapper stays at 7.4.

The one Java 17 casualty is spotless: `googleJavaFormat` reflects into `jdk.compiler` internals, which JDK 16+ no longer exports, so `spotlessJava` died with `IllegalAccessError` on `com.sun.tools.javac.parser.Tokens$TokenKind`. Fixed by adding a `gradle.properties` that passes the required `--add-exports` flags to the Gradle JVM (harmless on JDK 11). `spotlessApply` then reformatted one pre-existing violation in `DefaultJwtServiceTest`.

Boot 2.6's `bootBuildImage` does not derive the buildpack JRE from the toolchain, so `BP_JVM_VERSION: '17'` is set explicitly to keep the README's Docker path from producing an image that can't load major-version-61 classes.

Verified with JDK 17: `./gradlew clean build` green (`generateJava` still emits sources under `build/generated`, 68 tests, 0 failures), main classes compile to bytecode major version 61, and `bootRun` serves `GET /tags` (200) and `GET /articles`. `bootBuildImage` was only checked at configuration time — no Docker daemon available here.


Link to Devin session: https://app.devin.ai/sessions/df00076517e942cfa7e7d2a6721aba08
Requested by: @Thomas-Blake
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/942?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->