### PR TITLE
build: upgrade to Java 17 (Spring Boot 2.7.18, Gradle 7.6.4, Joda-Time removed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.6.3'
+    id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
@@ -7,14 +7,18 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 spotless {
     java {
         target project.fileTree(project.rootDir) {
             include '**/*.java'
-            exclude 'build/generated/**/*.*', 'build/generated-examples/**/*.*'
+            exclude 'build/**/*.*'
         }
         googleJavaFormat()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
-    implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 
     compileOnly 'org.projectlombok:lombok'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
 # google-java-format (used by Spotless) reads internal javac APIs, which JDK 16+
 # strongly encapsulates. Export them to the Gradle daemon running the format step.
-# The heap/metaspace values restate Gradle's daemon defaults, which setting
-# org.gradle.jvmargs would otherwise replace rather than extend.
+# Setting org.gradle.jvmargs replaces Gradle's daemon defaults rather than
+# extending them, so the heap/metaspace limits are restated here (raised above
+# the 512m/384m defaults to leave room for codegen and the formatter).
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m \
   --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 # google-java-format (used by Spotless) reads internal javac APIs, which JDK 16+
-# strongly encapsulates. Export them to the Gradle daemon running the format step.
+# strongly encapsulates. Export them to the Gradle daemon (this is global: it
+# applies to every task, not just the format step).
 # Setting org.gradle.jvmargs replaces Gradle's daemon defaults rather than
 # extending them, so the heap/metaspace limits are restated here (raised above
 # the 512m/384m defaults to leave room for codegen and the formatter).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+# google-java-format (used by Spotless) reads internal javac APIs, which JDK 16+
+# strongly encapsulates. Export them to the Gradle daemon running the format step.
+org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 # google-java-format (used by Spotless) reads internal javac APIs, which JDK 16+
 # strongly encapsulates. Export them to the Gradle daemon running the format step.
-org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+# The heap/metaspace values restate Gradle's daemon defaults, which setting
+# org.gradle.jvmargs would otherwise replace rather than extend.
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/spring/DateTimes.java
+++ b/src/main/java/io/spring/DateTimes.java
@@ -1,0 +1,21 @@
+package io.spring;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+public class DateTimes {
+
+  /** ISO-8601 in UTC with exactly three fractional-second digits, e.g. 2021-01-01T12:00:00.000Z. */
+  public static final DateTimeFormatter ISO_UTC =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC);
+
+  public static Instant now() {
+    return Instant.now().truncatedTo(ChronoUnit.MILLIS);
+  }
+
+  public static String format(Instant instant) {
+    return ISO_UTC.format(instant);
+  }
+}

--- a/src/main/java/io/spring/JacksonCustomizations.java
+++ b/src/main/java/io/spring/JacksonCustomizations.java
@@ -6,8 +6,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
+import java.time.Instant;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,23 +20,23 @@ public class JacksonCustomizations {
 
   public static class RealWorldModules extends SimpleModule {
     public RealWorldModules() {
-      addSerializer(DateTime.class, new DateTimeSerializer());
+      addSerializer(Instant.class, new DateTimeSerializer());
     }
   }
 
-  public static class DateTimeSerializer extends StdSerializer<DateTime> {
+  public static class DateTimeSerializer extends StdSerializer<Instant> {
 
     protected DateTimeSerializer() {
-      super(DateTime.class);
+      super(Instant.class);
     }
 
     @Override
-    public void serialize(DateTime value, JsonGenerator gen, SerializerProvider provider)
+    public void serialize(Instant value, JsonGenerator gen, SerializerProvider provider)
         throws IOException {
       if (value == null) {
         gen.writeNull();
       } else {
-        gen.writeString(ISODateTimeFormat.dateTime().withZoneUTC().print(value));
+        gen.writeString(DateTimes.format(value));
       }
     }
   }

--- a/src/main/java/io/spring/application/ArticleQueryService.java
+++ b/src/main/java/io/spring/application/ArticleQueryService.java
@@ -9,6 +9,7 @@ import io.spring.core.user.User;
 import io.spring.infrastructure.mybatis.readservice.ArticleFavoritesReadService;
 import io.spring.infrastructure.mybatis.readservice.ArticleReadService;
 import io.spring.infrastructure.mybatis.readservice.UserRelationshipQueryService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,7 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.AllArgsConstructor;
-import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -55,7 +55,7 @@ public class ArticleQueryService {
       String tag,
       String author,
       String favoritedBy,
-      CursorPageParameter<DateTime> page,
+      CursorPageParameter<Instant> page,
       User currentUser) {
     List<String> articleIds =
         articleReadService.findArticlesWithCursor(tag, author, favoritedBy, page);
@@ -78,7 +78,7 @@ public class ArticleQueryService {
   }
 
   public CursorPager<ArticleData> findUserFeedWithCursor(
-      User user, CursorPageParameter<DateTime> page) {
+      User user, CursorPageParameter<Instant> page) {
     List<String> followdUsers = userRelationshipQueryService.followedUsers(user.getId());
     if (followdUsers.size() == 0) {
       return new CursorPager<>(new ArrayList<>(), page.getDirection(), false);

--- a/src/main/java/io/spring/application/CommentQueryService.java
+++ b/src/main/java/io/spring/application/CommentQueryService.java
@@ -4,6 +4,7 @@ import io.spring.application.data.CommentData;
 import io.spring.core.user.User;
 import io.spring.infrastructure.mybatis.readservice.CommentReadService;
 import io.spring.infrastructure.mybatis.readservice.UserRelationshipQueryService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +12,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -54,7 +54,7 @@ public class CommentQueryService {
   }
 
   public CursorPager<CommentData> findByArticleIdWithCursor(
-      String articleId, User user, CursorPageParameter<DateTime> page) {
+      String articleId, User user, CursorPageParameter<Instant> page) {
     List<CommentData> comments = commentReadService.findByArticleIdWithCursor(articleId, page);
     if (comments.isEmpty()) {
       return new CursorPager<>(new ArrayList<>(), page.getDirection(), false);

--- a/src/main/java/io/spring/application/DateTimeCursor.java
+++ b/src/main/java/io/spring/application/DateTimeCursor.java
@@ -1,23 +1,22 @@
 package io.spring.application;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import java.time.Instant;
 
-public class DateTimeCursor extends PageCursor<DateTime> {
+public class DateTimeCursor extends PageCursor<Instant> {
 
-  public DateTimeCursor(DateTime data) {
+  public DateTimeCursor(Instant data) {
     super(data);
   }
 
   @Override
   public String toString() {
-    return String.valueOf(getData().getMillis());
+    return String.valueOf(getData().toEpochMilli());
   }
 
-  public static DateTime parse(String cursor) {
+  public static Instant parse(String cursor) {
     if (cursor == null) {
       return null;
     }
-    return new DateTime().withMillis(Long.parseLong(cursor)).withZone(DateTimeZone.UTC);
+    return Instant.ofEpochMilli(Long.parseLong(cursor));
   }
 }

--- a/src/main/java/io/spring/application/data/ArticleData.java
+++ b/src/main/java/io/spring/application/data/ArticleData.java
@@ -2,11 +2,11 @@ package io.spring.application.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.spring.application.DateTimeCursor;
+import java.time.Instant;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Data
 @NoArgsConstructor
@@ -19,8 +19,8 @@ public class ArticleData implements io.spring.application.Node {
   private String body;
   private boolean favorited;
   private int favoritesCount;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
   private List<String> tagList;
 
   @JsonProperty("author")

--- a/src/main/java/io/spring/application/data/CommentData.java
+++ b/src/main/java/io/spring/application/data/CommentData.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.spring.application.DateTimeCursor;
 import io.spring.application.Node;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Data
 @NoArgsConstructor
@@ -16,8 +16,8 @@ public class CommentData implements Node {
   private String id;
   private String body;
   @JsonIgnore private String articleId;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   @JsonProperty("author")
   private ProfileData profileData;

--- a/src/main/java/io/spring/core/article/Article.java
+++ b/src/main/java/io/spring/core/article/Article.java
@@ -2,14 +2,15 @@ package io.spring.core.article;
 
 import static java.util.stream.Collectors.toList;
 
+import io.spring.DateTimes;
 import io.spring.Util;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Getter
 @NoArgsConstructor
@@ -22,12 +23,12 @@ public class Article {
   private String description;
   private String body;
   private List<Tag> tags;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   public Article(
       String title, String description, String body, List<String> tagList, String userId) {
-    this(title, description, body, tagList, userId, new DateTime());
+    this(title, description, body, tagList, userId, DateTimes.now());
   }
 
   public Article(
@@ -36,7 +37,7 @@ public class Article {
       String body,
       List<String> tagList,
       String userId,
-      DateTime createdAt) {
+      Instant createdAt) {
     this.id = UUID.randomUUID().toString();
     this.slug = toSlug(title);
     this.title = title;
@@ -52,15 +53,15 @@ public class Article {
     if (!Util.isEmpty(title)) {
       this.title = title;
       this.slug = toSlug(title);
-      this.updatedAt = new DateTime();
+      this.updatedAt = DateTimes.now();
     }
     if (!Util.isEmpty(description)) {
       this.description = description;
-      this.updatedAt = new DateTime();
+      this.updatedAt = DateTimes.now();
     }
     if (!Util.isEmpty(body)) {
       this.body = body;
-      this.updatedAt = new DateTime();
+      this.updatedAt = DateTimes.now();
     }
   }
 

--- a/src/main/java/io/spring/core/comment/Comment.java
+++ b/src/main/java/io/spring/core/comment/Comment.java
@@ -1,10 +1,11 @@
 package io.spring.core.comment;
 
+import io.spring.DateTimes;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Getter
 @NoArgsConstructor
@@ -14,13 +15,13 @@ public class Comment {
   private String body;
   private String userId;
   private String articleId;
-  private DateTime createdAt;
+  private Instant createdAt;
 
   public Comment(String body, String userId, String articleId) {
     this.id = UUID.randomUUID().toString();
     this.body = body;
     this.userId = userId;
     this.articleId = articleId;
-    this.createdAt = new DateTime();
+    this.createdAt = DateTimes.now();
   }
 }

--- a/src/main/java/io/spring/graphql/ArticleDatafetcher.java
+++ b/src/main/java/io/spring/graphql/ArticleDatafetcher.java
@@ -9,6 +9,7 @@ import graphql.execution.DataFetcherResult;
 import graphql.relay.DefaultConnectionCursor;
 import graphql.relay.DefaultPageInfo;
 import graphql.schema.DataFetchingEnvironment;
+import io.spring.DateTimes;
 import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.CursorPageParameter;
@@ -30,7 +31,6 @@ import io.spring.graphql.types.Profile;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.format.ISODateTimeFormat;
 
 @DgsComponent
 @AllArgsConstructor
@@ -371,14 +371,14 @@ public class ArticleDatafetcher {
   private Article buildArticleResult(ArticleData articleData) {
     return Article.newBuilder()
         .body(articleData.getBody())
-        .createdAt(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getCreatedAt()))
+        .createdAt(DateTimes.format(articleData.getCreatedAt()))
         .description(articleData.getDescription())
         .favorited(articleData.isFavorited())
         .favoritesCount(articleData.getFavoritesCount())
         .slug(articleData.getSlug())
         .tagList(articleData.getTagList())
         .title(articleData.getTitle())
-        .updatedAt(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getUpdatedAt()))
+        .updatedAt(DateTimes.format(articleData.getUpdatedAt()))
         .build();
   }
 }

--- a/src/main/java/io/spring/graphql/CommentDatafetcher.java
+++ b/src/main/java/io/spring/graphql/CommentDatafetcher.java
@@ -7,6 +7,7 @@ import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
 import graphql.relay.DefaultConnectionCursor;
 import graphql.relay.DefaultPageInfo;
+import io.spring.DateTimes;
 import io.spring.application.CommentQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -25,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.format.ISODateTimeFormat;
 
 @DgsComponent
 @AllArgsConstructor
@@ -115,8 +115,8 @@ public class CommentDatafetcher {
     return Comment.newBuilder()
         .id(comment.getId())
         .body(comment.getBody())
-        .updatedAt(ISODateTimeFormat.dateTime().withZoneUTC().print(comment.getCreatedAt()))
-        .createdAt(ISODateTimeFormat.dateTime().withZoneUTC().print(comment.getCreatedAt()))
+        .updatedAt(DateTimes.format(comment.getCreatedAt()))
+        .createdAt(DateTimes.format(comment.getCreatedAt()))
         .build();
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -5,40 +5,40 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.TimeZone;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.MappedTypes;
 import org.apache.ibatis.type.TypeHandler;
-import org.joda.time.DateTime;
 
-@MappedTypes(DateTime.class)
-public class DateTimeHandler implements TypeHandler<DateTime> {
+@MappedTypes(Instant.class)
+public class DateTimeHandler implements TypeHandler<Instant> {
 
   private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
   @Override
-  public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
+  public void setParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.toEpochMilli()) : null, UTC_CALENDAR);
   }
 
   @Override
-  public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
+  public Instant getResult(ResultSet rs, String columnName) throws SQLException {
     Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
-    return timestamp != null ? new DateTime(timestamp.getTime()) : null;
+    return timestamp != null ? Instant.ofEpochMilli(timestamp.getTime()) : null;
   }
 
   @Override
-  public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
+  public Instant getResult(ResultSet rs, int columnIndex) throws SQLException {
     Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
-    return timestamp != null ? new DateTime(timestamp.getTime()) : null;
+    return timestamp != null ? Instant.ofEpochMilli(timestamp.getTime()) : null;
   }
 
   @Override
-  public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
+  public Instant getResult(CallableStatement cs, int columnIndex) throws SQLException {
     Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
-    return ts != null ? new DateTime(ts.getTime()) : null;
+    return ts != null ? Instant.ofEpochMilli(ts.getTime()) : null;
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,38 @@ import org.apache.ibatis.type.TypeHandler;
 @MappedTypes(Instant.class)
 public class DateTimeHandler implements TypeHandler<Instant> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  /**
+   * JDBC drivers mutate the supplied {@link Calendar} while converting timestamps, so each call
+   * gets its own instance rather than sharing one across request threads.
+   */
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
+  }
 
   @Override
   public void setParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.toEpochMilli()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.toEpochMilli()) : null, utcCalendar());
   }
 
   @Override
   public Instant getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar());
     return timestamp != null ? Instant.ofEpochMilli(timestamp.getTime()) : null;
   }
 
   @Override
   public Instant getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar());
     return timestamp != null ? Instant.ofEpochMilli(timestamp.getTime()) : null;
   }
 
   @Override
   public Instant getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar());
     return ts != null ? Instant.ofEpochMilli(ts.getTime()) : null;
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
@@ -2,10 +2,10 @@ package io.spring.infrastructure.mybatis.readservice;
 
 import io.spring.application.CursorPageParameter;
 import io.spring.application.data.CommentData;
+import java.time.Instant;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.joda.time.DateTime;
 
 @Mapper
 public interface CommentReadService {
@@ -14,5 +14,5 @@ public interface CommentReadService {
   List<CommentData> findByArticleId(@Param("articleId") String articleId);
 
   List<CommentData> findByArticleIdWithCursor(
-      @Param("articleId") String articleId, @Param("page") CursorPageParameter<DateTime> page);
+      @Param("articleId") String articleId, @Param("page") CursorPageParameter<Instant> page);
 }

--- a/src/test/java/io/spring/JacksonCustomizationsTest.java
+++ b/src/test/java/io/spring/JacksonCustomizationsTest.java
@@ -8,16 +8,25 @@ import io.spring.application.data.ProfileData;
 import java.time.Instant;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.annotation.Import;
 
 /**
  * Pins the wire format of serialized timestamps. The strings asserted here are exactly what the
  * previous Joda based serializer ({@code ISODateTimeFormat.dateTime().withZoneUTC()}) emitted.
+ *
+ * <p>Runs against the Boot built {@code ObjectMapper} on purpose: {@code JavaTimeModule} is on the
+ * classpath and registers its own {@code Instant} serializer, so this also pins that {@link
+ * JacksonCustomizations.RealWorldModules} wins that contest.
  */
+@JsonTest
+@Import(JacksonCustomizations.class)
 public class JacksonCustomizationsTest {
 
-  private final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JacksonCustomizations.RealWorldModules());
+  @Autowired private ObjectMapper objectMapper;
 
+  /** A zero millisecond instant is where {@code JavaTimeModule} would diverge (no {@code .000}). */
   @Test
   public void should_serialize_instant_as_iso8601_utc_with_millis() throws Exception {
     assertEquals(

--- a/src/test/java/io/spring/JacksonCustomizationsTest.java
+++ b/src/test/java/io/spring/JacksonCustomizationsTest.java
@@ -1,0 +1,77 @@
+package io.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.ProfileData;
+import java.time.Instant;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the wire format of serialized timestamps. The strings asserted here are exactly what the
+ * previous Joda based serializer ({@code ISODateTimeFormat.dateTime().withZoneUTC()}) emitted.
+ */
+public class JacksonCustomizationsTest {
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().registerModule(new JacksonCustomizations.RealWorldModules());
+
+  @Test
+  public void should_serialize_instant_as_iso8601_utc_with_millis() throws Exception {
+    assertEquals(
+        "\"2021-01-01T12:00:00.000Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00Z")));
+    assertEquals(
+        "\"2021-01-01T12:00:00.001Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.001Z")));
+    assertEquals(
+        "\"2021-01-01T12:00:00.100Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.1Z")));
+    assertEquals(
+        "\"2021-01-01T12:00:00.999Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.999Z")));
+    assertEquals("\"1970-01-01T00:00:00.000Z\"", objectMapper.writeValueAsString(Instant.EPOCH));
+    assertEquals(
+        "\"1969-12-31T23:59:59.999Z\"", objectMapper.writeValueAsString(Instant.ofEpochMilli(-1L)));
+  }
+
+  @Test
+  public void should_truncate_sub_millisecond_precision() throws Exception {
+    assertEquals(
+        "\"2021-01-01T12:00:00.123Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.123456789Z")));
+  }
+
+  @Test
+  public void should_serialize_null_instant_as_null() throws Exception {
+    assertEquals("null", objectMapper.writeValueAsString((Instant) null));
+  }
+
+  @Test
+  public void should_serialize_article_timestamps_in_realworld_format() throws Exception {
+    ArticleData articleData =
+        new ArticleData(
+            "id",
+            "a-title",
+            "a title",
+            "desc",
+            "body",
+            false,
+            0,
+            instant("2021-01-01T12:00:00Z"),
+            instant("2021-01-02T03:04:05.678Z"),
+            Arrays.asList("java"),
+            new ProfileData("uid", "user", "bio", "image", false));
+
+    String json = objectMapper.writeValueAsString(articleData);
+
+    assertEquals(true, json.contains("\"createdAt\":\"2021-01-01T12:00:00.000Z\""));
+    assertEquals(true, json.contains("\"updatedAt\":\"2021-01-02T03:04:05.678Z\""));
+  }
+
+  private static Instant instant(String iso) {
+    return Instant.parse(iso);
+  }
+}

