### PR TITLE
test: JDK 17 dependency audit — no version bumps needed, pin DGS runtime with a regression test

### DIFF
--- a/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
+++ b/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
@@ -1,6 +1,7 @@
 package io.spring.graphql;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
@@ -21,7 +22,7 @@ public class DgsRuntimeCompatibilityTest {
   public void schema_is_assembled_and_a_query_is_executed() {
     List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
 
-    assertThat(tags, is(List.of()));
+    assertThat(tags, is(notNullValue()));
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
+++ b/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
@@ -1,12 +1,15 @@
 package io.spring.graphql;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
+import graphql.ExecutionResult;
 import io.spring.graphql.types.Article;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,9 +23,11 @@ public class DgsRuntimeCompatibilityTest {
 
   @Test
   public void schema_is_assembled_and_a_query_is_executed() {
-    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+    ExecutionResult result = dgsQueryExecutor.execute("{ tags }");
 
-    assertThat(tags, is(notNullValue()));
+    assertThat(result.getErrors(), is(empty()));
+    Map<String, Object> data = result.getData();
+    assertThat(data.get("tags"), is(instanceOf(List.class)));
   }
 
   @Test

--- a/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
+++ b/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
@@ -1,0 +1,32 @@
+package io.spring.graphql;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import io.spring.graphql.types.Article;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class DgsRuntimeCompatibilityTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @Test
+  public void schema_is_assembled_and_a_query_is_executed() {
+    List<String> tags = dgsQueryExecutor.executeAndExtractJsonPath("{ tags }", "data.tags");
+
+    assertThat(tags, is(List.of()));
+  }
+
+  @Test
+  public void codegen_types_are_loadable_at_runtime() {
+    Article article = Article.newBuilder().slug("a-slug").title("A title").build();
+
+    assertThat(article.getSlug(), is("a-slug"));
+    assertThat(article.getTitle(), is("A title"));
+  }
+}

--- a/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
+++ b/src/test/java/io/spring/graphql/DgsRuntimeCompatibilityTest.java
@@ -9,7 +9,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 public class DgsRuntimeCompatibilityTest {
 


### PR DESCRIPTION
## Summary

Dependency & plugin compatibility audit for the Java 11 → 17 move. **Zero version bumps were needed** — every dependency and plugin in `build.gradle` works unchanged on JDK 17.0.13 with Spring Boot 2.6.3 and Gradle 7.6.4. The only diff here is one regression test; there is no `build.gradle` change, no `gradle.properties`, and no wrapper/toolchain change (sibling's scope).

One JDK-17-specific issue was found — **Spotless**, which is a *config* problem, not a version problem, and is fixed by the toolchain sibling's `gradle.properties`:

```
> Task :spotlessJava FAILED
Caused by: java.lang.IllegalAccessError: class com.google.googlejavaformat.java.JavaInput
  (in unnamed module @0x53f03f68) cannot access class com.sun.tools.javac.parser.Tokens$TokenKind
  (in module jdk.compiler) because module jdk.compiler does not export
  com.sun.tools.javac.parser to unnamed module @0x53f03f68
```

Verified fix (JEP 403 strong encapsulation, not a Spotless bug — do **not** bump `com.diffplug.spotless` for this):

```properties
# gradle.properties  -- owned by the toolchain sibling, deliberately NOT committed here
org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
```

With that in place `spotlessCheck` runs and reports only a **pre-existing** formatting violation in `DefaultJwtServiceTest` (present on `master`, JDK-independent — google-java-format 1.13.0 is selected identically on 11 and 17). Left untouched, out of scope.

### Compatibility results

| Dependency / plugin | Version | Verdict |
| --- | --- | --- |
| `com.netflix.dgs.codegen` | 5.0.6 | works — `generateJava` emits all 22 types |
| `com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter` | 4.9.21 | works — schema assembled, queries executed |
| Lombok (Boot-managed) | 1.18.22 | works — annotation processing OK, **no pin needed** |
| `org.mybatis.spring.boot:mybatis-spring-boot-starter` | 2.2.2 | works |
| `org.xerial:sqlite-jdbc` | 3.36.0.3 | works — native lib loads, Flyway migrates |
| `io.jsonwebtoken:jjwt-*` | 0.11.2 | works |
| `joda-time:joda-time` | 2.10.13 | works |
| `io.rest-assured:rest-assured` | 4.5.1 | works |
| Mockito / byte-buddy | 4.0.0 / 1.11.22 | works |
| JUnit platform | 1.8.2 | works — 68/68 tests green |
| `com.diffplug.spotless` | 6.2.1 | needs `--add-exports` config, **no bump** |

Lombok is the one the brief flagged as a likely bump. It is not: `annotationProcessor 'org.projectlombok:lombok' -> 1.18.22`, which is the first release with JDK 17 support, and `javap` on the compiled classes shows the generated members present:

```
$ javap -cp build/classes/java/main io.spring.core.user.User
  public java.lang.String getId();  ...  public boolean equals(java.lang.Object);
  protected boolean canEqual(java.lang.Object);  public int hashCode();
```

Pinning an explicit version would be a speculative change with no failing evidence behind it, so it was skipped.

### The one committed change

`DgsRuntimeCompatibilityTest` locks in the two things the existing 68 tests never touched — the DGS *runtime* (only codegen output was implicitly exercised, never a query) and the generated types being loadable:

```java
@ActiveProfiles("test")   // in-memory sqlite, so a leftover dev.db can't skew the assertion
@SpringBootTest
class DgsRuntimeCompatibilityTest {
  @Autowired DgsQueryExecutor dgsQueryExecutor;

  // boots the DGS starter, assembles schema.graphqls, runs a query end-to-end
  ExecutionResult result = dgsQueryExecutor.execute("{ tags }");
  assertThat(result.getErrors(), is(empty()));
  assertThat(result.<Map<String, Object>>getData().get("tags"), is(instanceOf(List.class)));

  // codegen output is on the runtime classpath with its builder intact
  Article.newBuilder().slug("a-slug").title("A title").build()
}
```

If a future JDK/Boot/DGS change silently breaks schema assembly or codegen, this fails the suite instead of only surfacing at runtime.

### Evidence

All commands run with `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64` (17.0.13), Gradle 7.6.4, toolchain 17 applied locally and reverted before commit.

```
./gradlew clean generateJava   BUILD SUCCESSFUL   22 .java files under build/generated
./gradlew compileJava          BUILD SUCCESSFUL   (only pre-existing deprecation/unchecked notes)
./gradlew test                 BUILD SUCCESSFUL   21 classes, 70 tests, 0 failures, 0 errors, 0 skipped
./gradlew assemble             BUILD SUCCESSFUL
./gradlew spotlessCheck        FAILED -> IllegalAccessError; passes parsing with --add-exports
```

The packaged jar was also booted on JDK 17 and driven end-to-end, which is what actually proves the runtime libraries (not just their tests) work:

```
Flyway Community Edition 8.0.5 ... Migrating schema "main" to version "1 - create tables"
Started RealWorldApplication in 2.543 seconds

POST /users     201  -> jjwt HS512 token issued
GET  /user      200  -> token parsed and authenticated
POST /articles  200  -> {"createdAt":"2026-08-07T09:24:43.700Z", ...}   (joda-time + MyBatis + SQLite)
POST /graphql   200  -> {"data":{"tags":["jdk17"]}}
POST /graphql   200  -> {"data":{"articles":{"edges":[{"node":{"slug":"jdk-17-audit", ...}}]}}}
```

### Notes for the integrator

- Nothing in `build.gradle` needs to change for JDK 17. Spring Boot stays on 2.6.3; no `javax.*` → `jakarta.*` change was made or needed.
- Snyk (`security/snyk (Cognition-default)`) reports `You have used your limit of private tests` — an org-wide quota error, identical on #955/#956/#957, unrelated to this diff.
- The `gradle.properties` `--add-exports` block is **required** for the build to be green, but is intentionally absent from this PR — please make sure the toolchain sibling's PR carries it.


Link to Devin session: https://app.devin.ai/sessions/8c9b82e9323e43eba64a7e801451e77b
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/964?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->