### PR TITLE
test: prove Lombok annotation processing works on JDK 17 (no build.gradle change needed)

### DIFF
--- a/src/test/java/io/spring/LombokAnnotationProcessingTest.java
+++ b/src/test/java/io/spring/LombokAnnotationProcessingTest.java
@@ -6,11 +6,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.spring.application.article.NewArticleParam;
 import io.spring.application.data.ArticleData;
+import io.spring.application.data.ProfileData;
 import io.spring.core.user.User;
 import java.util.Arrays;
 import java.util.Collections;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class LombokAnnotationProcessingTest {
 
@@ -33,6 +35,7 @@ public class LombokAnnotationProcessingTest {
   @Test
   public void data_generates_constructors_accessors_and_value_semantics() {
     DateTime now = new DateTime();
+    ProfileData author = new ProfileData("authorId", "author", "bio", "image", true);
     ArticleData first =
         new ArticleData(
             "id",
@@ -40,21 +43,24 @@ public class LombokAnnotationProcessingTest {
             "title",
             "desc",
             "body",
-            false,
-            0,
+            true,
+            3,
             now,
             now,
-            Collections.emptyList(),
-            null);
+            Collections.singletonList("java"),
+            author);
     ArticleData second = new ArticleData();
     second.setId("id");
     second.setSlug("slug");
     second.setTitle("title");
     second.setDescription("desc");
     second.setBody("body");
+    second.setFavorited(true);
+    second.setFavoritesCount(3);
     second.setCreatedAt(now);
     second.setUpdatedAt(now);
-    second.setTagList(Collections.emptyList());
+    second.setTagList(Collections.singletonList("java"));
+    second.setProfileData(author);
 
     assertThat(second, is(first));
     assertThat(second.hashCode(), is(first.hashCode()));
@@ -64,11 +70,15 @@ public class LombokAnnotationProcessingTest {
   @Test
   public void equals_and_hash_code_honour_explicit_field_selection() {
     User user = new User("email@test.com", "username", "123", "bio", "image");
-    User otherId = new User("email@test.com", "username", "123", "bio", "image");
+    User sameIdOnly = new User("other@test.com", "other", "456", "otherBio", "otherImage");
+    ReflectionTestUtils.setField(sameIdOnly, "id", user.getId());
+    User differentId = new User("email@test.com", "username", "123", "bio", "image");
 
     assertThat(user.getEmail(), is("email@test.com"));
     assertThat(user.getUsername(), is("username"));
-    assertThat(otherId.getId(), not(user.getId()));
-    assertThat(otherId, not(user));
+    assertThat(sameIdOnly, is(user));
+    assertThat(sameIdOnly.hashCode(), is(user.hashCode()));
+    assertThat(sameIdOnly.getEmail(), not(user.getEmail()));
+    assertThat(differentId, not(user));
   }
 }

--- a/src/test/java/io/spring/LombokAnnotationProcessingTest.java
+++ b/src/test/java/io/spring/LombokAnnotationProcessingTest.java
@@ -1,0 +1,74 @@
+package io.spring;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.spring.application.article.NewArticleParam;
+import io.spring.application.data.ArticleData;
+import io.spring.core.user.User;
+import java.util.Arrays;
+import java.util.Collections;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+public class LombokAnnotationProcessingTest {
+
+  @Test
+  public void builder_and_getters_are_generated() {
+    NewArticleParam param =
+        NewArticleParam.builder()
+            .title("title")
+            .description("desc")
+            .body("body")
+            .tagList(Arrays.asList("java", "spring"))
+            .build();
+
+    assertThat(param.getTitle(), is("title"));
+    assertThat(param.getDescription(), is("desc"));
+    assertThat(param.getBody(), is("body"));
+    assertThat(param.getTagList(), is(Arrays.asList("java", "spring")));
+  }
+
+  @Test
+  public void data_generates_constructors_accessors_and_value_semantics() {
+    DateTime now = new DateTime();
+    ArticleData first =
+        new ArticleData(
+            "id",
+            "slug",
+            "title",
+            "desc",
+            "body",
+            false,
+            0,
+            now,
+            now,
+            Collections.emptyList(),
+            null);
+    ArticleData second = new ArticleData();
+    second.setId("id");
+    second.setSlug("slug");
+    second.setTitle("title");
+    second.setDescription("desc");
+    second.setBody("body");
+    second.setCreatedAt(now);
+    second.setUpdatedAt(now);
+    second.setTagList(Collections.emptyList());
+
+    assertThat(second, is(first));
+    assertThat(second.hashCode(), is(first.hashCode()));
+    assertThat(first.toString().contains("slug"), is(true));
+  }
+
+  @Test
+  public void equals_and_hash_code_honour_explicit_field_selection() {
+    User user = new User("email@test.com", "username", "123", "bio", "image");
+    User otherId = new User("email@test.com", "username", "123", "bio", "image");
+
+    assertThat(user.getEmail(), is("email@test.com"));
+    assertThat(user.getUsername(), is("username"));
+    assertThat(otherId.getId(), not(user.getId()));
+    assertThat(otherId, not(user));
+  }
+}


### PR DESCRIPTION
## Summary

**No `build.gradle` change was required.** The Spring Boot 2.7.18 BOM already manages Lombok at **1.18.30** — exactly the first version with official JDK 17+ support — so the unversioned declarations resolve correctly:

```
$ ./gradlew dependencyInsight --dependency lombok --configuration compileClasspath
org.projectlombok:lombok:1.18.30 (selected by rule)
org.projectlombok:lombok -> 1.18.30 \--- compileClasspath

$ ./gradlew dependencyInsight --dependency lombok --configuration annotationProcessor
org.projectlombok:lombok:1.18.30 (selected by rule)
```

`./gradlew clean compileJava --rerun-tasks` under JDK 17.0.13 emits **no** Lombok warnings and no `jdk.compiler` internal-access / `IllegalAccessError` complaints. The only javac notes are pre-existing (`deprecated API`, `unchecked` in `GraphQLCustomizeExceptionHandler`). Pinning an explicit version would only re-state what the BOM already resolves, and would add a `build.gradle` line that conflicts with sibling PRs — so it was deliberately skipped.

Generated members verified via `javap` on the compiled classes (`ArticleData.builder`-style builder on `NewArticleParam`, `@Data` accessors + `equals`/`hashCode` on `ArticleData`, `@EqualsAndHashCode(of = {"id"})` on `User`). Note: `ArticleData` uses `@Data`/`@NoArgsConstructor`/`@AllArgsConstructor`, not `@Builder`; `@Builder` lives on `NewArticleParam`/`UpdateUserParam`. There are no `@Slf4j` usages in the codebase.

The only change here is one new test that locks this in, so a future JDK or Boot bump that silently breaks annotation processing fails the suite instead of the build:

- `LombokAnnotationProcessingTest.builder_and_getters_are_generated` — `NewArticleParam.builder()...build()` chain plus `@Getter` accessors
- `..._data_generates_constructors_accessors_and_value_semantics` — `@AllArgsConstructor` / `@NoArgsConstructor` / setters / `equals` / `hashCode` / `toString` on `ArticleData`
- `..._equals_and_hash_code_honour_explicit_field_selection` — `User` instances with identical fields but distinct generated ids are unequal, proving `@EqualsAndHashCode(of = {"id"})` was processed

`./gradlew clean build` (including `spotlessCheck` and the full test suite) is green on JDK 17.


Link to Devin session: https://app.devin.ai/sessions/85e5c93663a64868b1e4c48eddca643c
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/958?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->