### PR TITLE
feature: move Java baseline from 11 to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ tasks.named('clean') {
     }
 }
 
+tasks.named('bootBuildImage') {
+    environment = ['BP_JVM_VERSION': '17']
+}
+
 tasks.named('generateJava') {
     schemaPaths = ["${projectDir}/src/main/resources/schema"] // List of directories containing schema files
     packageName = 'io.spring.graphql' // The package name to use to generate sources

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+org.gradle.jvmargs=-Xmx2g \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Moves the build to Java 17 (`sourceCompatibility`/`targetCompatibility` 11 → 17). Spring Boot stays at 2.6.3 and the Gradle wrapper stays at 7.4; no dependency or plugin bumps were needed — Lombok (1.18.22, Boot-managed), DGS codegen 5.0.6 / DGS starter 4.9.21, and MyBatis 2.2.2 all work as-is on JDK 17.

Supporting changes:

- **`gradle.properties` (new)** — Spotless 6.2.1 runs `googleJavaFormat` in the Gradle daemon JVM, and google-java-format uses `com.sun.tools.javac.*` internals, which JDK 16+ strongly encapsulates. Without this, `spotlessJava` dies with `IllegalAccessError: ... module jdk.compiler does not export com.sun.tools.javac.parser to unnamed module`. Fixed by adding the standard `--add-exports jdk.compiler/com.sun.tools.javac.{api,file,parser,tree,util}=ALL-UNNAMED` daemon args (plus `-Xmx2g`, since setting `org.gradle.jvmargs` overrides the default heap).
- **`bootBuildImage`** — pins `BP_JVM_VERSION=17` so the Paketo buildpack ships a JRE that can load the now class-file-61 jar (README documents `./gradlew bootBuildImage`). Not exercised by an actual image build here.
- **`settings.gradle` (new)** — declares `gradlePluginPortal()` + `mavenCentral()` for `pluginManagement`. Equivalent to Gradle's default, but makes plugin resolution survive environments whose init scripts rewrite repository lists.
- **`DefaultJwtServiceTest`** — a pre-existing Spotless violation (line over 100 chars, unrelated to the JDK bump; it also fails `spotlessCheck` on Java 11). Applied `spotlessApply` so `./gradlew build` is green.

Verified on JDK 17 (`/usr/lib/jvm/java-17-openjdk-amd64`): `./gradlew clean build` succeeds — `generateJava` produces the DGS sources, `spotlessCheck` passes, and all 68 tests pass with 0 failures. Note that JDK 21 does *not* work (Lombok 1.18.22 breaks on it), which is why a matching blueprint change moves the session JDK from 21 to 17.


Link to Devin session: https://app.devin.ai/sessions/f9be1ef7de01423d97d8a4afb3cd640e
Requested by: @Thomas-Blake
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/966?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->