### PR TITLE
build: target Java 17 via Gradle toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 17 installed.
+You'll need Java 17 installed. The build pins a Java 17 toolchain, so Gradle needs a JDK 17 it can
+discover locally — on an older JDK it fails with `No matching toolchains found` rather than silently
+building against an older target.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,12 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 spotless {
     java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,9 @@
+# google-java-format (used by Spotless) reaches into internal javac APIs that
+# JDK 16+ no longer exports by default.
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m \
+    --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+    --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Moves the build target from Java 11 to Java 17. Spring Boot stays at 2.6.3 and the Gradle wrapper stays at 7.4 — both support JDK 17, so no dependency, wrapper, or `javax.*`→`jakarta.*` changes were needed.

Two changes carry the upgrade:

```diff
 // build.gradle
-sourceCompatibility = '11'
-targetCompatibility = '11'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
```

The toolchain block is used instead of `source/targetCompatibility` so the JDK is pinned for the build rather than inferred from whatever JDK happens to launch Gradle.

```properties
# gradle.properties (new)
org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m \
    --add-exports jdk.compiler/com.sun.tools.javac.{api,code,file,parser,tree,util}=ALL-UNNAMED
```

This is required, not cosmetic: `:spotlessJava` fails on JDK 17 with

```
java.lang.IllegalAccessError: class com.google.googlejavaformat.java.JavaInput cannot access
class com.sun.tools.javac.parser.Tokens$TokenKind (in module jdk.compiler) because module
jdk.compiler does not export com.sun.tools.javac.parser to unnamed module
```

google-java-format (via Spotless 6.2.1) reads javac internals that JDK 16+ no longer exports. Adding the exports is less invasive than bumping google-java-format/Spotless, since the reformat surface stays identical. Heap/metaspace are pinned in the same property because setting `org.gradle.jvmargs` otherwise drops Gradle's defaults.

Side effects: with Spotless now actually executing under JDK 17, `googleJavaFormat` flagged one long constructor call in `DefaultJwtServiceTest` (reformatted by `spotlessApply`), and the README's "You'll need Java 11 installed" prerequisite is updated to 17.

## Verification

`./gradlew clean build` on JDK 17 (compile + DGS `generateJava` + tests + `spotlessCheck`) is green. Three parallel sessions independently re-verified on this branch, and none required a further change:

- **Codegen/compile** — DGS codegen 5.0.6 emits the same 22 sources into `io.spring.graphql`; all 180 main classes are class-file major version 61. No DGS bump needed.
- **Tests** — 68 tests across 20 classes, 0 failures, run twice with `--rerun-tasks`. No `InaccessibleObjectException` or illegal-access warnings from Mockito/Spring/Jackson/Joda-Time, so the `test` task needs **no** `--add-opens`. sqlite-jdbc 3.36.0.3 and Flyway 8.0.5 both work unchanged.
- **Tooling** — Lombok already resolves to 1.18.22 via the Boot 2.6.3 BOM (the first JDK 17-compatible release), so no explicit pin. Dropping each export individually confirmed 5 of the 6 are load-bearing (`javac.code` is not needed by google-java-format 1.13.0); it is kept because it is part of the set google-java-format documents upstream. Bumping to `googleJavaFormat('1.19.2')` still throws the same `IllegalAccessError`, confirming the exports — not the formatter version — are the fix.

`bootBuildImage` also needs no change: Boot 2.6.3 derives `BP_JVM_VERSION` from `targetCompatibility`, which the toolchain sets, so the task resolves `targetJavaVersion=17`.


Link to Devin session: https://app.devin.ai/sessions/b0aaec0e54494fbb905cd08d68f68087
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/956?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->