### PR TITLE
test: prove Mockito/byte-buddy and rest-assured work on JDK 17 (no fix needed)

### DIFF
--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 
 import io.restassured.path.json.JsonPath;
 import io.restassured.path.xml.XmlPath;
+import io.spring.application.ArticleQueryService;
+import io.spring.application.data.ArticleData;
 import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
 import java.io.IOException;
@@ -37,24 +39,34 @@ class TestStackJdk17Test {
     assertTrue(
         running.isAtLeast(ClassFileVersion.JAVA_V17),
         "expected to run on JDK 17+, but byte-buddy sees " + running);
+    // Only trips when -Dnet.bytebuddy.experimental=true lets ofThisVm() report a version byte-buddy
+    // does not natively support; without the flag that case throws and is caught above.
     assertTrue(
         running.isAtMost(ClassFileVersion.latest()),
-        "byte-buddy only supports this JVM in experimental mode; bump net.bytebuddy:byte-buddy");
+        "byte-buddy supports this JVM only in experimental mode; bump net.bytebuddy:byte-buddy");
   }
 
   @Test
-  void mockitoShouldSubclassApplicationClassesCompiledForJava17() throws IOException {
+  void mockitoShouldMockApplicationTypesCompiledForJava17() throws IOException {
     ClassFileVersion compiled = ClassFileVersion.of(User.class);
     assertTrue(
         compiled.isAtLeast(ClassFileVersion.JAVA_V17),
         "expected application classes at Java 17+ bytecode, but found " + compiled);
 
-    UserRepository userRepository = mock(UserRepository.class);
     User user = new User("john@jacob.com", "johnjacob", "123", "", "");
-    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
 
+    UserRepository userRepository = mock(UserRepository.class);
+    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
     assertEquals(Optional.of(user), userRepository.findByUsername("johnjacob"));
     verify(userRepository).findByUsername("johnjacob");
+
+    // Subclassing a concrete class is the encapsulation-sensitive path: byte-buddy has to define
+    // the
+    // proxy against the target's own package rather than just implement an interface.
+    ArticleQueryService articleQueryService = mock(ArticleQueryService.class);
+    when(articleQueryService.findById(eq("article-id"), eq(user))).thenReturn(Optional.empty());
+    assertEquals(Optional.<ArticleData>empty(), articleQueryService.findById("article-id", user));
+    verify(articleQueryService).findById("article-id", user);
   }
 
   /**

--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -60,9 +60,8 @@ class TestStackJdk17Test {
     assertEquals(Optional.of(user), userRepository.findByUsername("johnjacob"));
     verify(userRepository).findByUsername("johnjacob");
 
-    // Subclassing a concrete class is the encapsulation-sensitive path: byte-buddy has to define
-    // the
-    // proxy against the target's own package rather than just implement an interface.
+    // Subclassing a concrete class is the encapsulation-sensitive path: byte-buddy defines the
+    // proxy against the target's own package instead of merely implementing an interface.
     ArticleQueryService articleQueryService = mock(ArticleQueryService.class);
     when(articleQueryService.findById(eq("article-id"), eq(user))).thenReturn(Optional.empty());
     assertEquals(Optional.<ArticleData>empty(), articleQueryService.findById("article-id", user));

--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -1,5 +1,6 @@
 package io.spring;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import net.bytebuddy.ClassFileVersion;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 
 /**
  * Guards the test stack itself against JDK strong encapsulation. Mockito mocks through byte-buddy
@@ -26,7 +28,12 @@ class TestStackJdk17Test {
 
   @Test
   void byteBuddyShouldSupportTheRunningJvmWithoutExperimentalMode() {
-    ClassFileVersion running = ClassFileVersion.ofThisVm();
+    // ofThisVm() throws rather than returning a sentinel when byte-buddy cannot map java.version,
+    // so the throwing case is folded in here to keep the "bump byte-buddy" hint on both paths.
+    ClassFileVersion running =
+        assertDoesNotThrow(
+            (ThrowingSupplier<ClassFileVersion>) ClassFileVersion::ofThisVm,
+            "byte-buddy does not recognise this JVM; bump net.bytebuddy:byte-buddy");
     assertTrue(
         running.isAtLeast(ClassFileVersion.JAVA_V17),
         "expected to run on JDK 17+, but byte-buddy sees " + running);
@@ -37,10 +44,10 @@ class TestStackJdk17Test {
 
   @Test
   void mockitoShouldSubclassApplicationClassesCompiledForJava17() throws IOException {
-    assertEquals(
-        ClassFileVersion.JAVA_V17,
-        ClassFileVersion.of(User.class),
-        "test assumes application classes are compiled for Java 17");
+    ClassFileVersion compiled = ClassFileVersion.of(User.class);
+    assertTrue(
+        compiled.isAtLeast(ClassFileVersion.JAVA_V17),
+        "expected application classes at Java 17+ bytecode, but found " + compiled);
 
     UserRepository userRepository = mock(UserRepository.class);
     User user = new User("john@jacob.com", "johnjacob", "123", "", "");

--- a/src/test/java/io/spring/TestStackJdk17Test.java
+++ b/src/test/java/io/spring/TestStackJdk17Test.java
@@ -1,0 +1,67 @@
+package io.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.restassured.path.json.JsonPath;
+import io.restassured.path.xml.XmlPath;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import net.bytebuddy.ClassFileVersion;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the test stack itself against JDK strong encapsulation. Mockito mocks through byte-buddy
+ * and rest-assured's JsonPath/XmlPath go through Groovy; both reach into areas the JDK
+ * progressively locks down, so a JDK bump can break them while production code stays fine.
+ */
+class TestStackJdk17Test {
+
+  @Test
+  void byteBuddyShouldSupportTheRunningJvmWithoutExperimentalMode() {
+    ClassFileVersion running = ClassFileVersion.ofThisVm();
+    assertTrue(
+        running.isAtLeast(ClassFileVersion.JAVA_V17),
+        "expected to run on JDK 17+, but byte-buddy sees " + running);
+    assertTrue(
+        running.isAtMost(ClassFileVersion.latest()),
+        "byte-buddy only supports this JVM in experimental mode; bump net.bytebuddy:byte-buddy");
+  }
+
+  @Test
+  void mockitoShouldSubclassApplicationClassesCompiledForJava17() throws IOException {
+    assertEquals(
+        ClassFileVersion.JAVA_V17,
+        ClassFileVersion.of(User.class),
+        "test assumes application classes are compiled for Java 17");
+
+    UserRepository userRepository = mock(UserRepository.class);
+    User user = new User("john@jacob.com", "johnjacob", "123", "", "");
+    when(userRepository.findByUsername(eq("johnjacob"))).thenReturn(Optional.of(user));
+
+    assertEquals(Optional.of(user), userRepository.findByUsername("johnjacob"));
+    verify(userRepository).findByUsername("johnjacob");
+  }
+
+  /**
+   * GPath evaluation compiles the expression to Groovy and dispatches it reflectively, so it is the
+   * part of rest-assured a JDK bump is most likely to break. The closure form is included because
+   * it exercises Groovy's runtime call site machinery rather than plain property access.
+   */
+  @Test
+  void restAssuredGroovyPathsShouldResolveUnderStrongEncapsulation() {
+    JsonPath json = new JsonPath("{\"user\":{\"username\":\"johnjacob\",\"followers\":[1,2,3]}}");
+    assertEquals("johnjacob", json.getString("user.username"));
+    assertEquals(List.of(2, 3), json.getList("user.followers.findAll { it > 1 }"));
+
+    XmlPath xml = new XmlPath("<user><username>johnjacob</username></user>");
+    assertEquals("johnjacob", xml.getString("user.username"));
+  }
+}


### PR DESCRIPTION
## Summary

**No fix was required — the test stack already works on JDK 17.** This PR adds only the regression test that proves it, so a future dependency or JDK change can't silently break mocking or rest-assured's Groovy paths. No `build.gradle` / `gradle.properties` changes and no `--add-opens` test JVM args, so this contributes zero merge-conflict surface for the sibling JDK 17 PRs.

The Java 17 baseline runs the full suite green: **68 tests, 0 failures, 0 errors, 0 skipped, all 20 test classes executing**. Every `system-err` block in `build/test-results/test/*.xml` is empty and the build log contains no `illegal reflective access`, `InaccessibleObjectException`, byte-buddy `experimental`, or self-attach warnings.

### Why it works: the BOM upgrades the risky libraries for us

`dependencyInsight ... --configuration testRuntimeClasspath` shows the DGS platform *wants* versions that predate JDK 17, and the Spring Boot 2.7.18 BOM overrides them:

```
net.bytebuddy:byte-buddy:{prefer 1.10.20} -> 1.12.23   (via graphql-dgs-platform-dependencies:4.3.1)
net.bytebuddy:byte-buddy:1.12.9           -> 1.12.23   (via mockito-core:4.5.1)
org.mockito:mockito-core:{prefer 3.3.3}   -> 4.5.1
org.codehaus.groovy:groovy:3.0.9          -> 3.0.19    (rest-assured 4.5.1 asks for 3.0.9)
```

Resolved: **mockito-core 4.5.1**, **byte-buddy / byte-buddy-agent 1.12.23**, **groovy 3.0.19**. byte-buddy 1.12.23 reports `ofThisVm() = Java 17 (61)` with `latest() = Java 20 (64)`, so JDK 17 is inside its supported range, not experimental fallback. Mockito 4.x supports JDK 17 (Mockito 5 is where the *minimum* moves to Java 11).

Those DGS `prefer` constraints are the fragility here: they are weak and lose to the BOM today, but they mean the JDK-17-safe versions are inherited rather than asserted anywhere.

### What the test asserts

`TestStackJdk17Test` covers the three things that break first when the JDK tightens encapsulation:

```java
// 1. byte-buddy actually knows this JVM, rather than throwing or falling back to experimental mode
assertDoesNotThrow(ClassFileVersion::ofThisVm).isAtLeast(JAVA_V17) && .isAtMost(latest())

// 2. Mockito can proxy an interface AND subclass a concrete class at class-file version 61
assertTrue(ClassFileVersion.of(User.class).isAtLeast(JAVA_V17));
mock(UserRepository.class)      // interface proxy
mock(ArticleQueryService.class) // concrete subclass: proxy defined against the target's own
                                // package, Objenesis bypassing @AllArgsConstructor

// 3. rest-assured's Groovy-backed GPath, including the closure form that goes
//    through Groovy's runtime call-site machinery rather than plain property access
json.getList("user.followers.findAll { it > 1 }")
```

The `ClassFileVersion.of(User.class)` assertion is deliberately load-bearing: the mock checks below it are only *evidence about JDK 17* if the mocked types are genuinely Java 17 bytecode. Without it, lowering the compile target would leave this test green and meaningless.

### Negative controls (why I trust the "nothing is broken" answer)

I tried to *make* the stack fail on JDK 17 and could not, which is worth recording so nobody re-litigates it:

- Forcing the DGS-preferred `byte-buddy 1.10.20` + `mockito-core 3.3.3` and mocking a class-file-61 interface out-of-process: **mock succeeded**. `ClassFileVersion.ofThisVm()` on 1.10.20 also returns `Java 17 (61)`.
- Forcing `groovy 3.0.9` (the version rest-assured 4.5.1 declares, i.e. below the 3.0.16 fix for GROOVY-10391) via `resolutionStrategy.eachDependency`: **all three tests still passed**.

I had initially written a comment claiming the Groovy assertion only passes because of the BOM upgrade; the 3.0.9 control disproved that, so the comment now describes what the test exercises rather than a failure mode I did not observe.

### Verification

`./gradlew clean build` on JDK 17.0.13 — **BUILD SUCCESSFUL, 71 tests** (68 baseline + 3 new), 0 failures, 0 errors, 0 skipped. `spotlessApply` run; no reformatting of existing files.

The failing `security/snyk` check is a **preexisting account-quota failure** ("You have used your limit of private tests"), not a finding against this diff — the same check fails identically on the base PR #957, which contains none of these changes.


Link to Devin session: https://app.devin.ai/sessions/26a3fc34f03242d4aaf7707968d0a1f4
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/960?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->