### PR TITLE
fix: resolve top 5 SonarQube issues (weekly sweep)

### DIFF
--- a/src/main/java/io/spring/api/ArticleApi.java
+++ b/src/main/java/io/spring/api/ArticleApi.java
@@ -33,7 +33,7 @@ public class ArticleApi {
   private ArticleCommandService articleCommandService;
 
   @GetMapping
-  public ResponseEntity<?> article(
+  public ResponseEntity<Map<String, Object>> article(
       @PathVariable("slug") String slug, @AuthenticationPrincipal User user) {
     return articleQueryService
         .findBySlug(slug, user)
@@ -42,7 +42,7 @@ public class ArticleApi {
   }
 
   @PutMapping
-  public ResponseEntity<?> updateArticle(
+  public ResponseEntity<Map<String, Object>> updateArticle(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody UpdateArticleParam updateArticleParam) {

--- a/src/main/java/io/spring/api/CommentsApi.java
+++ b/src/main/java/io/spring/api/CommentsApi.java
@@ -38,7 +38,7 @@ public class CommentsApi {
   private CommentQueryService commentQueryService;
 
   @PostMapping
-  public ResponseEntity<?> createComment(
+  public ResponseEntity<Map<String, Object>> createComment(
       @PathVariable("slug") String slug,
       @AuthenticationPrincipal User user,
       @Valid @RequestBody NewCommentParam newCommentParam) {

--- a/src/main/java/io/spring/api/exception/InvalidRequestException.java
+++ b/src/main/java/io/spring/api/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import org.springframework.validation.Errors;
 
 @SuppressWarnings("serial")
 public class InvalidRequestException extends RuntimeException {
-  private final Errors errors;
+  private final transient Errors errors;
 
   public InvalidRequestException(Errors errors) {
     super("");

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -15,30 +15,34 @@ import org.joda.time.DateTime;
 @MappedTypes(DateTime.class)
 public class DateTimeHandler implements TypeHandler<DateTime> {
 
-  private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
   @Override
   public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
       throws SQLException {
     ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, utcCalendar());
   }
 
   @Override
   public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnName, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp timestamp = rs.getTimestamp(columnIndex, utcCalendar());
     return timestamp != null ? new DateTime(timestamp.getTime()) : null;
   }
 
   @Override
   public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
+    Timestamp ts = cs.getTimestamp(columnIndex, utcCalendar());
     return ts != null ? new DateTime(ts.getTime()) : null;
+  }
+
+  private static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
   }
 }

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -13,7 +13,8 @@ public class DefaultJwtServiceTest {
 
   @BeforeEach
   public void setUp() {
-    jwtService = new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+    jwtService =
+        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Weekly SonarQube sweep of `choikh0423_demo-spring-boot-test-coverage` (the Sonar project analyzing this repo). No BLOCKER issues are open; the four CRITICAL issues plus the highest-ranked MAJOR *bug* are fixed here.

| # | Issue key | Severity / type | Rule | Issue | Fix |
|---|-----------|-----------------|------|-------|-----|
| 1 | `AZ1u3HCaEnUkF3fpjVtj` | CRITICAL / CODE_SMELL | java:S1452 | `ArticleApi.article` returned wildcard `ResponseEntity<?>` (line 36) | `ResponseEntity<Map<String, Object>>` — the type `articleResponse()` already produces |
| 2 | `AZ1u3HCaEnUkF3fpjVtk` | CRITICAL / CODE_SMELL | java:S1452 | Same in `ArticleApi.updateArticle` (line 45) | same |
| 3 | `AZ1u3HBkEnUkF3fpjVtQ` | CRITICAL / CODE_SMELL | java:S1452 | Same in `CommentsApi.createComment` (line 41) | same |
| 4 | `AZ1u3HBdEnUkF3fpjVtN` | CRITICAL / CODE_SMELL | java:S1948 | `InvalidRequestException.errors` is a non-transient, non-serializable `Errors` field in a `Serializable` exception | marked `transient` (Spring `Errors` is request-scoped and never meant to survive serialization) |
| 5 | `AZ1u3HAmEnUkF3fpjVtC` | MAJOR / BUG | java:S2885 | `DateTimeHandler` shared a `static final Calendar` across threads; `Calendar` is not thread-safe and MyBatis type handlers are singletons | keep only the immutable-by-copy `TimeZone` static and build a fresh calendar per call:<br>`private static Calendar utcCalendar() { return Calendar.getInstance(UTC); }` |

Ranking followed severity → type (BUG over CODE_SMELL) → effort → recency; ties among the equal CRITICAL code smells were broken by lower effort then recency.

One unrelated hunk: `DefaultJwtServiceTest` had a pre-existing `spotlessCheck` violation on `master`, so `spotlessApply` reformatted that line.

`./gradlew spotlessCheck test` passes (run on JDK 11 — Gradle 7.4 cannot run on the JDK 21 the current snapshot sets as `JAVA_HOME`, and google-java-format fails on JDK 17 without `--add-exports`).


Link to Devin session: https://app.devin.ai/sessions/87939f7fc8234614a7a2249300c2acbf
Requested by: @choikh0423
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/999?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->