### PR TITLE
build: target Java 17 and unblock Spotless on JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '17'
+targetCompatibility = '17'
 
 spotless {
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,12 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
-targetCompatibility = '17'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 spotless {
     java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,16 @@
 # encapsulated on JDK 16+. These flags keep spotlessJavaCheck/spotlessApply working.
 org.gradle.jvmargs=-Xmx2g \
   --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,13 @@
+# google-java-format (used by Spotless) accesses internal javac APIs, which are
+# encapsulated on JDK 16+. These flags keep spotlessJavaCheck/spotlessApply working.
+org.gradle.jvmargs=-Xmx2g \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Stream A of the Java 11 → 17 migration: build toolchain only. Spring Boot stays at 2.6.3, no `javax.*` → `jakarta.*` work, no application source changes.

```diff
-sourceCompatibility = '11'
-targetCompatibility = '11'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
```

A toolchain declaration was chosen over plain `sourceCompatibility`/`targetCompatibility = '17'` so the JDK requirement is explicit and Gradle can locate/provision a 17 JDK instead of failing with `invalid target release: 17` on a JDK 11 default.

New `gradle.properties` sets `org.gradle.jvmargs` with `--add-exports`/`--add-opens` for `jdk.compiler/com.sun.tools.javac.{api,code,file,main,parser,tree,util}`. Without these, `spotlessJava` on JDK 17 dies with `InvocationTargetException` (google-java-format reaching into encapsulated javac internals) — verified by running `spotlessJavaCheck` on `master` under JDK 17. These reach the Gradle daemon, which is where Spotless and the non-forked `compileJava` run; nothing else in the build needs javac internals.

With Spotless actually able to run, it surfaced one pre-existing format violation in `DefaultJwtServiceTest` (long constructor line wrapping); applied `spotlessApply` output verbatim — it is the only source change in the PR.

### Dependency audit (JDK 17)
No version bumps were needed; all verified by a green `clean build`, `test`, `generateJava`, and `spotlessJavaCheck` on JDK 17.0.13.

| Dependency | Pinned | Result |
| --- | --- | --- |
| `com.netflix.dgs.codegen` plugin | 5.0.6 | as-is; `generateJava` regenerates `io.spring.graphql.types.*` and compiles |
| `com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter` | 4.9.21 | as-is; GraphQL tests pass |
| `org.mybatis.spring.boot:mybatis-spring-boot-starter` | 2.2.2 | as-is; MyBatis/SQLite integration tests pass |
| `org.xerial:sqlite-jdbc` | 3.36.0.3 | as-is |
| `org.projectlombok:lombok` | BOM-managed | resolves to **1.18.22** on `compileClasspath`/`annotationProcessor`, which is the first JDK 17-capable release — no explicit pin added |

Compiled classes are class-file major version 61 (Java 17).

Out of scope for this PR (owned by a parallel stream): `README.md` (still says Java 11), `gradle/wrapper/gradle-wrapper.properties`.


Link to Devin session: https://app.devin.ai/sessions/c391f73e54d44df5b6a69b6e25ad7f40
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/982?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->