### PR TITLE
build: add --add-exports so Spotless/google-java-format runs on JDK 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,9 @@
+# google-java-format (used by Spotless) reaches into jdk.compiler internals, which JDK 16+
+# strongly encapsulates. Without these exports spotlessJava/spotlessCheck fail with
+# IllegalAccessError: module jdk.compiler does not export com.sun.tools.javac.parser.
+org.gradle.jvmargs=-Xmx2g \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # google-java-format (used by Spotless) reaches into jdk.compiler internals, which JDK 16+
 # strongly encapsulates. Without these exports spotlessJava/spotlessCheck fail with
 # IllegalAccessError: module jdk.compiler does not export com.sun.tools.javac.parser.
-# The memory flags restate Gradle 7.6's own daemon defaults, which setting this property
-# would otherwise discard.
-org.gradle.jvmargs=-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m \
+# The leading flags restate Gradle 7.x's own daemon defaults
+# (DaemonParameters.DEFAULT_JVM_ARGS), which setting this property would otherwise discard.
+org.gradle.jvmargs=-Xmx512m -Xms256m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError \
   --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
 # google-java-format (used by Spotless) reaches into jdk.compiler internals, which JDK 16+
 # strongly encapsulates. Without these exports spotlessJava/spotlessCheck fail with
 # IllegalAccessError: module jdk.compiler does not export com.sun.tools.javac.parser.
-org.gradle.jvmargs=-Xmx2g \
-  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,10 @@
 # google-java-format (used by Spotless) reaches into jdk.compiler internals, which JDK 16+
 # strongly encapsulates. Without these exports spotlessJava/spotlessCheck fail with
 # IllegalAccessError: module jdk.compiler does not export com.sun.tools.javac.parser.
-org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+# The memory flags restate Gradle 7.6's own daemon defaults, which setting this property
+# would otherwise discard.
+org.gradle.jvmargs=-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

The only thing in this repo that actually trips JDK 17's strong encapsulation is `google-java-format` (bundled with the `com.diffplug.spotless` 6.2.1 plugin). It parses Java with `com.sun.tools.javac`, which `jdk.compiler` no longer exports, so `spotlessJava` / `spotlessCheck` die during the build:

```
java.lang.IllegalAccessError: class com.google.googlejavaformat.java.JavaInput
  (in unnamed module @0x3674999e) cannot access class com.sun.tools.javac.parser.Tokens$TokenKind
  (in module jdk.compiler) because module jdk.compiler does not export
  com.sun.tools.javac.parser to unnamed module @0x3674999e
```

Spotless formats in the Gradle daemon, so the fix is a new `gradle.properties` setting `org.gradle.jvmargs` with the five `--add-exports` that `google-java-format` needs (`javac.api`, `.file`, `.parser`, `.tree`, `.util`). The alternative — bumping `google-java-format`/Spotless — is a sibling session's dependency scope, and this flag-only fix is JDK-11-compatible (`--add-exports` is accepted from 9 onward), so it is safe on either JDK while the migration is in flight.

Setting `org.gradle.jvmargs` at all *discards* Gradle's built-in daemon memory defaults, so the value also restates them verbatim rather than silently changing the daemon's memory profile. These are `DaemonParameters.DEFAULT_JVM_ARGS`, read out of the launcher jar rather than from the docs (byte-identical in `gradle-launcher-7.4.jar` and `gradle-launcher-7.6.4.jar`, so this is correct both before and after the sibling's wrapper bump):

```
-Xmx512m -Xms256m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
```

Net effect: the daemon's memory profile is byte-identical to before this PR, and the only behavioral delta is the exports.

With Spotless able to run again it immediately flagged one pre-existing over-100-column line in `DefaultJwtServiceTest` (introduced by 9d968683, not a JDK 17 regression — it would fail on 11 too). That hunk is just `spotlessApply`'s own output for that file, so `./gradlew build` is green end to end.

Deliberately **not** in this PR (sibling scopes): the Java toolchain 17 + Gradle 7.6.4 wrapper bump, and dependency version bumps. Both were applied locally, uncommitted, to verify the below. Note this file becomes redundant if the dependency sibling bumps Spotless/google-java-format — it can then be deleted outright.

### Runtime verdict (no code changes needed)

Everything else is clean on JDK 17 — this is the reporting half of the task:

- Boots on `17.0.13` in 2.93s with **zero** WARN/ERROR lines: Tomcat 9.0.56, Spring Security filter chain, DGS GraphiQL, Hikari, and Flyway 8.0.5 applying `V1__create_tables` against `jdbc:sqlite:dev.db`.
- No `InaccessibleObjectException` anywhere. `src/` contains no `setAccessible`, `sun.*`, `jdk.internal`, or `Unsafe` usage, and the libraries that do deep reflection at runtime (Spring CGLIB proxying, MyBatis 3.5.9 mapper proxies, Jackson 2.13.1, kotlin-reflect 1.6.10 via DGS, joda-time 2.10.13, sqlite-jdbc 3.36.0.3 native extraction) all stay within opened packages. **No `--add-opens`/`--add-exports` are required to boot the app or to run `./gradlew test`** — the exports here are build-tooling-only.
- Smoke-tested green: `POST /users` 201, `POST /users/login` 200, `GET /user` (JWT) 200, `POST /articles` 200, `GET /articles` 200, `GET /tags` 200, plus a GraphQL `articles` query and a `createArticle` mutation, and `GET /graphiql` 200.
- `application.properties` / `application-test.properties` need **no** JDK-17 changes: the SQLite URL + `org.sqlite.JDBC` driver, Flyway, MyBatis, and the HS512 JWT secret all behave identically. (`jwt.secret` being checked into source is a pre-existing security smell, unrelated to this migration.)


Link to Devin session: https://app.devin.ai/sessions/40fb28907cb44df8a2a10a5ef713f117
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/963?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->