### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,34 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar());
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar());
     return ts != null ? new DateTime(ts.getTime()) : null;
+  }
+
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
   }
 }


### PR DESCRIPTION
## Summary

Weekly SonarQube sweep on project `choikh0423_demo-spring-boot-test-coverage` (the Sonar project analyzing this repo — there is no project keyed `spring-boot-realworld-example-app`). 265 open issues; no BLOCKER exists, so the top 5 by severity → type → effort → recency are the 4 CRITICALs plus the highest-ranked MAJOR `BUG`.

| Key | Severity / Type | Rule | Location |
|---|---|---|---|
| `AZ1u3HBdEnUkF3fpjVtN` | CRITICAL / CODE_SMELL | java:S1948 — non-serializable field in a `Serializable` class | `InvalidRequestException:7` |
| `AZ1u3HCaEnUkF3fpjVtj` | CRITICAL / CODE_SMELL | java:S1452 — generic wildcard in return type | `ArticleApi:36` |
| `AZ1u3HCaEnUkF3fpjVtk` | CRITICAL / CODE_SMELL | java:S1452 | `ArticleApi:45` |
| `AZ1u3HBkEnUkF3fpjVtQ` | CRITICAL / CODE_SMELL | java:S1452 | `CommentsApi:41` |
| `AZ1u3HAmEnUkF3fpjVtC` | MAJOR / **BUG** | java:S2885 — non-thread-safe field is `static` | `DateTimeHandler:18` |

Fixes:

1. **S1948** — `RuntimeException` is serializable but Spring's `Errors` is not, so serializing an `InvalidRequestException` would fail. The field is only meaningful in-process (read by the exception handler to build the 422 body), so it becomes `transient`:
   `private final transient Errors errors;`

2. **S1452 ×3** — the three wildcard endpoints all return the `Map<String, Object>` produced by their private `*Response(...)` helper, so the wildcard is replaced with the concrete type; no behavior or serialized payload changes:
   `ResponseEntity<?> article(...)` → `ResponseEntity<Map<String, Object>> article(...)` (same for `updateArticle` and `CommentsApi#createComment`).

3. **S2885 (BUG)** — `DateTimeHandler` is a MyBatis singleton, and `java.util.Calendar` is mutable/not thread-safe; a single `static final Calendar UTC_CALENDAR` was shared across all concurrent JDBC reads and writes. Only the immutable `TimeZone` is kept static and a fresh `Calendar` is created per call:

```diff
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
+  }
```

## Verification

`./gradlew test` passes. `./gradlew spotlessCheck` reports no violation in any of the four touched files; it flags one pre-existing formatting violation in `src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java`, which is untouched here and left alone.


Link to Devin session: https://app.devin.ai/sessions/9ed56ed68d2248b7b5f91f53b6b192a2
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/986?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->