--- a/src/test/java/io/spring/LombokAnnotationProcessingTest.java
+++ b/src/test/java/io/spring/LombokAnnotationProcessingTest.java
@@ -8,9 +8,9 @@ import io.spring.application.article.NewArticleParam;
 import io.spring.application.data.ArticleData;
 import io.spring.application.data.ProfileData;
 import io.spring.core.user.User;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -34,7 +34,7 @@ public class LombokAnnotationProcessingTest {
 
   @Test
   public void data_generates_constructors_accessors_and_value_semantics() {
-    DateTime now = new DateTime();
+    Instant now = DateTimes.now();
     ProfileData author = new ProfileData("authorId", "author", "bio", "image", true);
     ArticleData first =
         new ArticleData(
@@ -59,8 +59,8 @@ public class LombokAnnotationProcessingTest {
     second.setBody("body");
     second.setFavorited(true);
     second.setFavoritesCount(3);
-    second.setCreatedAt(new DateTime(now.getMillis()));
-    second.setUpdatedAt(new DateTime(now.getMillis()));
+    second.setCreatedAt(Instant.ofEpochMilli(now.toEpochMilli()));
+    second.setUpdatedAt(Instant.ofEpochMilli(now.toEpochMilli()));
     second.setTagList(Collections.singletonList("java"));
     second.setProfileData(new ProfileData("authorId", "author", "bio", "image", true));
 

--- a/src/test/java/io/spring/LombokAnnotationProcessingTest.java
+++ b/src/test/java/io/spring/LombokAnnotationProcessingTest.java
@@ -6,11 +6,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.spring.application.article.NewArticleParam;
 import io.spring.application.data.ArticleData;
+import io.spring.application.data.ProfileData;
 import io.spring.core.user.User;
 import java.util.Arrays;
 import java.util.Collections;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class LombokAnnotationProcessingTest {
 
@@ -33,6 +35,7 @@ public class LombokAnnotationProcessingTest {
   @Test
   public void data_generates_constructors_accessors_and_value_semantics() {
     DateTime now = new DateTime();
+    ProfileData author = new ProfileData("authorId", "author", "bio", "image", true);
     ArticleData first =
         new ArticleData(
             "id",
@@ -40,21 +43,24 @@ public class LombokAnnotationProcessingTest {
             "title",
             "desc",
             "body",
-            false,
-            0,
+            true,
+            3,
             now,
             now,
-            Collections.emptyList(),
-            null);
+            Collections.singletonList("java"),
+            author);
     ArticleData second = new ArticleData();
     second.setId("id");
     second.setSlug("slug");
     second.setTitle("title");
     second.setDescription("desc");
     second.setBody("body");
+    second.setFavorited(true);
+    second.setFavoritesCount(3);
     second.setCreatedAt(now);
     second.setUpdatedAt(now);
-    second.setTagList(Collections.emptyList());
+    second.setTagList(Collections.singletonList("java"));
+    second.setProfileData(author);
 
     assertThat(second, is(first));
     assertThat(second.hashCode(), is(first.hashCode()));
@@ -64,11 +70,15 @@ public class LombokAnnotationProcessingTest {
   @Test
   public void equals_and_hash_code_honour_explicit_field_selection() {
     User user = new User("email@test.com", "username", "123", "bio", "image");
-    User otherId = new User("email@test.com", "username", "123", "bio", "image");
+    User sameIdOnly = new User("other@test.com", "other", "456", "otherBio", "otherImage");
+    ReflectionTestUtils.setField(sameIdOnly, "id", user.getId());
+    User differentId = new User("email@test.com", "username", "123", "bio", "image");
 
     assertThat(user.getEmail(), is("email@test.com"));
     assertThat(user.getUsername(), is("username"));
-    assertThat(otherId.getId(), not(user.getId()));
-    assertThat(otherId, not(user));
+    assertThat(sameIdOnly, is(user));
+    assertThat(sameIdOnly.hashCode(), is(user.hashCode()));
+    assertThat(sameIdOnly.getEmail(), not(user.getEmail()));
+    assertThat(differentId, not(user));
   }
 }

--- a/src/test/java/io/spring/LombokAnnotationProcessingTest.java
+++ b/src/test/java/io/spring/LombokAnnotationProcessingTest.java
@@ -1,0 +1,74 @@
+package io.spring;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.data.ArticleData;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Collections;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+public class LombokAnnotationProcessingTest {
+
+  @Test
+  public void builder_and_getters_are_generated() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    assertThat(param.getTitle(), is("title"));
+    assertThat(param.getDescription(), is("desc"));
+    assertThat(param.getBody(), is("body"));
+    assertThat(param.getTagList(), is(Arrays.asList("java", "spring")));
+  }
+
+  @Test
+  public void data_generates_constructors_accessors_and_value_semantics() {
+    DateTime now = new DateTime();
+    ArticleData first =
+        new ArticleData(
+            "id",
+            "slug",
+            "title",
+            "desc",
+            "body",
+            false,
+            0,
+            now,
+            now,
+            Collections.emptyList(),
+            null);
+    ArticleData second = new ArticleData();
+    second.setId("id");
+    second.setSlug("slug");
+    second.setTitle("title");
+    second.setDescription("desc");
+    second.setBody("body");
+    second.setCreatedAt(now);
+    second.setUpdatedAt(now);
+    second.setTagList(Collections.emptyList());
+
+    assertThat(second, is(first));
+    assertThat(second.hashCode(), is(first.hashCode()));
+    assertThat(first.toString().contains("slug"), is(true));
+  }
+
+  @Test
+  public void equals_and_hash_code_honour_explicit_field_selection() {
+    User user = new User("email@test.com", "username", "123", "bio", "image");
+    User otherId = new User("email@test.com", "username", "123", "bio", "image");
+
+    assertThat(user.getEmail(), is("email@test.com"));
+    assertThat(user.getUsername(), is("username"));
+    assertThat(otherId.getId(), not(user.getId()));
+    assertThat(otherId, not(user));
+  }
+}

--- a/src/test/java/io/spring/LombokAnnotationProcessingTest.java
+++ b/src/test/java/io/spring/LombokAnnotationProcessingTest.java
@@ -49,6 +49,8 @@ public class LombokAnnotationProcessingTest {
             now,
             Collections.singletonList("java"),
             author);
+    // Every reference type is a distinct-but-equal instance so the generated equals/hashCode are
+    // forced to compare by value rather than by identity.
     ArticleData second = new ArticleData();
     second.setId("id");
     second.setSlug("slug");
@@ -57,10 +59,10 @@ public class LombokAnnotationProcessingTest {
     second.setBody("body");
     second.setFavorited(true);
     second.setFavoritesCount(3);
-    second.setCreatedAt(now);
-    second.setUpdatedAt(now);
+    second.setCreatedAt(new DateTime(now.getMillis()));
+    second.setUpdatedAt(new DateTime(now.getMillis()));
     second.setTagList(Collections.singletonList("java"));
-    second.setProfileData(author);
+    second.setProfileData(new ProfileData("authorId", "author", "bio", "image", true));
 
     assertThat(second, is(first));
     assertThat(second.hashCode(), is(first.hashCode()));

--- a/src/test/java/io/spring/TestHelper.java
+++ b/src/test/java/io/spring/TestHelper.java
@@ -4,13 +4,13 @@ import io.spring.application.data.ArticleData;
 import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
 import io.spring.core.user.User;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.joda.time.DateTime;
 
 public class TestHelper {
   public static ArticleData articleDataFixture(String seed, User user) {
-    DateTime now = new DateTime();
+    Instant now = DateTimes.now();
     return new ArticleData(
         seed + "id",
         "title-" + seed,

--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 
 import io.restassured.path.json.JsonPath;
 import io.restassured.path.xml.XmlPath;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
 import java.io.IOException;
@@ -37,24 +39,34 @@ class TestStackJdk17Test {
     assertTrue(
         running.isAtLeast(ClassFileVersion.JAVA_V17),
         "expected to run on JDK 17+, but byte-buddy sees " + running);
+    // Only trips when -Dnet.bytebuddy.experimental=true lets ofThisVm() report a version byte-buddy
+    // does not natively support; without the flag that case throws and is caught above.
     assertTrue(
         running.isAtMost(ClassFileVersion.latest()),
-        "byte-buddy only supports this JVM in experimental mode; bump net.bytebuddy:byte-buddy");
+        "byte-buddy supports this JVM only in experimental mode; bump net.bytebuddy:byte-buddy");
   }
 
   @Test
-  void mockitoShouldSubclassApplicationClassesCompiledForJava17() throws IOException {
+  void mockitoShouldMockApplicationTypesCompiledForJava17() throws IOException {
     ClassFileVersion compiled = ClassFileVersion.of(User.class);
     assertTrue(
         compiled.isAtLeast(ClassFileVersion.JAVA_V17),
         "expected application classes at Java 17+ bytecode, but found " + compiled);
 
-    UserRepository userRepository = mock(UserRepository.class);
     User user = new User("john@jacob.com", "johnjacob", "123", "", "");
-    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
 
+    UserRepository userRepository = mock(UserRepository.class);
+    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
     assertEquals(Optional.of(user), userRepository.findByUsername("johnjacob"));
     verify(userRepository).findByUsername("johnjacob");
+
+    // Subclassing a concrete class is the encapsulation-sensitive path: byte-buddy has to define
+    // the
+    // proxy against the target's own package rather than just implement an interface.
+    ArticleQueryService articleQueryService = mock(ArticleQueryService.class);
+    when(articleQueryService.findById(eq("article-id"), eq(user))).thenReturn(Optional.empty());
+    assertEquals(Optional.<ArticleData>empty(), articleQueryService.findById("article-id", user));
+    verify(articleQueryService).findById("article-id", user);
   }
 
   /**

--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -60,9 +60,8 @@ class TestStackJdk17Test {
     assertEquals(Optional.of(user), userRepository.findByUsername("johnjacob"));
     verify(userRepository).findByUsername("johnjacob");
 
-    // Subclassing a concrete class is the encapsulation-sensitive path: byte-buddy has to define
-    // the
-    // proxy against the target's own package rather than just implement an interface.
+    // Subclassing a concrete class is the encapsulation-sensitive path: byte-buddy defines the
+    // proxy against the target's own package instead of merely implementing an interface.
     ArticleQueryService articleQueryService = mock(ArticleQueryService.class);
     when(articleQueryService.findById(eq("article-id"), eq(user))).thenReturn(Optional.empty());
     assertEquals(Optional.<ArticleData>empty(), articleQueryService.findById("article-id", user));

--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -1,5 +1,6 @@
 package io.spring;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import net.bytebuddy.ClassFileVersion;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 
 /**
  * Guards the test stack itself against JDK strong encapsulation. Mockito mocks through byte-buddy
@@ -26,7 +28,12 @@ class TestStackJdk17Test {
 
   @Test
   void byteBuddyShouldSupportTheRunningJvmWithoutExperimentalMode() {
-    ClassFileVersion running = ClassFileVersion.ofThisVm();
+    // ofThisVm() throws rather than returning a sentinel when byte-buddy cannot map java.version,
+    // so the throwing case is folded in here to keep the "bump byte-buddy" hint on both paths.
+    ClassFileVersion running =
+        assertDoesNotThrow(
+            (ThrowingSupplier<ClassFileVersion>) ClassFileVersion::ofThisVm,
+            "byte-buddy does not recognise this JVM; bump net.bytebuddy:byte-buddy");
     assertTrue(
         running.isAtLeast(ClassFileVersion.JAVA_V17),
         "expected to run on JDK 17+, but byte-buddy sees " + running);
@@ -37,10 +44,10 @@ class TestStackJdk17Test {
 
   @Test
   void mockitoShouldSubclassApplicationClassesCompiledForJava17() throws IOException {
-    assertEquals(
-        ClassFileVersion.JAVA_V17,
-        ClassFileVersion.of(User.class),
-        "test assumes application classes are compiled for Java 17");
+    ClassFileVersion compiled = ClassFileVersion.of(User.class);
+    assertTrue(
+        compiled.isAtLeast(ClassFileVersion.JAVA_V17),
+        "expected application classes at Java 17+ bytecode, but found " + compiled);
 
     UserRepository userRepository = mock(UserRepository.class);
     User user = new User("john@jacob.com", "johnjacob", "123", "", "");

--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -1,0 +1,67 @@
+package io.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.restassured.path.json.JsonPath;
+import io.restassured.path.xml.XmlPath;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import net.bytebuddy.ClassFileVersion;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the test stack itself against JDK strong encapsulation. Mockito mocks through byte-buddy
+ * and rest-assured's JsonPath/XmlPath go through Groovy; both reach into areas the JDK
+ * progressively locks down, so a JDK bump can break them while production code stays fine.
+ */
+class TestStackJdk17Test {
+
+  @Test
+  void byteBuddyShouldSupportTheRunningJvmWithoutExperimentalMode() {
+    ClassFileVersion running = ClassFileVersion.ofThisVm();
+    assertTrue(
+        running.isAtLeast(ClassFileVersion.JAVA_V17),
+        "expected to run on JDK 17+, but byte-buddy sees " + running);
+    assertTrue(
+        running.isAtMost(ClassFileVersion.latest()),
+        "byte-buddy only supports this JVM in experimental mode; bump net.bytebuddy:byte-buddy");
+  }
+
+  @Test
+  void mockitoShouldSubclassApplicationClassesCompiledForJava17() throws IOException {
+    assertEquals(
+        ClassFileVersion.JAVA_V17,
+        ClassFileVersion.of(User.class),
+        "test assumes application classes are compiled for Java 17");
+
+    UserRepository userRepository = mock(UserRepository.class);
+    User user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
+
+    assertEquals(Optional.of(user), userRepository.findByUsername("johnjacob"));
+    verify(userRepository).findByUsername("johnjacob");
+  }
+
+  /**
+   * GPath evaluation compiles the expression to Groovy and dispatches it reflectively, so it is the
+   * part of rest-assured a JDK bump is most likely to break. The closure form is included because
+   * it exercises Groovy's runtime call site machinery rather than plain property access.
+   */
+  @Test
+  void restAssuredGroovyPathsShouldResolveUnderStrongEncapsulation() {
+    JsonPath json = new JsonPath("{\"user\":{\"username\":\"johnjacob\",\"followers\":[1,2,3]}}");
+    assertEquals("johnjacob", json.getString("user.username"));
+    assertEquals(List.of(2, 3), json.getList("user.followers.findAll { it > 1 }"));
+
+    XmlPath xml = new XmlPath("<user><username>johnjacob</username></user>");
+    assertEquals("johnjacob", xml.getString("user.username"));
+  }
+}

--- a/src/test/java/io/spring/api/ArticleApiTest.java
+++ b/src/test/java/io/spring/api/ArticleApiTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.DateTimes;
 import io.spring.JacksonCustomizations;
 import io.spring.TestHelper;
 import io.spring.api.security.WebSecurityConfig;
@@ -19,13 +20,12 @@ import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
 import io.spring.core.article.ArticleRepository;
 import io.spring.core.user.User;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +55,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
   @Test
   public void should_read_article_success() throws Exception {
     String slug = "test-new-article";
-    DateTime time = new DateTime();
+    Instant time = DateTimes.now();
     Article article =
         new Article(
             "Test New Article",
@@ -74,7 +74,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
         .statusCode(200)
         .body("article.slug", equalTo(slug))
         .body("article.body", equalTo(articleData.getBody()))
-        .body("article.createdAt", equalTo(ISODateTimeFormat.dateTime().withZoneUTC().print(time)));
+        .body("article.createdAt", equalTo(DateTimes.format(time)));
   }
 
   @Test
@@ -131,7 +131,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
         new Article(
             title, description, body, Arrays.asList("java", "spring", "jpg"), anotherUser.getId());
 
-    DateTime time = new DateTime();
+    Instant time = DateTimes.now();
     ArticleData articleData =
         new ArticleData(
             article.getId(),

--- a/src/test/java/io/spring/api/ArticlesApiTest.java
+++ b/src/test/java/io/spring/api/ArticlesApiTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.DateTimes;
 import io.spring.JacksonCustomizations;
 import io.spring.api.security.WebSecurityConfig;
 import io.spring.application.ArticleQueryService;
@@ -20,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,8 +63,8 @@ public class ArticlesApiTest extends TestWithCurrentUser {
             body,
             false,
             0,
-            new DateTime(),
-            new DateTime(),
+            DateTimes.now(),
+            DateTimes.now(),
             tagList,
             new ProfileData("userid", user.getUsername(), user.getBio(), user.getImage(), false));
 
@@ -132,8 +132,8 @@ public class ArticlesApiTest extends TestWithCurrentUser {
             body,
             false,
             0,
-            new DateTime(),
-            new DateTime(),
+            DateTimes.now(),
+            DateTimes.now(),
             asList(tagList),
             new ProfileData("userid", user.getUsername(), user.getBio(), user.getImage(), false));
 

--- a/src/test/java/io/spring/application/DateTimeCursorTest.java
+++ b/src/test/java/io/spring/application/DateTimeCursorTest.java
@@ -1,0 +1,57 @@
+package io.spring.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class DateTimeCursorTest {
+
+  @Test
+  public void should_encode_cursor_as_epoch_millis() {
+    assertEquals(
+        "1609502400000", new DateTimeCursor(Instant.parse("2021-01-01T12:00:00Z")).toString());
+  }
+
+  @Test
+  public void should_round_trip_cursor() {
+    Instant instant = Instant.parse("2021-01-01T12:00:00.123Z");
+    assertEquals(instant, DateTimeCursor.parse(new DateTimeCursor(instant).toString()));
+  }
+
+  @Test
+  public void should_parse_null_cursor_to_null() {
+    assertNull(DateTimeCursor.parse(null));
+  }
+
+  @Test
+  public void should_keep_cursor_ordering_consistent_with_instant_ordering() {
+    List<Instant> instants =
+        Arrays.asList(
+            Instant.parse("2021-01-01T12:00:00.001Z"),
+            Instant.parse("2021-01-01T12:00:00.000Z"),
+            Instant.parse("2020-06-05T04:03:02.100Z"),
+            Instant.parse("2021-01-01T12:00:01.000Z"));
+
+    List<Instant> byInstant =
+        instants.stream().sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+    List<Instant> byCursor =
+        instants.stream()
+            .sorted(
+                Comparator.comparingLong(
+                        (Instant i) -> Long.parseLong(new DateTimeCursor(i).toString()))
+                    .reversed())
+            .collect(Collectors.toList());
+
+    assertEquals(byInstant, byCursor);
+    assertTrue(
+        Long.parseLong(new DateTimeCursor(instants.get(0)).toString())
+            > Long.parseLong(new DateTimeCursor(instants.get(1)).toString()));
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
@@ -1,5 +1,6 @@
 package io.spring.application.article;
 
+import io.spring.DateTimes;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -19,9 +20,10 @@ import io.spring.infrastructure.DbTestBase;
 import io.spring.infrastructure.repository.MyBatisArticleFavoriteRepository;
 import io.spring.infrastructure.repository.MyBatisArticleRepository;
 import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +54,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
     userRepository.save(user);
     article =
         new Article(
-            "test", "desc", "body", Arrays.asList("java", "spring"), user.getId(), new DateTime());
+            "test", "desc", "body", Arrays.asList("java", "spring"), user.getId(), DateTimes.now());
     articleRepository.save(article);
   }
 
@@ -92,7 +94,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             "body",
             Arrays.asList("test"),
             user.getId(),
-            new DateTime().minusHours(1));
+            DateTimes.now().minus(1, ChronoUnit.HOURS));
     articleRepository.save(anotherArticle);
 
     ArticleDataList recentArticles =
@@ -116,7 +118,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             "body",
             Arrays.asList("test"),
             user.getId(),
-            new DateTime().minusHours(1));
+            DateTimes.now().minus(1, ChronoUnit.HOURS));
     articleRepository.save(anotherArticle);
 
     CursorPager<ArticleData> recentArticles =
@@ -130,7 +132,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             null,
             null,
             null,
-            new CursorPageParameter<DateTime>(
+            new CursorPageParameter<Instant>(
                 DateTimeCursor.parse(recentArticles.getEndCursor().toString()), 20, Direction.NEXT),
             user);
     Assertions.assertEquals(nodata.getData().size(), 0);

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -34,6 +34,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Guards the Netflix DGS codegen output against the GraphQL schema. The codegen plugin is
@@ -44,6 +45,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional
 public class DgsCodegenSchemaTest {
 
   private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
@@ -176,9 +178,6 @@ public class DgsCodegenSchemaTest {
 
   @Test
   public void datafetchersResolveAgainstTheGeneratedSchema() {
-    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
-    assertThat(tags).isNotNull();
-
     io.spring.core.user.User author =
         new io.spring.core.user.User(
             "dgs-codegen@example.com", "dgs-codegen-user", "password", "", "");
@@ -207,5 +206,8 @@ public class DgsCodegenSchemaTest {
     assertThat(article.getBody()).isEqualTo("body");
     assertThat(article.getTagList()).containsExactly("dgs-codegen");
     assertThat(article.getFavoritesCount()).isZero();
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+    assertThat(tags).contains("dgs-codegen");
   }
 }

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -21,17 +21,19 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Guards the Netflix DGS codegen output against the GraphQL schema. The codegen plugin is
@@ -39,7 +41,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * sources; these assertions fail loudly if the generated {@code io.spring.graphql.types} classes
  * stop matching {@code schema.graphqls}.
  */
+@ActiveProfiles("test")
 @SpringBootTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 public class DgsCodegenSchemaTest {
 
   private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
@@ -175,37 +179,33 @@ public class DgsCodegenSchemaTest {
     List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
     assertThat(tags).isNotNull();
 
-    // UserRepository has no delete, and the suite shares an on-disk database, so keep the seeded
-    // rows unique per run rather than colliding on the users/articles unique constraints.
-    String seed = UUID.randomUUID().toString().substring(0, 8);
-    String title = "DGS codegen round trip " + seed;
     io.spring.core.user.User author =
         new io.spring.core.user.User(
-            "dgs-codegen-" + seed + "@example.com", "dgs-codegen-" + seed, "password", "", "");
+            "dgs-codegen@example.com", "dgs-codegen-user", "password", "", "");
     userRepository.save(author);
     io.spring.core.article.Article seeded =
         new io.spring.core.article.Article(
-            title, "description", "body", List.of("dgs-codegen"), author.getId());
+            "DGS codegen round trip",
+            "description",
+            "body",
+            List.of("dgs-codegen"),
+            author.getId());
     articleRepository.save(seeded);
 
-    try {
-      // Deserializing into the generated Article proves the runtime response binds to the codegen
-      // output field-for-field, not merely that the query executed without errors.
-      Article article =
-          dgsQueryExecutor.executeAndExtractJsonPathAsObject(
-              String.format(
-                  "{ article(slug: \"%s\") { title slug description body tagList favorited"
-                      + " favoritesCount } }",
-                  seeded.getSlug()),
-              "data.article",
-              Article.class);
-      assertThat(article.getTitle()).isEqualTo(title);
-      assertThat(article.getSlug()).isEqualTo(seeded.getSlug());
-      assertThat(article.getBody()).isEqualTo("body");
-      assertThat(article.getTagList()).containsExactly("dgs-codegen");
-      assertThat(article.getFavoritesCount()).isZero();
-    } finally {
-      articleRepository.remove(seeded);
-    }
+    // Deserializing into the generated Article proves the runtime response binds to the codegen
+    // output field-for-field, not merely that the query executed without errors.
+    Article article =
+        dgsQueryExecutor.executeAndExtractJsonPathAsObject(
+            String.format(
+                "{ article(slug: \"%s\") { title slug description body tagList favorited"
+                    + " favoritesCount } }",
+                seeded.getSlug()),
+            "data.article",
+            Article.class);
+    assertThat(article.getTitle()).isEqualTo("DGS codegen round trip");
+    assertThat(article.getSlug()).isEqualTo(seeded.getSlug());
+    assertThat(article.getBody()).isEqualTo("body");
+    assertThat(article.getTagList()).containsExactly("dgs-codegen");
+    assertThat(article.getFavoritesCount()).isZero();
   }
 }

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -11,6 +11,9 @@ import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.Article;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
@@ -18,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +46,8 @@ public class DgsCodegenSchemaTest {
   private static final Set<String> DEFAULT_ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
+  @Autowired private ArticleRepository articleRepository;
+  @Autowired private UserRepository userRepository;
 
   /**
    * Datafetchers read the security context directly, which over HTTP always holds at least an
@@ -169,10 +175,37 @@ public class DgsCodegenSchemaTest {
     List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
     assertThat(tags).isNotNull();
 
-    List<Object> edges =
-        dgsQueryExecutor.executeAndExtractJsonPath(
-            "{ articles(first: 1) { edges { node { title slug } } pageInfo { hasNextPage } } }",
-            "data.articles.edges");
-    assertThat(edges).isNotNull();
+    // UserRepository has no delete, and the suite shares an on-disk database, so keep the seeded
+    // rows unique per run rather than colliding on the users/articles unique constraints.
+    String seed = UUID.randomUUID().toString().substring(0, 8);
+    String title = "DGS codegen round trip " + seed;
+    io.spring.core.user.User author =
+        new io.spring.core.user.User(
+            "dgs-codegen-" + seed + "@example.com", "dgs-codegen-" + seed, "password", "", "");
+    userRepository.save(author);
+    io.spring.core.article.Article seeded =
+        new io.spring.core.article.Article(
+            title, "description", "body", List.of("dgs-codegen"), author.getId());
+    articleRepository.save(seeded);
+
+    try {
+      // Deserializing into the generated Article proves the runtime response binds to the codegen
+      // output field-for-field, not merely that the query executed without errors.
+      Article article =
+          dgsQueryExecutor.executeAndExtractJsonPathAsObject(
+              String.format(
+                  "{ article(slug: \"%s\") { title slug description body tagList favorited"
+                      + " favoritesCount } }",
+                  seeded.getSlug()),
+              "data.article",
+              Article.class);
+      assertThat(article.getTitle()).isEqualTo(title);
+      assertThat(article.getSlug()).isEqualTo(seeded.getSlug());
+      assertThat(article.getBody()).isEqualTo("body");
+      assertThat(article.getTagList()).containsExactly("dgs-codegen");
+      assertThat(article.getFavoritesCount()).isZero();
+    } finally {
+      articleRepository.remove(seeded);
+    }
   }
 }

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -39,7 +39,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class DgsCodegenSchemaTest {
 
   private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
-  private static final Set<String> ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
+  private static final Set<String> DEFAULT_ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
 
@@ -71,6 +71,18 @@ public class DgsCodegenSchemaTest {
     }
   }
 
+  /** Operation roots have no generated type; read them from {@code schema { ... }} if declared. */
+  private static Set<String> rootTypeNames(TypeDefinitionRegistry registry) {
+    return registry
+        .schemaDefinition()
+        .map(
+            definition ->
+                definition.getOperationTypeDefinitions().stream()
+                    .map(operation -> operation.getTypeName().getName())
+                    .collect(Collectors.toSet()))
+        .orElse(DEFAULT_ROOT_TYPES);
+  }
+
   private static Class<?> generatedClass(String typeName) {
     try {
       return Class.forName(GENERATED_TYPES_PACKAGE + "." + typeName);
@@ -89,10 +101,12 @@ public class DgsCodegenSchemaTest {
 
   @Test
   public void everySchemaTypeHasAGeneratedClass() throws IOException {
+    TypeDefinitionRegistry registry = schema();
+    Set<String> rootTypes = rootTypeNames(registry);
     List<String> typeNames =
-        schema().types().values().stream()
+        registry.types().values().stream()
             .map(TypeDefinition::getName)
-            .filter(name -> !ROOT_TYPES.contains(name))
+            .filter(name -> !rootTypes.contains(name))
             .collect(Collectors.toList());
 
     assertThat(typeNames).isNotEmpty();
@@ -101,8 +115,10 @@ public class DgsCodegenSchemaTest {
 
   @Test
   public void generatedObjectTypesExposeEverySchemaField() throws IOException {
-    for (TypeDefinition<?> type : schema().types().values()) {
-      if (ROOT_TYPES.contains(type.getName())) {
+    TypeDefinitionRegistry registry = schema();
+    Set<String> rootTypes = rootTypeNames(registry);
+    for (TypeDefinition<?> type : registry.types().values()) {
+      if (rootTypes.contains(type.getName())) {
         continue;
       }
       if (type instanceof ObjectTypeDefinition) {

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -1,0 +1,162 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import graphql.language.FieldDefinition;
+import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputValueDefinition;
+import graphql.language.ObjectTypeDefinition;
+import graphql.language.TypeDefinition;
+import graphql.language.UnionTypeDefinition;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Guards the Netflix DGS codegen output against the GraphQL schema. The codegen plugin is
+ * Kotlin-based and runs in the Gradle JVM, so a toolchain change can silently stop producing
+ * sources; these assertions fail loudly if the generated {@code io.spring.graphql.types} classes
+ * stop matching {@code schema.graphqls}.
+ */
+@SpringBootTest
+public class DgsCodegenSchemaTest {
+
+  private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
+  private static final Set<String> ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  /**
+   * Datafetchers read the security context directly, which over HTTP always holds at least an
+   * anonymous token. In-process execution bypasses the filter chain, so populate it here.
+   */
+  @BeforeEach
+  public void setUpAnonymousAuthentication() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "dgs-codegen-test",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+
+  @AfterEach
+  public void clearAuthentication() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private static TypeDefinitionRegistry schema() throws IOException {
+    try (InputStreamReader reader =
+        new InputStreamReader(
+            new ClassPathResource("schema/schema.graphqls").getInputStream(),
+            StandardCharsets.UTF_8)) {
+      return new SchemaParser().parse(reader);
+    }
+  }
+
+  private static Class<?> generatedClass(String typeName) {
+    try {
+      return Class.forName(GENERATED_TYPES_PACKAGE + "." + typeName);
+    } catch (ClassNotFoundException e) {
+      throw new AssertionError(
+          "No generated class for schema type " + typeName + "; did generateJava run?", e);
+    }
+  }
+
+  private static Set<String> declaredFieldNames(Class<?> clazz) {
+    return Arrays.stream(clazz.getDeclaredFields())
+        .filter(field -> !field.isSynthetic())
+        .map(Field::getName)
+        .collect(Collectors.toSet());
+  }
+
+  @Test
+  public void everySchemaTypeHasAGeneratedClass() throws IOException {
+    List<String> typeNames =
+        schema().types().values().stream()
+            .map(TypeDefinition::getName)
+            .filter(name -> !ROOT_TYPES.contains(name))
+            .collect(Collectors.toList());
+
+    assertThat(typeNames).isNotEmpty();
+    typeNames.forEach(DgsCodegenSchemaTest::generatedClass);
+  }
+
+  @Test
+  public void generatedObjectTypesExposeEverySchemaField() throws IOException {
+    for (TypeDefinition<?> type : schema().types().values()) {
+      if (ROOT_TYPES.contains(type.getName())) {
+        continue;
+      }
+      if (type instanceof ObjectTypeDefinition) {
+        Set<String> generatedFields = declaredFieldNames(generatedClass(type.getName()));
+        List<String> schemaFields =
+            ((ObjectTypeDefinition) type)
+                .getFieldDefinitions().stream()
+                    .map(FieldDefinition::getName)
+                    .collect(Collectors.toList());
+        assertThat(generatedFields)
+            .as("generated fields of %s", type.getName())
+            .containsAll(schemaFields);
+      } else if (type instanceof InputObjectTypeDefinition) {
+        Set<String> generatedFields = declaredFieldNames(generatedClass(type.getName()));
+        List<String> schemaFields =
+            ((InputObjectTypeDefinition) type)
+                .getInputValueDefinitions().stream()
+                    .map(InputValueDefinition::getName)
+                    .collect(Collectors.toList());
+        assertThat(generatedFields)
+            .as("generated fields of %s", type.getName())
+            .containsAll(schemaFields);
+      }
+    }
+  }
+
+  @Test
+  public void generatedUnionMembersImplementTheUnionInterface() throws IOException {
+    for (TypeDefinition<?> type : schema().types().values()) {
+      if (!(type instanceof UnionTypeDefinition)) {
+        continue;
+      }
+      Class<?> unionClass = generatedClass(type.getName());
+      assertThat(unionClass.isInterface()).as("%s is an interface", type.getName()).isTrue();
+      ((UnionTypeDefinition) type)
+          .getMemberTypes().stream()
+              .map(graphql.language.TypeName.class::cast)
+              .forEach(
+                  member ->
+                      assertThat(unionClass.isAssignableFrom(generatedClass(member.getName())))
+                          .as("%s implements %s", member.getName(), type.getName())
+                          .isTrue());
+    }
+  }
+
+  @Test
+  public void datafetchersResolveAgainstTheGeneratedSchema() {
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+    assertThat(tags).isNotNull();
+
+    List<Object> edges =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ articles(first: 1) { edges { node { title slug } } pageInfo { hasNextPage } } }",
+            "data.articles.edges");
+    assertThat(edges).isNotNull();
+  }
+}

--- a/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
+++ b/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
@@ -53,13 +53,14 @@ public class DateTimeHandlerTest extends DbTestBase {
         new Article("stored at", "desc", "body", Arrays.asList("java"), user.getId(), createdAt);
     articleRepository.save(article);
 
-    jdbcTemplate.query(
-        "select created_at, updated_at from articles where id = ?",
-        rs -> {
-          assertEquals(1609502400123L, rs.getLong("created_at"));
-          assertEquals(1609502400123L, rs.getLong("updated_at"));
-        },
-        article.getId());
+    assertEquals(
+        1609502400123L,
+        jdbcTemplate.queryForObject(
+            "select created_at from articles where id = ?", Long.class, article.getId()));
+    assertEquals(
+        1609502400123L,
+        jdbcTemplate.queryForObject(
+            "select updated_at from articles where id = ?", Long.class, article.getId()));
 
     assertEquals(createdAt, articleRepository.findById(article.getId()).get().getCreatedAt());
   }

--- a/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
+++ b/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
@@ -1,0 +1,66 @@
+package io.spring.infrastructure.mybatis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisArticleRepository;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.time.Instant;
+import java.util.Arrays;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/** Pins the on-disk timestamp representation written by {@link DateTimeHandler}. */
+@Import({MyBatisArticleRepository.class, MyBatisUserRepository.class})
+public class DateTimeHandlerTest extends DbTestBase {
+
+  @Autowired private SqlSessionFactory sqlSessionFactory;
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @Autowired private ArticleRepository articleRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  /**
+   * Unlike Joda's {@code DateTime}, {@code Instant} has a built-in MyBatis handler that would
+   * silently write a different on-disk value. Our handler must win the registry lookup.
+   */
+  @Test
+  public void should_register_handler_for_instant() {
+    assertInstanceOf(
+        DateTimeHandler.class,
+        sqlSessionFactory
+            .getConfiguration()
+            .getTypeHandlerRegistry()
+            .getTypeHandler(Instant.class));
+  }
+
+  @Test
+  public void should_store_timestamps_as_epoch_millis() {
+    User user = new User("handler@test.com", "handler", "123", "", "");
+    userRepository.save(user);
+    Instant createdAt = Instant.ofEpochMilli(1609502400123L);
+    Article article =
+        new Article("stored at", "desc", "body", Arrays.asList("java"), user.getId(), createdAt);
+    articleRepository.save(article);
+
+    jdbcTemplate.query(
+        "select created_at, updated_at from articles where id = ?",
+        rs -> {
+          assertEquals(1609502400123L, rs.getLong("created_at"));
+          assertEquals(1609502400123L, rs.getLong("updated_at"));
+        },
+        article.getId());
+
+    assertEquals(createdAt, articleRepository.findById(article.getId()).get().getCreatedAt());
+  }
+}

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Java 11 → 17, staying on the Spring Boot 2.x line (no Jakarta / Boot 3 migration). `javax.*` imports and `WebSecurityConfig extends WebSecurityConfigurerAdapter` are untouched — verified: 21 files still import `javax.*`, zero `jakarta.*` references, and `WebSecurityConfig` / `application.properties` have a zero-line diff against `master`.

```diff
 plugins {
-    id 'org.springframework.boot' version '2.6.3'
+    id 'org.springframework.boot' version '2.7.18'
 }
-sourceCompatibility = '11'
-targetCompatibility = '11'
+java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }
-implementation 'joda-time:joda-time:2.10.13'
```

`io.spring.dependency-management 1.0.11.RELEASE` resolves fine against the 2.7.18 BOM — left as is. Wrapper bumped `gradle-7.4-bin.zip` → `gradle-7.6.4-bin.zip` (7.4 predates official JDK 17 toolchain provisioning support).

Two knock-on fixes from the JDK bump rather than deliberate changes:

- **New `gradle.properties`.** google-java-format (via Spotless) reaches into `com.sun.tools.javac.*`, which JDK 16+ strongly encapsulates, so `spotlessJava` died with `IllegalAccessError: ... module jdk.compiler does not export com.sun.tools.javac.parser`. `org.gradle.jvmargs` now passes the five `--add-exports` the formatter needs. Note this is daemon-global; the `test` task runs on the *toolchain* JVM and needed no flags (no `--add-opens` anywhere).
- **Spotless target `exclude 'build/**/*.*'`** (was only `build/generated/**` + `build/generated-examples/**`), so DGS-generated sources under other `build/` subdirectories aren't format-checked. `DefaultJwtServiceTest` picked up a one-line reflow once the formatter could actually run.

## Integrated follow-up work

Four parallel investigations landed here (#958, #959, #960, #961). **Three of the four found nothing to fix** — the 2.7.18 BOM already drags the JDK-17-sensitive libraries forward — so they contribute regression tests rather than version bumps:

| | Finding | Change |
|---|---|---|
| Lombok (#958) | BOM already resolves `1.18.30`, the first release with official JDK 17 support | test only |
| DGS codegen (#959) | codegen `5.0.6` + starter `4.9.21` generate and serve `/graphql` unchanged | test only |
| Test stack (#960) | mockito `4.5.1`, byte-buddy `1.12.23`, groovy `3.0.19` — no `--add-opens` needed | test only |
| Joda-Time (#961) | genuinely in use across 17 files | full refactor |

Those three deliberately left `build.gradle` alone: pinning versions the BOM already resolves would only restate it, while costing merge conflicts between four concurrent branches. Worth knowing that the DGS platform *prefers* pre-JDK-17 versions (`byte-buddy 1.10.20`, `mockito-core 3.3.3`) and loses to the BOM — those are weak constraints, so the safe versions are inherited rather than asserted.

### Joda-Time → `java.time`

The one substantive refactor. `org.joda.time.DateTime` → `java.time.Instant` across the datafetchers, MyBatis `DateTimeHandler`, `DateTimeCursor`, and the data classes, with the dependency dropped. Two traps it avoids:

- `DateTimeFormatter.ISO_INSTANT` would have silently changed the wire format (it emits variable fractional-second digits), so the format is pinned to `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` in a new `DateTimes` helper and diffed against Joda over 1M random timestamps.
- `Instant.now()` is µs-precision where Joda was ms, so `DateTimes.now()` truncates to millis — otherwise stored and serialized values would gain digits.

`JavaTimeModule` is also on the classpath and registers its own `Instant` serializer, so the format holds only by module-registration order; that ordering is now pinned by a test in both the Jackson and MyBatis registries.

## Verification on JDK 17

`./gradlew clean build` green — **88 tests, 0 failures, 0 errors**; compiled classes are major version 61.

Booted the jar against a **deleted-and-recreated** `dev.db` (Flyway applied 1 migration from scratch), then exercised the full stack:

```
POST /users       → 201, token issued
POST /articles    → 201  createdAt "2026-08-07T08:04:20.762Z"
GET  /articles    → 200  createdAt "2026-08-07T08:04:20.762Z"
GET  /tags        → 200  {"tags":["java17"]}
POST /graphql     → 200  createdAt "2026-08-07T08:04:20.762Z"
sqlite dev.db     → created_at = 1786089860762   (epoch millis, unchanged)
```

The identical millisecond value across REST, GraphQL, and the raw SQLite column is the check that matters for the Joda migration: three-digit fractional seconds preserved on the wire, epoch-millis integers preserved in the DB.

## Known issue

`security/snyk (Cognition-default)` fails with *"You have used your limit of private tests"* — an account quota message, not a finding against this diff. It fails identically on branches containing none of these changes.


Link to Devin session: https://app.devin.ai/sessions/2b81d21ed2a24fd89d282ba0a6e05db3
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/957?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->