### PR TITLE
build: target Java 17 via Gradle toolchain (wrapper 7.6.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ tasks.named('clean') {
     }
 }
 
+tasks.named('bootBuildImage') {
+    environment = ['BP_JVM_VERSION': '17']
+}
+
 tasks.named('generateJava') {
     schemaPaths = ["${projectDir}/src/main/resources/schema"] // List of directories containing schema files
     packageName = 'io.spring.graphql' // The package name to use to generate sources

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,11 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 spotless {
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ tasks.named('clean') {
 }
 
 tasks.named('bootBuildImage') {
-    environment = ['BP_JVM_VERSION': '17']
+    environment.put('BP_JVM_VERSION', '17')
 }
 
 tasks.named('generateJava') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+# google-java-format (used by Spotless) needs access to internal jdk.compiler packages on JDK 16+.
+org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 # google-java-format (used by Spotless) needs access to internal jdk.compiler packages on JDK 16+.
-org.gradle.jvmargs=--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+# Heap/metaspace are restated because setting org.gradle.jvmargs replaces Gradle's defaults.
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m \
+    --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
     --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
     --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
     --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Build-config-only step of the Java 11 → 17 upgrade. No dependency versions changed and no application logic changed.

- `build.gradle`: replaced `sourceCompatibility/targetCompatibility = '11'` with a single toolchain declaration (`java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }`). Verified emitted bytecode is class file major version 61. Note this now also selects the JVM used for `test`/`bootRun`, not just the bytecode level, so a local JDK 17 is required (toolchain auto-provisioning intentionally not enabled).
- `gradle/wrapper/gradle-wrapper.properties`: `gradle-7.4-bin.zip` → `gradle-7.6.4-bin.zip` for better JDK 17 support.
- New `gradle.properties`: `org.gradle.jvmargs` with `--add-exports=jdk.compiler/com.sun.tools.javac.{api,file,parser,tree,util}=ALL-UNNAMED`. Without these, `spotlessJava` fails on JDK 17 with `IllegalAccessError: class com.google.googlejavaformat.java.JavaInput ... cannot access class com.sun.tools.javac.parser.Tokens$TokenKind`. `-Xmx1g -XX:MaxMetaspaceSize=512m` is restated because setting `org.gradle.jvmargs` replaces Gradle's daemon defaults rather than appending to them.
- `build.gradle`: `bootBuildImage { environment.put('BP_JVM_VERSION', '17') }` — Spring Boot 2.6's buildpack integration does not derive the JRE version from the toolchain, so without this the Paketo builder could pick a Java 11 JRE and the image would fail with `UnsupportedClassVersionError`. Not executed here (no Docker daemon on the VM).
- `README.md`: Java 11 → Java 17 in the getting-started prerequisite.
- One formatting-only hunk in `DefaultJwtServiceTest.java` produced by `./gradlew spotlessApply` — required for `spotlessCheck` (and therefore `build`) to pass; no behavior change.

## Validation

`./gradlew clean build` on JDK 17.0.13: **BUILD SUCCESSFUL** (generateJava, compileJava, bootJar, spotlessCheck, compileTestJava, test, check all pass).

Notes for the other upgrade scopes:
- No dependency version bumps were needed for the build to pass on JDK 17 (dependency-audit scope).
- No JDK-17 module-access failures in application or test code (runtime/reflection scope); the only module-access issue was the Spotless/google-java-format one fixed here.
- Pre-existing (not JDK-related) warnings remain: Gradle flags `spotlessJava` consuming `compileJava`/`generateJava`/`processResources` outputs without a declared dependency, and Gradle 8 deprecation warnings.


Link to Devin session: https://app.devin.ai/sessions/aaa70bf09e3649adb11110c9ae7b4062
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/992?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->