### PR TITLE
test: assert DGS codegen output matches the GraphQL schema on JDK 17

### DIFF
--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -34,6 +34,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Guards the Netflix DGS codegen output against the GraphQL schema. The codegen plugin is
@@ -44,6 +45,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional
 public class DgsCodegenSchemaTest {
 
   private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
@@ -176,9 +178,6 @@ public class DgsCodegenSchemaTest {
 
   @Test
   public void datafetchersResolveAgainstTheGeneratedSchema() {
-    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
-    assertThat(tags).isNotNull();
-
     io.spring.core.user.User author =
         new io.spring.core.user.User(
             "dgs-codegen@example.com", "dgs-codegen-user", "password", "", "");
@@ -207,5 +206,8 @@ public class DgsCodegenSchemaTest {
     assertThat(article.getBody()).isEqualTo("body");
     assertThat(article.getTagList()).containsExactly("dgs-codegen");
     assertThat(article.getFavoritesCount()).isZero();
+
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+    assertThat(tags).contains("dgs-codegen");
   }
 }

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -21,17 +21,19 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Guards the Netflix DGS codegen output against the GraphQL schema. The codegen plugin is
@@ -39,7 +41,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * sources; these assertions fail loudly if the generated {@code io.spring.graphql.types} classes
  * stop matching {@code schema.graphqls}.
  */
+@ActiveProfiles("test")
 @SpringBootTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 public class DgsCodegenSchemaTest {
 
   private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
@@ -175,37 +179,33 @@ public class DgsCodegenSchemaTest {
     List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
     assertThat(tags).isNotNull();
 
-    // UserRepository has no delete, and the suite shares an on-disk database, so keep the seeded
-    // rows unique per run rather than colliding on the users/articles unique constraints.
-    String seed = UUID.randomUUID().toString().substring(0, 8);
-    String title = "DGS codegen round trip " + seed;
     io.spring.core.user.User author =
         new io.spring.core.user.User(
-            "dgs-codegen-" + seed + "@example.com", "dgs-codegen-" + seed, "password", "", "");
+            "dgs-codegen@example.com", "dgs-codegen-user", "password", "", "");
     userRepository.save(author);
     io.spring.core.article.Article seeded =
         new io.spring.core.article.Article(
-            title, "description", "body", List.of("dgs-codegen"), author.getId());
+            "DGS codegen round trip",
+            "description",
+            "body",
+            List.of("dgs-codegen"),
+            author.getId());
     articleRepository.save(seeded);
 
-    try {
-      // Deserializing into the generated Article proves the runtime response binds to the codegen
-      // output field-for-field, not merely that the query executed without errors.
-      Article article =
-          dgsQueryExecutor.executeAndExtractJsonPathAsObject(
-              String.format(
-                  "{ article(slug: \"%s\") { title slug description body tagList favorited"
-                      + " favoritesCount } }",
-                  seeded.getSlug()),
-              "data.article",
-              Article.class);
-      assertThat(article.getTitle()).isEqualTo(title);
-      assertThat(article.getSlug()).isEqualTo(seeded.getSlug());
-      assertThat(article.getBody()).isEqualTo("body");
-      assertThat(article.getTagList()).containsExactly("dgs-codegen");
-      assertThat(article.getFavoritesCount()).isZero();
-    } finally {
-      articleRepository.remove(seeded);
-    }
+    // Deserializing into the generated Article proves the runtime response binds to the codegen
+    // output field-for-field, not merely that the query executed without errors.
+    Article article =
+        dgsQueryExecutor.executeAndExtractJsonPathAsObject(
+            String.format(
+                "{ article(slug: \"%s\") { title slug description body tagList favorited"
+                    + " favoritesCount } }",
+                seeded.getSlug()),
+            "data.article",
+            Article.class);
+    assertThat(article.getTitle()).isEqualTo("DGS codegen round trip");
+    assertThat(article.getSlug()).isEqualTo(seeded.getSlug());
+    assertThat(article.getBody()).isEqualTo("body");
+    assertThat(article.getTagList()).containsExactly("dgs-codegen");
+    assertThat(article.getFavoritesCount()).isZero();
   }
 }

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -11,6 +11,9 @@ import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.UserRepository;
+import io.spring.graphql.types.Article;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
@@ -18,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +46,8 @@ public class DgsCodegenSchemaTest {
   private static final Set<String> DEFAULT_ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
+  @Autowired private ArticleRepository articleRepository;
+  @Autowired private UserRepository userRepository;
 
   /**
    * Datafetchers read the security context directly, which over HTTP always holds at least an
@@ -169,10 +175,37 @@ public class DgsCodegenSchemaTest {
     List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
     assertThat(tags).isNotNull();
 
-    List<Object> edges =
-        dgsQueryExecutor.executeAndExtractJsonPath(
-            "{ articles(first: 1) { edges { node { title slug } } pageInfo { hasNextPage } } }",
-            "data.articles.edges");
-    assertThat(edges).isNotNull();
+    // UserRepository has no delete, and the suite shares an on-disk database, so keep the seeded
+    // rows unique per run rather than colliding on the users/articles unique constraints.
+    String seed = UUID.randomUUID().toString().substring(0, 8);
+    String title = "DGS codegen round trip " + seed;
+    io.spring.core.user.User author =
+        new io.spring.core.user.User(
+            "dgs-codegen-" + seed + "@example.com", "dgs-codegen-" + seed, "password", "", "");
+    userRepository.save(author);
+    io.spring.core.article.Article seeded =
+        new io.spring.core.article.Article(
+            title, "description", "body", List.of("dgs-codegen"), author.getId());
+    articleRepository.save(seeded);
+
+    try {
+      // Deserializing into the generated Article proves the runtime response binds to the codegen
+      // output field-for-field, not merely that the query executed without errors.
+      Article article =
+          dgsQueryExecutor.executeAndExtractJsonPathAsObject(
+              String.format(
+                  "{ article(slug: \"%s\") { title slug description body tagList favorited"
+                      + " favoritesCount } }",
+                  seeded.getSlug()),
+              "data.article",
+              Article.class);
+      assertThat(article.getTitle()).isEqualTo(title);
+      assertThat(article.getSlug()).isEqualTo(seeded.getSlug());
+      assertThat(article.getBody()).isEqualTo("body");
+      assertThat(article.getTagList()).containsExactly("dgs-codegen");
+      assertThat(article.getFavoritesCount()).isZero();
+    } finally {
+      articleRepository.remove(seeded);
+    }
   }
 }

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -39,7 +39,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class DgsCodegenSchemaTest {
 
   private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
-  private static final Set<String> ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
+  private static final Set<String> DEFAULT_ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
 
   @Autowired private DgsQueryExecutor dgsQueryExecutor;
 
@@ -71,6 +71,18 @@ public class DgsCodegenSchemaTest {
     }
   }
 
+  /** Operation roots have no generated type; read them from {@code schema { ... }} if declared. */
+  private static Set<String> rootTypeNames(TypeDefinitionRegistry registry) {
+    return registry
+        .schemaDefinition()
+        .map(
+            definition ->
+                definition.getOperationTypeDefinitions().stream()
+                    .map(operation -> operation.getTypeName().getName())
+                    .collect(Collectors.toSet()))
+        .orElse(DEFAULT_ROOT_TYPES);
+  }
+
   private static Class<?> generatedClass(String typeName) {
     try {
       return Class.forName(GENERATED_TYPES_PACKAGE + "." + typeName);
@@ -89,10 +101,12 @@ public class DgsCodegenSchemaTest {
 
   @Test
   public void everySchemaTypeHasAGeneratedClass() throws IOException {
+    TypeDefinitionRegistry registry = schema();
+    Set<String> rootTypes = rootTypeNames(registry);
     List<String> typeNames =
-        schema().types().values().stream()
+        registry.types().values().stream()
             .map(TypeDefinition::getName)
-            .filter(name -> !ROOT_TYPES.contains(name))
+            .filter(name -> !rootTypes.contains(name))
             .collect(Collectors.toList());
 
     assertThat(typeNames).isNotEmpty();
@@ -101,8 +115,10 @@ public class DgsCodegenSchemaTest {
 
   @Test
   public void generatedObjectTypesExposeEverySchemaField() throws IOException {
-    for (TypeDefinition<?> type : schema().types().values()) {
-      if (ROOT_TYPES.contains(type.getName())) {
+    TypeDefinitionRegistry registry = schema();
+    Set<String> rootTypes = rootTypeNames(registry);
+    for (TypeDefinition<?> type : registry.types().values()) {
+      if (rootTypes.contains(type.getName())) {
         continue;
       }
       if (type instanceof ObjectTypeDefinition) {

--- a/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
+++ b/src/test/java/io/spring/graphql/DgsCodegenSchemaTest.java
@@ -1,0 +1,162 @@
+package io.spring.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import graphql.language.FieldDefinition;
+import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputValueDefinition;
+import graphql.language.ObjectTypeDefinition;
+import graphql.language.TypeDefinition;
+import graphql.language.UnionTypeDefinition;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Guards the Netflix DGS codegen output against the GraphQL schema. The codegen plugin is
+ * Kotlin-based and runs in the Gradle JVM, so a toolchain change can silently stop producing
+ * sources; these assertions fail loudly if the generated {@code io.spring.graphql.types} classes
+ * stop matching {@code schema.graphqls}.
+ */
+@SpringBootTest
+public class DgsCodegenSchemaTest {
+
+  private static final String GENERATED_TYPES_PACKAGE = "io.spring.graphql.types";
+  private static final Set<String> ROOT_TYPES = Set.of("Query", "Mutation", "Subscription");
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  /**
+   * Datafetchers read the security context directly, which over HTTP always holds at least an
+   * anonymous token. In-process execution bypasses the filter chain, so populate it here.
+   */
+  @BeforeEach
+  public void setUpAnonymousAuthentication() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "dgs-codegen-test",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+
+  @AfterEach
+  public void clearAuthentication() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private static TypeDefinitionRegistry schema() throws IOException {
+    try (InputStreamReader reader =
+        new InputStreamReader(
+            new ClassPathResource("schema/schema.graphqls").getInputStream(),
+            StandardCharsets.UTF_8)) {
+      return new SchemaParser().parse(reader);
+    }
+  }
+
+  private static Class<?> generatedClass(String typeName) {
+    try {
+      return Class.forName(GENERATED_TYPES_PACKAGE + "." + typeName);
+    } catch (ClassNotFoundException e) {
+      throw new AssertionError(
+          "No generated class for schema type " + typeName + "; did generateJava run?", e);
+    }
+  }
+
+  private static Set<String> declaredFieldNames(Class<?> clazz) {
+    return Arrays.stream(clazz.getDeclaredFields())
+        .filter(field -> !field.isSynthetic())
+        .map(Field::getName)
+        .collect(Collectors.toSet());
+  }
+
+  @Test
+  public void everySchemaTypeHasAGeneratedClass() throws IOException {
+    List<String> typeNames =
+        schema().types().values().stream()
+            .map(TypeDefinition::getName)
+            .filter(name -> !ROOT_TYPES.contains(name))
+            .collect(Collectors.toList());
+
+    assertThat(typeNames).isNotEmpty();
+    typeNames.forEach(DgsCodegenSchemaTest::generatedClass);
+  }
+
+  @Test
+  public void generatedObjectTypesExposeEverySchemaField() throws IOException {
+    for (TypeDefinition<?> type : schema().types().values()) {
+      if (ROOT_TYPES.contains(type.getName())) {
+        continue;
+      }
+      if (type instanceof ObjectTypeDefinition) {
+        Set<String> generatedFields = declaredFieldNames(generatedClass(type.getName()));
+        List<String> schemaFields =
+            ((ObjectTypeDefinition) type)
+                .getFieldDefinitions().stream()
+                    .map(FieldDefinition::getName)
+                    .collect(Collectors.toList());
+        assertThat(generatedFields)
+            .as("generated fields of %s", type.getName())
+            .containsAll(schemaFields);
+      } else if (type instanceof InputObjectTypeDefinition) {
+        Set<String> generatedFields = declaredFieldNames(generatedClass(type.getName()));
+        List<String> schemaFields =
+            ((InputObjectTypeDefinition) type)
+                .getInputValueDefinitions().stream()
+                    .map(InputValueDefinition::getName)
+                    .collect(Collectors.toList());
+        assertThat(generatedFields)
+            .as("generated fields of %s", type.getName())
+            .containsAll(schemaFields);
+      }
+    }
+  }
+
+  @Test
+  public void generatedUnionMembersImplementTheUnionInterface() throws IOException {
+    for (TypeDefinition<?> type : schema().types().values()) {
+      if (!(type instanceof UnionTypeDefinition)) {
+        continue;
+      }
+      Class<?> unionClass = generatedClass(type.getName());
+      assertThat(unionClass.isInterface()).as("%s is an interface", type.getName()).isTrue();
+      ((UnionTypeDefinition) type)
+          .getMemberTypes().stream()
+              .map(graphql.language.TypeName.class::cast)
+              .forEach(
+                  member ->
+                      assertThat(unionClass.isAssignableFrom(generatedClass(member.getName())))
+                          .as("%s implements %s", member.getName(), type.getName())
+                          .isTrue());
+    }
+  }
+
+  @Test
+  public void datafetchersResolveAgainstTheGeneratedSchema() {
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+    assertThat(tags).isNotNull();
+
+    List<Object> edges =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            "{ articles(first: 1) { edges { node { title slug } } pageInfo { hasNextPage } } }",
+            "data.articles.edges");
+    assertThat(edges).isNotNull();
+  }
+}


### PR DESCRIPTION
## Summary

**No production change was required.** Netflix DGS codegen `5.0.6` and `graphql-dgs-spring-boot-starter:4.9.21` both work as-is under the JDK 17 toolchain — no `Unsupported class file major version`, no Kotlin metadata error, no `IllegalAccessError`. No version was bumped; `build.gradle` is untouched.

This PR adds only a regression test, because the failure mode this task was guarding against is silent: `generateJava` can stop emitting types (or emit a subset) without failing the build, and the hand-written datafetchers would only break later. `DgsCodegenSchemaTest` parses `src/main/resources/schema/schema.graphqls` with graphql-java's `SchemaParser` (already on the classpath via DGS) and asserts against the codegen output by reflection, so it stays correct as the schema evolves rather than hard-coding a type list:

```java
rootTypeNames(registry)                // read from `schema { query: ... mutation: ... }`
registry.types()                       // every non-root TypeDefinition
  -> Class.forName("io.spring.graphql.types." + name)          // a class exists
  -> declaredFieldNames(clazz).containsAll(schemaFieldNames)   // fields line up
UnionTypeDefinition -> unionClass.isInterface() && members implement it
```

The runtime test seeds an article and asserts it round-trips back out deserialized into the generated type, so it fails on any codegen/datafetcher mismatch rather than merely on a thrown GraphQL error:

```java
Article article = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
    "{ article(slug: \"...\") { title slug description body tagList favorited favoritesCount } }",
    "data.article", Article.class);
assertThat(article.getTagList()).containsExactly("dgs-codegen");
assertThat(tags).contains("dgs-codegen");   // `{ tags }`, queried after seeding
```

Three non-obvious details:

- The datafetchers call `SecurityUtil.getCurrentUser()`, which dereferences `SecurityContextHolder.getContext().getAuthentication()` without a null check. Over HTTP the filter chain always installs at least an `AnonymousAuthenticationToken`, but `DgsQueryExecutor` executes in-process and bypasses the filter chain, so the test's `@BeforeEach` installs an anonymous token to reproduce real unauthenticated request conditions (rather than changing `SecurityUtil`, which is out of scope here).
- Binding the *connection* type is not possible: codegen maps `ArticlesConnection.pageInfo` to the abstract `graphql.relay.PageInfo`, which Jackson cannot construct. Binding the `Article` node is the equivalent assertion that does work.
- The test carries `@ActiveProfiles("test")` + `@AutoConfigureTestDatabase(replace = NONE)` (matching `ArticleRepositoryTransactionTest`) so its writes go to `jdbc:sqlite::memory:` instead of the on-disk `dev.db`, plus `@Transactional` so they roll back. Both matter: `articleRepository.remove(...)` does not delete the associated `tags` row and `UserRepository` has no delete at all, so explicit cleanup cannot fully undo the fixture. `@Transactional` additionally pins one pooled connection to the test thread, which an in-memory SQLite datasource needs for the seed writes and the GraphQL reads to see the same database.

## Verification

- `./gradlew clean generateJava` — BUILD SUCCESSFUL on JDK 17.
- `./gradlew compileJava` — generated sources under `build/generated` compile; hand-written `io.spring.graphql.**` datafetchers/mutations compile against them.
- Generated `io.spring.graphql.types.*` covers all 21 non-root schema types (`Article`, `ArticleEdge`, `ArticlesConnection`, `Comment`, ..., `UserResult`).
- `./gradlew clean build` — BUILD SUCCESSFUL (tests + `spotlessCheck`); the test also passes on repeated `--rerun-tasks` runs.
- Confirmed the suite leaves `dev.db` untouched, running `./gradlew test` from a deleted database before and after the profile fix:

```
before:  users 1   articles 0   tags 1     # article removed, user + tag leaked
after:   users 0   articles 0   tags 0
```

- Confirmed the rollback with a throwaway probe test (not committed) asserting the seeded article is invisible to a sibling test class sharing the cached context, having checked the JUnit XML timestamps to be sure it ran *after* the seeding test:

```
with @Transactional:      BUILD SUCCESSFUL (5 tests)
without @Transactional:   RollbackProbeTest > seededArticleFromDgsTestIsNotVisible() FAILED
```

- Ran the jar and exercised the real endpoint:

```
POST /graphql {"query":"{ articles(first: 5) { edges { node { title slug tagList author { username } } } } tags }"}
-> {"data":{"articles":{"edges":[{"node":{"title":"DGS codegen on JDK 17","slug":"dgs-codegen-on-jdk-17","tagList":["jdk17"],"author":{"username":"dgsuser"}}}]},"tags":["jdk17"]}}

POST /graphql mutation createArticle(...)
-> {"data":{"createArticle":{"article":{"slug":"dgs-codegen-on-jdk-17",...}}}}
```

- Dependency check: `runtimeClasspath` pulls only `jakarta.annotation-api:1.3.5` / `jakarta.validation-api:2.0.2`, which are the Java-EE-8 `javax.*`-namespace artifacts shipped by Spring Boot 2.7 — no Jakarta EE 9 / Boot 3 transitives.

## CI note

`security/snyk` fails with `You have used your limit of private tests` — an account quota, not a code finding. The same check fails identically on the base PR #957, which contains none of this PR's changes.


Link to Devin session: https://app.devin.ai/sessions/0693033cdbff42d1add10b252740599a
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/959?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->