### PR TITLE
refactor: replace Joda-Time with java.time.Instant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
-    implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/io/spring/DateTimes.java
+++ b/src/main/java/io/spring/DateTimes.java
@@ -1,0 +1,21 @@
+package io.spring;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+public class DateTimes {
+
+  /** ISO-8601 in UTC with exactly three fractional-second digits, e.g. 2021-01-01T12:00:00.000Z. */
+  public static final DateTimeFormatter ISO_UTC =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC);
+
+  public static Instant now() {
+    return Instant.now().truncatedTo(ChronoUnit.MILLIS);
+  }
+
+  public static String format(Instant instant) {
+    return ISO_UTC.format(instant);
+  }
+}

--- a/src/main/java/io/spring/JacksonCustomizations.java
+++ b/src/main/java/io/spring/JacksonCustomizations.java
@@ -6,8 +6,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
+import java.time.Instant;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,23 +20,23 @@ public class JacksonCustomizations {
 
   public static class RealWorldModules extends SimpleModule {
     public RealWorldModules() {
-      addSerializer(DateTime.class, new DateTimeSerializer());
+      addSerializer(Instant.class, new DateTimeSerializer());
     }
   }
 
-  public static class DateTimeSerializer extends StdSerializer<DateTime> {
+  public static class DateTimeSerializer extends StdSerializer<Instant> {
 
     protected DateTimeSerializer() {
-      super(DateTime.class);
+      super(Instant.class);
     }
 
     @Override
-    public void serialize(DateTime value, JsonGenerator gen, SerializerProvider provider)
+    public void serialize(Instant value, JsonGenerator gen, SerializerProvider provider)
         throws IOException {
       if (value == null) {
         gen.writeNull();
       } else {
-        gen.writeString(ISODateTimeFormat.dateTime().withZoneUTC().print(value));
+        gen.writeString(DateTimes.format(value));
       }
     }
   }

--- a/src/main/java/io/spring/application/ArticleQueryService.java
+++ b/src/main/java/io/spring/application/ArticleQueryService.java
@@ -9,6 +9,7 @@ import io.spring.core.user.User;
 import io.spring.infrastructure.mybatis.readservice.ArticleFavoritesReadService;
 import io.spring.infrastructure.mybatis.readservice.ArticleReadService;
 import io.spring.infrastructure.mybatis.readservice.UserRelationshipQueryService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,7 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.AllArgsConstructor;
-import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -55,7 +55,7 @@ public class ArticleQueryService {
       String tag,
       String author,
       String favoritedBy,
-      CursorPageParameter<DateTime> page,
+      CursorPageParameter<Instant> page,
       User currentUser) {
     List<String> articleIds =
         articleReadService.findArticlesWithCursor(tag, author, favoritedBy, page);
@@ -78,7 +78,7 @@ public class ArticleQueryService {
   }
 
   public CursorPager<ArticleData> findUserFeedWithCursor(
-      User user, CursorPageParameter<DateTime> page) {
+      User user, CursorPageParameter<Instant> page) {
     List<String> followdUsers = userRelationshipQueryService.followedUsers(user.getId());
     if (followdUsers.size() == 0) {
       return new CursorPager<>(new ArrayList<>(), page.getDirection(), false);

--- a/src/main/java/io/spring/application/CommentQueryService.java
+++ b/src/main/java/io/spring/application/CommentQueryService.java
@@ -4,6 +4,7 @@ import io.spring.application.data.CommentData;
 import io.spring.core.user.User;
 import io.spring.infrastructure.mybatis.readservice.CommentReadService;
 import io.spring.infrastructure.mybatis.readservice.UserRelationshipQueryService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +12,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -54,7 +54,7 @@ public class CommentQueryService {
   }
 
   public CursorPager<CommentData> findByArticleIdWithCursor(
-      String articleId, User user, CursorPageParameter<DateTime> page) {
+      String articleId, User user, CursorPageParameter<Instant> page) {
     List<CommentData> comments = commentReadService.findByArticleIdWithCursor(articleId, page);
     if (comments.isEmpty()) {
       return new CursorPager<>(new ArrayList<>(), page.getDirection(), false);

--- a/src/main/java/io/spring/application/DateTimeCursor.java
+++ b/src/main/java/io/spring/application/DateTimeCursor.java
@@ -1,23 +1,22 @@
 package io.spring.application;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import java.time.Instant;
 
-public class DateTimeCursor extends PageCursor<DateTime> {
+public class DateTimeCursor extends PageCursor<Instant> {
 
-  public DateTimeCursor(DateTime data) {
+  public DateTimeCursor(Instant data) {
     super(data);
   }
 
   @Override
   public String toString() {
-    return String.valueOf(getData().getMillis());
+    return String.valueOf(getData().toEpochMilli());
   }
 
-  public static DateTime parse(String cursor) {
+  public static Instant parse(String cursor) {
     if (cursor == null) {
       return null;
     }
-    return new DateTime().withMillis(Long.parseLong(cursor)).withZone(DateTimeZone.UTC);
+    return Instant.ofEpochMilli(Long.parseLong(cursor));
   }
 }

--- a/src/main/java/io/spring/application/data/ArticleData.java
+++ b/src/main/java/io/spring/application/data/ArticleData.java
@@ -2,11 +2,11 @@ package io.spring.application.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.spring.application.DateTimeCursor;
+import java.time.Instant;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Data
 @NoArgsConstructor
@@ -19,8 +19,8 @@ public class ArticleData implements io.spring.application.Node {
   private String body;
   private boolean favorited;
   private int favoritesCount;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
   private List<String> tagList;
 
   @JsonProperty("author")

--- a/src/main/java/io/spring/application/data/CommentData.java
+++ b/src/main/java/io/spring/application/data/CommentData.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.spring.application.DateTimeCursor;
 import io.spring.application.Node;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Data
 @NoArgsConstructor
@@ -16,8 +16,8 @@ public class CommentData implements Node {
   private String id;
   private String body;
   @JsonIgnore private String articleId;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   @JsonProperty("author")
   private ProfileData profileData;

--- a/src/main/java/io/spring/core/article/Article.java
+++ b/src/main/java/io/spring/core/article/Article.java
@@ -2,14 +2,15 @@ package io.spring.core.article;
 
 import static java.util.stream.Collectors.toList;
 
+import io.spring.DateTimes;
 import io.spring.Util;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Getter
 @NoArgsConstructor
@@ -22,12 +23,12 @@ public class Article {
   private String description;
   private String body;
   private List<Tag> tags;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   public Article(
       String title, String description, String body, List<String> tagList, String userId) {
-    this(title, description, body, tagList, userId, new DateTime());
+    this(title, description, body, tagList, userId, DateTimes.now());
   }
 
   public Article(
@@ -36,7 +37,7 @@ public class Article {
       String body,
       List<String> tagList,
       String userId,
-      DateTime createdAt) {
+      Instant createdAt) {
     this.id = UUID.randomUUID().toString();
     this.slug = toSlug(title);
     this.title = title;
@@ -52,15 +53,15 @@ public class Article {
     if (!Util.isEmpty(title)) {
       this.title = title;
       this.slug = toSlug(title);
-      this.updatedAt = new DateTime();
+      this.updatedAt = DateTimes.now();
     }
     if (!Util.isEmpty(description)) {
       this.description = description;
-      this.updatedAt = new DateTime();
+      this.updatedAt = DateTimes.now();
     }
     if (!Util.isEmpty(body)) {
       this.body = body;
-      this.updatedAt = new DateTime();
+      this.updatedAt = DateTimes.now();
     }
   }
 

--- a/src/main/java/io/spring/core/comment/Comment.java
+++ b/src/main/java/io/spring/core/comment/Comment.java
@@ -1,10 +1,11 @@
 package io.spring.core.comment;
 
+import io.spring.DateTimes;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Getter
 @NoArgsConstructor
@@ -14,13 +15,13 @@ public class Comment {
   private String body;
   private String userId;
   private String articleId;
-  private DateTime createdAt;
+  private Instant createdAt;
 
   public Comment(String body, String userId, String articleId) {
     this.id = UUID.randomUUID().toString();
     this.body = body;
     this.userId = userId;
     this.articleId = articleId;
-    this.createdAt = new DateTime();
+    this.createdAt = DateTimes.now();
   }
 }

--- a/src/main/java/io/spring/graphql/ArticleDatafetcher.java
+++ b/src/main/java/io/spring/graphql/ArticleDatafetcher.java
@@ -9,6 +9,7 @@ import graphql.execution.DataFetcherResult;
 import graphql.relay.DefaultConnectionCursor;
 import graphql.relay.DefaultPageInfo;
 import graphql.schema.DataFetchingEnvironment;
+import io.spring.DateTimes;
 import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.CursorPageParameter;
@@ -30,7 +31,6 @@ import io.spring.graphql.types.Profile;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.format.ISODateTimeFormat;
 
 @DgsComponent
 @AllArgsConstructor
@@ -371,14 +371,14 @@ public class ArticleDatafetcher {
   private Article buildArticleResult(ArticleData articleData) {
     return Article.newBuilder()
         .body(articleData.getBody())
-        .createdAt(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getCreatedAt()))
+        .createdAt(DateTimes.format(articleData.getCreatedAt()))
         .description(articleData.getDescription())
         .favorited(articleData.isFavorited())
         .favoritesCount(articleData.getFavoritesCount())
         .slug(articleData.getSlug())
         .tagList(articleData.getTagList())
         .title(articleData.getTitle())
-        .updatedAt(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getUpdatedAt()))
+        .updatedAt(DateTimes.format(articleData.getUpdatedAt()))
         .build();
   }
 }

--- a/src/main/java/io/spring/graphql/CommentDatafetcher.java
+++ b/src/main/java/io/spring/graphql/CommentDatafetcher.java
@@ -7,6 +7,7 @@ import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
 import graphql.relay.DefaultConnectionCursor;
 import graphql.relay.DefaultPageInfo;
+import io.spring.DateTimes;
 import io.spring.application.CommentQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -25,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.format.ISODateTimeFormat;
 
 @DgsComponent
 @AllArgsConstructor
@@ -115,8 +115,8 @@ public class CommentDatafetcher {
     return Comment.newBuilder()
         .id(comment.getId())
         .body(comment.getBody())
-        .updatedAt(ISODateTimeFormat.dateTime().withZoneUTC().print(comment.getCreatedAt()))
-        .createdAt(ISODateTimeFormat.dateTime().withZoneUTC().print(comment.getCreatedAt()))
+        .updatedAt(DateTimes.format(comment.getCreatedAt()))
+        .createdAt(DateTimes.format(comment.getCreatedAt()))
         .build();
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -5,40 +5,40 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.TimeZone;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.MappedTypes;
 import org.apache.ibatis.type.TypeHandler;
-import org.joda.time.DateTime;
 
-@MappedTypes(DateTime.class)
-public class DateTimeHandler implements TypeHandler<DateTime> {
+@MappedTypes(Instant.class)
+public class DateTimeHandler implements TypeHandler<Instant> {
 
   private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
   @Override
-  public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
+  public void setParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.toEpochMilli()) : null, UTC_CALENDAR);
   }
 
   @Override
-  public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
+  public Instant getResult(ResultSet rs, String columnName) throws SQLException {
     Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
-    return timestamp != null ? new DateTime(timestamp.getTime()) : null;
+    return timestamp != null ? Instant.ofEpochMilli(timestamp.getTime()) : null;
   }
 
   @Override
-  public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
+  public Instant getResult(ResultSet rs, int columnIndex) throws SQLException {
     Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
-    return timestamp != null ? new DateTime(timestamp.getTime()) : null;
+    return timestamp != null ? Instant.ofEpochMilli(timestamp.getTime()) : null;
   }
 
   @Override
-  public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
+  public Instant getResult(CallableStatement cs, int columnIndex) throws SQLException {
     Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
-    return ts != null ? new DateTime(ts.getTime()) : null;
+    return ts != null ? Instant.ofEpochMilli(ts.getTime()) : null;
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
@@ -2,10 +2,10 @@ package io.spring.infrastructure.mybatis.readservice;
 
 import io.spring.application.CursorPageParameter;
 import io.spring.application.data.CommentData;
+import java.time.Instant;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.joda.time.DateTime;
 
 @Mapper
 public interface CommentReadService {
@@ -14,5 +14,5 @@ public interface CommentReadService {
   List<CommentData> findByArticleId(@Param("articleId") String articleId);
 
   List<CommentData> findByArticleIdWithCursor(
-      @Param("articleId") String articleId, @Param("page") CursorPageParameter<DateTime> page);
+      @Param("articleId") String articleId, @Param("page") CursorPageParameter<Instant> page);
 }

--- a/src/test/java/io/spring/JacksonCustomizationsTest.java
+++ b/src/test/java/io/spring/JacksonCustomizationsTest.java
@@ -8,16 +8,25 @@ import io.spring.application.data.ProfileData;
 import java.time.Instant;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.annotation.Import;
 
 /**
  * Pins the wire format of serialized timestamps. The strings asserted here are exactly what the
  * previous Joda based serializer ({@code ISODateTimeFormat.dateTime().withZoneUTC()}) emitted.
+ *
+ * <p>Runs against the Boot built {@code ObjectMapper} on purpose: {@code JavaTimeModule} is on the
+ * classpath and registers its own {@code Instant} serializer, so this also pins that {@link
+ * JacksonCustomizations.RealWorldModules} wins that contest.
  */
+@JsonTest
+@Import(JacksonCustomizations.class)
 public class JacksonCustomizationsTest {
 
-  private final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JacksonCustomizations.RealWorldModules());
+  @Autowired private ObjectMapper objectMapper;
 
+  /** A zero millisecond instant is where {@code JavaTimeModule} would diverge (no {@code .000}). */
   @Test
   public void should_serialize_instant_as_iso8601_utc_with_millis() throws Exception {
     assertEquals(

--- a/src/test/java/io/spring/JacksonCustomizationsTest.java
+++ b/src/test/java/io/spring/JacksonCustomizationsTest.java
@@ -1,0 +1,77 @@
+package io.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.spring.application.data.ArticleData;
+import io.spring.application.data.ProfileData;
+import java.time.Instant;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the wire format of serialized timestamps. The strings asserted here are exactly what the
+ * previous Joda based serializer ({@code ISODateTimeFormat.dateTime().withZoneUTC()}) emitted.
+ */
+public class JacksonCustomizationsTest {
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().registerModule(new JacksonCustomizations.RealWorldModules());
+
+  @Test
+  public void should_serialize_instant_as_iso8601_utc_with_millis() throws Exception {
+    assertEquals(
+        "\"2021-01-01T12:00:00.000Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00Z")));
+    assertEquals(
+        "\"2021-01-01T12:00:00.001Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.001Z")));
+    assertEquals(
+        "\"2021-01-01T12:00:00.100Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.1Z")));
+    assertEquals(
+        "\"2021-01-01T12:00:00.999Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.999Z")));
+    assertEquals("\"1970-01-01T00:00:00.000Z\"", objectMapper.writeValueAsString(Instant.EPOCH));
+    assertEquals(
+        "\"1969-12-31T23:59:59.999Z\"", objectMapper.writeValueAsString(Instant.ofEpochMilli(-1L)));
+  }
+
+  @Test
+  public void should_truncate_sub_millisecond_precision() throws Exception {
+    assertEquals(
+        "\"2021-01-01T12:00:00.123Z\"",
+        objectMapper.writeValueAsString(instant("2021-01-01T12:00:00.123456789Z")));
+  }
+
+  @Test
+  public void should_serialize_null_instant_as_null() throws Exception {
+    assertEquals("null", objectMapper.writeValueAsString((Instant) null));
+  }
+
+  @Test
+  public void should_serialize_article_timestamps_in_realworld_format() throws Exception {
+    ArticleData articleData =
+        new ArticleData(
+            "id",
+            "a-title",
+            "a title",
+            "desc",
+            "body",
+            false,
+            0,
+            instant("2021-01-01T12:00:00Z"),
+            instant("2021-01-02T03:04:05.678Z"),
+            Arrays.asList("java"),
+            new ProfileData("uid", "user", "bio", "image", false));
+
+    String json = objectMapper.writeValueAsString(articleData);
+
+    assertEquals(true, json.contains("\"createdAt\":\"2021-01-01T12:00:00.000Z\""));
+    assertEquals(true, json.contains("\"updatedAt\":\"2021-01-02T03:04:05.678Z\""));
+  }
+
+  private static Instant instant(String iso) {
+    return Instant.parse(iso);
+  }
+}

--- a/src/test/java/io/spring/TestHelper.java
+++ b/src/test/java/io/spring/TestHelper.java
@@ -4,13 +4,13 @@ import io.spring.application.data.ArticleData;
 import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
 import io.spring.core.user.User;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.joda.time.DateTime;
 
 public class TestHelper {
   public static ArticleData articleDataFixture(String seed, User user) {
-    DateTime now = new DateTime();
+    Instant now = DateTimes.now();
     return new ArticleData(
         seed + "id",
         "title-" + seed,

--- a/src/test/java/io/spring/api/ArticleApiTest.java
+++ b/src/test/java/io/spring/api/ArticleApiTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.DateTimes;
 import io.spring.JacksonCustomizations;
 import io.spring.TestHelper;
 import io.spring.api.security.WebSecurityConfig;
@@ -19,13 +20,12 @@ import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
 import io.spring.core.article.ArticleRepository;
 import io.spring.core.user.User;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +55,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
   @Test
   public void should_read_article_success() throws Exception {
     String slug = "test-new-article";
-    DateTime time = new DateTime();
+    Instant time = DateTimes.now();
     Article article =
         new Article(
             "Test New Article",
@@ -74,7 +74,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
         .statusCode(200)
         .body("article.slug", equalTo(slug))
         .body("article.body", equalTo(articleData.getBody()))
-        .body("article.createdAt", equalTo(ISODateTimeFormat.dateTime().withZoneUTC().print(time)));
+        .body("article.createdAt", equalTo(DateTimes.format(time)));
   }
 
   @Test
@@ -131,7 +131,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
         new Article(
             title, description, body, Arrays.asList("java", "spring", "jpg"), anotherUser.getId());
 
-    DateTime time = new DateTime();
+    Instant time = DateTimes.now();
     ArticleData articleData =
         new ArticleData(
             article.getId(),

--- a/src/test/java/io/spring/api/ArticlesApiTest.java
+++ b/src/test/java/io/spring/api/ArticlesApiTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.DateTimes;
 import io.spring.JacksonCustomizations;
 import io.spring.api.security.WebSecurityConfig;
 import io.spring.application.ArticleQueryService;
@@ -20,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,8 +63,8 @@ public class ArticlesApiTest extends TestWithCurrentUser {
             body,
             false,
             0,
-            new DateTime(),
-            new DateTime(),
+            DateTimes.now(),
+            DateTimes.now(),
             tagList,
             new ProfileData("userid", user.getUsername(), user.getBio(), user.getImage(), false));
 
@@ -132,8 +132,8 @@ public class ArticlesApiTest extends TestWithCurrentUser {
             body,
             false,
             0,
-            new DateTime(),
-            new DateTime(),
+            DateTimes.now(),
+            DateTimes.now(),
             asList(tagList),
             new ProfileData("userid", user.getUsername(), user.getBio(), user.getImage(), false));
 

--- a/src/test/java/io/spring/application/DateTimeCursorTest.java
+++ b/src/test/java/io/spring/application/DateTimeCursorTest.java
@@ -1,0 +1,57 @@
+package io.spring.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class DateTimeCursorTest {
+
+  @Test
+  public void should_encode_cursor_as_epoch_millis() {
+    assertEquals(
+        "1609502400000", new DateTimeCursor(Instant.parse("2021-01-01T12:00:00Z")).toString());
+  }
+
+  @Test
+  public void should_round_trip_cursor() {
+    Instant instant = Instant.parse("2021-01-01T12:00:00.123Z");
+    assertEquals(instant, DateTimeCursor.parse(new DateTimeCursor(instant).toString()));
+  }
+
+  @Test
+  public void should_parse_null_cursor_to_null() {
+    assertNull(DateTimeCursor.parse(null));
+  }
+
+  @Test
+  public void should_keep_cursor_ordering_consistent_with_instant_ordering() {
+    List<Instant> instants =
+        Arrays.asList(
+            Instant.parse("2021-01-01T12:00:00.001Z"),
+            Instant.parse("2021-01-01T12:00:00.000Z"),
+            Instant.parse("2020-06-05T04:03:02.100Z"),
+            Instant.parse("2021-01-01T12:00:01.000Z"));
+
+    List<Instant> byInstant =
+        instants.stream().sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+    List<Instant> byCursor =
+        instants.stream()
+            .sorted(
+                Comparator.comparingLong(
+                        (Instant i) -> Long.parseLong(new DateTimeCursor(i).toString()))
+                    .reversed())
+            .collect(Collectors.toList());
+
+    assertEquals(byInstant, byCursor);
+    assertTrue(
+        Long.parseLong(new DateTimeCursor(instants.get(0)).toString())
+            > Long.parseLong(new DateTimeCursor(instants.get(1)).toString()));
+  }
+}

--- a/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
@@ -1,5 +1,6 @@
 package io.spring.application.article;
 
+import io.spring.DateTimes;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -19,9 +20,10 @@ import io.spring.infrastructure.DbTestBase;
 import io.spring.infrastructure.repository.MyBatisArticleFavoriteRepository;
 import io.spring.infrastructure.repository.MyBatisArticleRepository;
 import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +54,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
     userRepository.save(user);
     article =
         new Article(
-            "test", "desc", "body", Arrays.asList("java", "spring"), user.getId(), new DateTime());
+            "test", "desc", "body", Arrays.asList("java", "spring"), user.getId(), DateTimes.now());
     articleRepository.save(article);
   }
 
@@ -92,7 +94,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             "body",
             Arrays.asList("test"),
             user.getId(),
-            new DateTime().minusHours(1));
+            DateTimes.now().minus(1, ChronoUnit.HOURS));
     articleRepository.save(anotherArticle);
 
     ArticleDataList recentArticles =
@@ -116,7 +118,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             "body",
             Arrays.asList("test"),
             user.getId(),
-            new DateTime().minusHours(1));
+            DateTimes.now().minus(1, ChronoUnit.HOURS));
     articleRepository.save(anotherArticle);
 
     CursorPager<ArticleData> recentArticles =
@@ -130,7 +132,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             null,
             null,
             null,
-            new CursorPageParameter<DateTime>(
+            new CursorPageParameter<Instant>(
                 DateTimeCursor.parse(recentArticles.getEndCursor().toString()), 20, Direction.NEXT),
             user);
     Assertions.assertEquals(nodata.getData().size(), 0);

--- a/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
+++ b/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
@@ -53,13 +53,14 @@ public class DateTimeHandlerTest extends DbTestBase {
         new Article("stored at", "desc", "body", Arrays.asList("java"), user.getId(), createdAt);
     articleRepository.save(article);
 
-    jdbcTemplate.query(
-        "select created_at, updated_at from articles where id = ?",
-        rs -> {
-          assertEquals(1609502400123L, rs.getLong("created_at"));
-          assertEquals(1609502400123L, rs.getLong("updated_at"));
-        },
-        article.getId());
+    assertEquals(
+        1609502400123L,
+        jdbcTemplate.queryForObject(
+            "select created_at from articles where id = ?", Long.class, article.getId()));
+    assertEquals(
+        1609502400123L,
+        jdbcTemplate.queryForObject(
+            "select updated_at from articles where id = ?", Long.class, article.getId()));
 
     assertEquals(createdAt, articleRepository.findById(article.getId()).get().getCreatedAt());
   }

--- a/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
+++ b/src/test/java/io/spring/infrastructure/mybatis/DateTimeHandlerTest.java
@@ -1,0 +1,66 @@
+package io.spring.infrastructure.mybatis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.spring.core.article.Article;
+import io.spring.core.article.ArticleRepository;
+import io.spring.core.user.User;
+import io.spring.core.user.UserRepository;
+import io.spring.infrastructure.DbTestBase;
+import io.spring.infrastructure.repository.MyBatisArticleRepository;
+import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.time.Instant;
+import java.util.Arrays;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/** Pins the on-disk timestamp representation written by {@link DateTimeHandler}. */
+@Import({MyBatisArticleRepository.class, MyBatisUserRepository.class})
+public class DateTimeHandlerTest extends DbTestBase {
+
+  @Autowired private SqlSessionFactory sqlSessionFactory;
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @Autowired private ArticleRepository articleRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  /**
+   * Unlike Joda's {@code DateTime}, {@code Instant} has a built-in MyBatis handler that would
+   * silently write a different on-disk value. Our handler must win the registry lookup.
+   */
+  @Test
+  public void should_register_handler_for_instant() {
+    assertInstanceOf(
+        DateTimeHandler.class,
+        sqlSessionFactory
+            .getConfiguration()
+            .getTypeHandlerRegistry()
+            .getTypeHandler(Instant.class));
+  }
+
+  @Test
+  public void should_store_timestamps_as_epoch_millis() {
+    User user = new User("handler@test.com", "handler", "123", "", "");
+    userRepository.save(user);
+    Instant createdAt = Instant.ofEpochMilli(1609502400123L);
+    Article article =
+        new Article("stored at", "desc", "body", Arrays.asList("java"), user.getId(), createdAt);
+    articleRepository.save(article);
+
+    jdbcTemplate.query(
+        "select created_at, updated_at from articles where id = ?",
+        rs -> {
+          assertEquals(1609502400123L, rs.getLong("created_at"));
+          assertEquals(1609502400123L, rs.getLong("updated_at"));
+        },
+        article.getId());
+
+    assertEquals(createdAt, articleRepository.findById(article.getId()).get().getCreatedAt());
+  }
+}


### PR DESCRIPTION
## Summary

Drops `joda-time:joda-time:2.10.13` and moves every timestamp to `java.time.Instant`. The bar was behavioral identity — JSON strings and SQLite values must be byte-for-byte the same — so the two conversion points were reproduced exactly rather than replaced with the "natural" java.time equivalents.

**Wire format.** Joda's `ISODateTimeFormat.dateTime().withZoneUTC()` emits a fixed 3 fractional digits and `Z`. `DateTimeFormatter.ISO_INSTANT` does *not* (it emits variable digits: `12:00:00Z`, not `12:00:00.000Z`), so a new `io.spring.DateTimes` pins the pattern:

```java
ISO_UTC = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC);
```

Verified equivalent against the Joda formatter over 1,000,000 random epoch-millis plus edge cases (epoch, negative, year 0001, year 9999): all match.

**Precision.** `DateTime.now()` is millisecond-precision; `Instant.now()` is microsecond-precision on this JDK/OS. Left alone, in-memory entities would carry µs that the DB (millis) and the JSON (`.SSS`) both drop, so an entity would stop equaling its own round-trip. `DateTimes.now()` truncates:

```java
public static Instant now() { return Instant.now().truncatedTo(ChronoUnit.MILLIS); }
```

**Persistence.** `DateTimeHandler` keeps its UTC `Calendar` and epoch-millis conversion; only the type changes, so the on-disk representation (SQLite `integer` millis) is untouched:

```diff
-@MappedTypes(DateTime.class)
-new Timestamp(parameter.getMillis())   ->  new DateTime(timestamp.getTime())
+@MappedTypes(Instant.class)
+new Timestamp(parameter.toEpochMilli()) ->  Instant.ofEpochMilli(timestamp.getTime())
```

`DateTimeCursor` likewise still encodes epoch millis (`toEpochMilli()`), so cursors minted by the old code remain valid and comparable against `created_at`.

**Two collisions Joda didn't have.** `Instant` — unlike `DateTime` — already has a default handler in *both* registries this app relies on, and in both cases ours only wins by registration order. Each is now pinned by a test rather than left to chance:

| Registry | Default | Ours wins because | Guarded by |
|---|---|---|---|
| MyBatis `TypeHandlerRegistry` | `InstantTypeHandler` (writes `Timestamp.from`, no UTC calendar) | `mybatis.type-handlers-package` scan runs after built-ins | `DateTimeHandlerTest` |
| Jackson | `JavaTimeModule` (`ISO_INSTANT`, variable digits) | Boot registers `Module` beans after well-known modules, and `withAdditionalSerializers` prepends | `JacksonCustomizationsTest` |

## Verification

- `./gradlew clean build` green on JDK 17; `runtimeClasspath` and the boot jar contain no joda artifact.
- **JSON unchanged** — `JacksonCustomizationsTest` runs `@JsonTest` against the *Boot-built* `ObjectMapper` (not a hand-rolled one) and asserts exact strings (`2021-01-01T12:00:00.000Z`, `.001`, `.100`, `.999`, epoch, pre-epoch, ns truncation, null). Confirmed the guard bites: dropping the `@Import` lets `JavaTimeModule` take over and the assertions fail with `expected <...T12:00:00.000Z> but was <...T12:00:00Z>`.
- **DB round-trip unchanged** — booted both jars against a fresh `dev.db`, created articles + a comment via REST. Both write `typeof(created_at) = 'integer'` epoch millis. Cross-read both ways (old build reading the new build's DB and vice versa): `/articles`, `/articles/{slug}`, `/articles/{slug}/comments` and the GraphQL article connection are byte-identical after normalization.
- **Cursor pagination unchanged** — GraphQL `articles(first: 2)` then `after: <endCursor>` returns the same slugs in the same order with identical cursor values on both builds; `DateTimeCursorTest` pins the encoding and ordering.

## Notes

- `TestHelper`/`ArticleApiTest` still use `"joda"` as a literal *tag name* in fixtures; left as-is to keep the diff scoped.
- `build.gradle` touched on one line only (the dependency removal) to minimize conflicts with sibling branches.
- Review flagged the pre-existing shared mutable `UTC_CALENDAR` in `DateTimeHandler`. Real, but a concurrency fix unrelated to the Joda removal — left for a follow-up rather than widening this diff.


Link to Devin session: https://app.devin.ai/sessions/5d44e9ca1276469ea2c9180a447b16fc
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/961?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->