### PR TITLE
build: bump Spotless 6.2.1 -> 6.2.2 (only dependency change required for JDK 17)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
-    id "com.diffplug.spotless" version "6.2.1"
+    id "com.diffplug.spotless" version "6.2.2"
 }
 
 version = '0.0.1-SNAPSHOT'

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary

JDK 17 dependency/plugin audit (child 2 of 3). Every dependency in `build.gradle` compiles and tests clean on JDK 17 as-is — the **only** required change is Spotless.

Spotless 6.2.1 runs google-java-format in the Gradle JVM without the `jdk.compiler` exports, so `spotlessJava` dies on any JDK 16+:

```
java.lang.IllegalAccessError: class com.google.googlejavaformat.java.JavaInput ... cannot access
class com.sun.tools.javac.parser.Tokens$TokenKind (in module jdk.compiler) because module
jdk.compiler does not export com.sun.tools.javac.parser to unnamed module
```

6.2.2 is the first release that adds the required `--add-exports` handling; verified by bisecting 6.2.1 → 6.25.0 with `spotlessCheck --rerun-tasks` (6.2.1 fails, 6.2.2+ all pass), so this is the minimal bump. The one-line reformat in `DefaultJwtServiceTest` is the output of `spotlessApply` under the new formatter — needed for `spotlessCheck` to pass.

Note this failure is independent of the source/target level: the Gradle daemon already runs on JDK 17, so master's `spotlessCheck` is broken today. The diff contains no toolchain change (that's the other session's scope).

### Per-dependency verdict (JDK 17)

| Dependency / plugin | Version | Verdict |
| --- | --- | --- |
| org.springframework.boot plugin / starters | 2.6.3 | compatible as-is |
| io.spring.dependency-management | 1.0.11.RELEASE | compatible as-is |
| com.netflix.dgs.codegen | 5.0.6 | compatible as-is — `generateJava` emits 22 sources under `build/generated`, all compile |
| graphql-dgs-spring-boot-starter | 4.9.21 | compatible as-is |
| com.diffplug.spotless | 6.2.1 | **bumped to 6.2.2** |
| Lombok (managed) | 1.18.22 | compatible as-is — no explicit pin needed |
| mybatis-spring-boot-starter (+ -test) | 2.2.2 | compatible as-is |
| jjwt api/impl/jackson | 0.11.2 | compatible as-is |
| joda-time | 2.10.13 | compatible as-is |
| sqlite-jdbc | 3.36.0.3 | compatible as-is |
| rest-assured (+ json-path/xml-path/spring-mock-mvc) | 4.5.1 | compatible as-is |

### Verification

`./gradlew clean build --rerun-tasks` on JDK 17.0.13, run both with the existing `sourceCompatibility/targetCompatibility '11'` and with a temporary Java 17 toolchain (reverted before commit): BUILD SUCCESSFUL, 68 tests, 0 failures, spotlessCheck green. No `InaccessibleObjectException` or other reflection failures surfaced at test runtime, so nothing to hand to the runtime-reflection scope.

Alternative if you prefer to keep Spotless pinned at 6.2.1: add `org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED` (plus the api/file/tree/util exports) to `gradle.properties`. The version bump is the smaller, self-contained fix.


Link to Devin session: https://app.devin.ai/sessions/536a4ce882d544dba1bf1f29242fa33e
Requested by: @araza-cog
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/993?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->