### PR TITLE
Replace Joda-Time with java.time (Instant)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6',
                 'io.jsonwebtoken:jjwt-jackson:0.12.6'
-    implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/io/spring/DateTimeFormats.java
+++ b/src/main/java/io/spring/DateTimeFormats.java
@@ -1,0 +1,11 @@
+package io.spring;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public final class DateTimeFormats {
+  public static final DateTimeFormatter UTC_DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+
+  private DateTimeFormats() {}
+}

--- a/src/main/java/io/spring/JacksonCustomizations.java
+++ b/src/main/java/io/spring/JacksonCustomizations.java
@@ -6,8 +6,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
+import java.time.Instant;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,23 +20,23 @@ public class JacksonCustomizations {
 
   public static class RealWorldModules extends SimpleModule {
     public RealWorldModules() {
-      addSerializer(DateTime.class, new DateTimeSerializer());
+      addSerializer(Instant.class, new InstantSerializer());
     }
   }
 
-  public static class DateTimeSerializer extends StdSerializer<DateTime> {
+  public static class InstantSerializer extends StdSerializer<Instant> {
 
-    protected DateTimeSerializer() {
-      super(DateTime.class);
+    protected InstantSerializer() {
+      super(Instant.class);
     }
 
     @Override
-    public void serialize(DateTime value, JsonGenerator gen, SerializerProvider provider)
+    public void serialize(Instant value, JsonGenerator gen, SerializerProvider provider)
         throws IOException {
       if (value == null) {
         gen.writeNull();
       } else {
-        gen.writeString(ISODateTimeFormat.dateTime().withZoneUTC().print(value));
+        gen.writeString(DateTimeFormats.UTC_DATE_TIME_FORMATTER.format(value));
       }
     }
   }

--- a/src/main/java/io/spring/application/ArticleQueryService.java
+++ b/src/main/java/io/spring/application/ArticleQueryService.java
@@ -9,6 +9,7 @@ import io.spring.core.user.User;
 import io.spring.infrastructure.mybatis.readservice.ArticleFavoritesReadService;
 import io.spring.infrastructure.mybatis.readservice.ArticleReadService;
 import io.spring.infrastructure.mybatis.readservice.UserRelationshipQueryService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,7 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.AllArgsConstructor;
-import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -55,7 +55,7 @@ public class ArticleQueryService {
       String tag,
       String author,
       String favoritedBy,
-      CursorPageParameter<DateTime> page,
+      CursorPageParameter<Instant> page,
       User currentUser) {
     List<String> articleIds =
         articleReadService.findArticlesWithCursor(tag, author, favoritedBy, page);
@@ -78,7 +78,7 @@ public class ArticleQueryService {
   }
 
   public CursorPager<ArticleData> findUserFeedWithCursor(
-      User user, CursorPageParameter<DateTime> page) {
+      User user, CursorPageParameter<Instant> page) {
     List<String> followdUsers = userRelationshipQueryService.followedUsers(user.getId());
     if (followdUsers.size() == 0) {
       return new CursorPager<>(new ArrayList<>(), page.getDirection(), false);

--- a/src/main/java/io/spring/application/CommentQueryService.java
+++ b/src/main/java/io/spring/application/CommentQueryService.java
@@ -4,6 +4,7 @@ import io.spring.application.data.CommentData;
 import io.spring.core.user.User;
 import io.spring.infrastructure.mybatis.readservice.CommentReadService;
 import io.spring.infrastructure.mybatis.readservice.UserRelationshipQueryService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +12,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -54,7 +54,7 @@ public class CommentQueryService {
   }
 
   public CursorPager<CommentData> findByArticleIdWithCursor(
-      String articleId, User user, CursorPageParameter<DateTime> page) {
+      String articleId, User user, CursorPageParameter<Instant> page) {
     List<CommentData> comments = commentReadService.findByArticleIdWithCursor(articleId, page);
     if (comments.isEmpty()) {
       return new CursorPager<>(new ArrayList<>(), page.getDirection(), false);

--- a/src/main/java/io/spring/application/DateTimeCursor.java
+++ b/src/main/java/io/spring/application/DateTimeCursor.java
@@ -1,23 +1,22 @@
 package io.spring.application;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import java.time.Instant;
 
-public class DateTimeCursor extends PageCursor<DateTime> {
+public class DateTimeCursor extends PageCursor<Instant> {
 
-  public DateTimeCursor(DateTime data) {
+  public DateTimeCursor(Instant data) {
     super(data);
   }
 
   @Override
   public String toString() {
-    return String.valueOf(getData().getMillis());
+    return String.valueOf(getData().toEpochMilli());
   }
 
-  public static DateTime parse(String cursor) {
+  public static Instant parse(String cursor) {
     if (cursor == null) {
       return null;
     }
-    return new DateTime().withMillis(Long.parseLong(cursor)).withZone(DateTimeZone.UTC);
+    return Instant.ofEpochMilli(Long.parseLong(cursor));
   }
 }

--- a/src/main/java/io/spring/application/data/ArticleData.java
+++ b/src/main/java/io/spring/application/data/ArticleData.java
@@ -2,11 +2,11 @@ package io.spring.application.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.spring.application.DateTimeCursor;
+import java.time.Instant;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Data
 @NoArgsConstructor
@@ -19,8 +19,8 @@ public class ArticleData implements io.spring.application.Node {
   private String body;
   private boolean favorited;
   private int favoritesCount;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
   private List<String> tagList;
 
   @JsonProperty("author")

--- a/src/main/java/io/spring/application/data/CommentData.java
+++ b/src/main/java/io/spring/application/data/CommentData.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.spring.application.DateTimeCursor;
 import io.spring.application.Node;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Data
 @NoArgsConstructor
@@ -16,8 +16,8 @@ public class CommentData implements Node {
   private String id;
   private String body;
   @JsonIgnore private String articleId;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   @JsonProperty("author")
   private ProfileData profileData;

--- a/src/main/java/io/spring/core/article/Article.java
+++ b/src/main/java/io/spring/core/article/Article.java
@@ -3,13 +3,13 @@ package io.spring.core.article;
 import static java.util.stream.Collectors.toList;
 
 import io.spring.Util;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Getter
 @NoArgsConstructor
@@ -22,12 +22,12 @@ public class Article {
   private String description;
   private String body;
   private List<Tag> tags;
-  private DateTime createdAt;
-  private DateTime updatedAt;
+  private Instant createdAt;
+  private Instant updatedAt;
 
   public Article(
       String title, String description, String body, List<String> tagList, String userId) {
-    this(title, description, body, tagList, userId, new DateTime());
+    this(title, description, body, tagList, userId, Instant.now());
   }
 
   public Article(
@@ -36,7 +36,7 @@ public class Article {
       String body,
       List<String> tagList,
       String userId,
-      DateTime createdAt) {
+      Instant createdAt) {
     this.id = UUID.randomUUID().toString();
     this.slug = toSlug(title);
     this.title = title;
@@ -52,15 +52,15 @@ public class Article {
     if (!Util.isEmpty(title)) {
       this.title = title;
       this.slug = toSlug(title);
-      this.updatedAt = new DateTime();
+      this.updatedAt = Instant.now();
     }
     if (!Util.isEmpty(description)) {
       this.description = description;
-      this.updatedAt = new DateTime();
+      this.updatedAt = Instant.now();
     }
     if (!Util.isEmpty(body)) {
       this.body = body;
-      this.updatedAt = new DateTime();
+      this.updatedAt = Instant.now();
     }
   }
 

--- a/src/main/java/io/spring/core/comment/Comment.java
+++ b/src/main/java/io/spring/core/comment/Comment.java
@@ -1,10 +1,10 @@
 package io.spring.core.comment;
 
+import java.time.Instant;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 @Getter
 @NoArgsConstructor
@@ -14,13 +14,13 @@ public class Comment {
   private String body;
   private String userId;
   private String articleId;
-  private DateTime createdAt;
+  private Instant createdAt;
 
   public Comment(String body, String userId, String articleId) {
     this.id = UUID.randomUUID().toString();
     this.body = body;
     this.userId = userId;
     this.articleId = articleId;
-    this.createdAt = new DateTime();
+    this.createdAt = Instant.now();
   }
 }

--- a/src/main/java/io/spring/graphql/ArticleDatafetcher.java
+++ b/src/main/java/io/spring/graphql/ArticleDatafetcher.java
@@ -7,6 +7,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
+import io.spring.DateTimeFormats;
 import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ArticleQueryService;
 import io.spring.application.CursorPageParameter;
@@ -29,7 +30,6 @@ import io.spring.graphql.types.Profile;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.format.ISODateTimeFormat;
 
 @DgsComponent
 @AllArgsConstructor
@@ -368,14 +368,14 @@ public class ArticleDatafetcher {
   private Article buildArticleResult(ArticleData articleData) {
     return Article.newBuilder()
         .body(articleData.getBody())
-        .createdAt(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getCreatedAt()))
+        .createdAt(DateTimeFormats.UTC_DATE_TIME_FORMATTER.format(articleData.getCreatedAt()))
         .description(articleData.getDescription())
         .favorited(articleData.isFavorited())
         .favoritesCount(articleData.getFavoritesCount())
         .slug(articleData.getSlug())
         .tagList(articleData.getTagList())
         .title(articleData.getTitle())
-        .updatedAt(ISODateTimeFormat.dateTime().withZoneUTC().print(articleData.getUpdatedAt()))
+        .updatedAt(DateTimeFormats.UTC_DATE_TIME_FORMATTER.format(articleData.getUpdatedAt()))
         .build();
   }
 }

--- a/src/main/java/io/spring/graphql/CommentDatafetcher.java
+++ b/src/main/java/io/spring/graphql/CommentDatafetcher.java
@@ -5,6 +5,7 @@ import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
+import io.spring.DateTimeFormats;
 import io.spring.application.CommentQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -24,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.joda.time.format.ISODateTimeFormat;
 
 @DgsComponent
 @AllArgsConstructor
@@ -112,8 +112,8 @@ public class CommentDatafetcher {
     return Comment.newBuilder()
         .id(comment.getId())
         .body(comment.getBody())
-        .updatedAt(ISODateTimeFormat.dateTime().withZoneUTC().print(comment.getCreatedAt()))
-        .createdAt(ISODateTimeFormat.dateTime().withZoneUTC().print(comment.getCreatedAt()))
+        .updatedAt(DateTimeFormats.UTC_DATE_TIME_FORMATTER.format(comment.getCreatedAt()))
+        .createdAt(DateTimeFormats.UTC_DATE_TIME_FORMATTER.format(comment.getCreatedAt()))
         .build();
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/DateTimeHandler.java
@@ -5,40 +5,39 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.TimeZone;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.MappedTypes;
 import org.apache.ibatis.type.TypeHandler;
-import org.joda.time.DateTime;
 
-@MappedTypes(DateTime.class)
-public class DateTimeHandler implements TypeHandler<DateTime> {
+@MappedTypes(Instant.class)
+public class DateTimeHandler implements TypeHandler<Instant> {
 
   private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
   @Override
-  public void setParameter(PreparedStatement ps, int i, DateTime parameter, JdbcType jdbcType)
+  public void setParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType)
       throws SQLException {
-    ps.setTimestamp(
-        i, parameter != null ? new Timestamp(parameter.getMillis()) : null, UTC_CALENDAR);
+    ps.setTimestamp(i, parameter != null ? Timestamp.from(parameter) : null, UTC_CALENDAR);
   }
 
   @Override
-  public DateTime getResult(ResultSet rs, String columnName) throws SQLException {
+  public Instant getResult(ResultSet rs, String columnName) throws SQLException {
     Timestamp timestamp = rs.getTimestamp(columnName, UTC_CALENDAR);
-    return timestamp != null ? new DateTime(timestamp.getTime()) : null;
+    return timestamp != null ? timestamp.toInstant() : null;
   }
 
   @Override
-  public DateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
+  public Instant getResult(ResultSet rs, int columnIndex) throws SQLException {
     Timestamp timestamp = rs.getTimestamp(columnIndex, UTC_CALENDAR);
-    return timestamp != null ? new DateTime(timestamp.getTime()) : null;
+    return timestamp != null ? timestamp.toInstant() : null;
   }
 
   @Override
-  public DateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
+  public Instant getResult(CallableStatement cs, int columnIndex) throws SQLException {
     Timestamp ts = cs.getTimestamp(columnIndex, UTC_CALENDAR);
-    return ts != null ? new DateTime(ts.getTime()) : null;
+    return ts != null ? ts.toInstant() : null;
   }
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/ArticleReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/ArticleReadService.java
@@ -3,6 +3,7 @@ package io.spring.infrastructure.mybatis.readservice;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.Page;
 import io.spring.application.data.ArticleData;
+import java.time.Instant;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -30,7 +31,7 @@ public interface ArticleReadService {
       @Param("authors") List<String> authors, @Param("page") Page page);
 
   List<ArticleData> findArticlesOfAuthorsWithCursor(
-      @Param("authors") List<String> authors, @Param("page") CursorPageParameter page);
+      @Param("authors") List<String> authors, @Param("page") CursorPageParameter<Instant> page);
 
   int countFeedSize(@Param("authors") List<String> authors);
 
@@ -38,5 +39,5 @@ public interface ArticleReadService {
       @Param("tag") String tag,
       @Param("author") String author,
       @Param("favoritedBy") String favoritedBy,
-      @Param("page") CursorPageParameter page);
+      @Param("page") CursorPageParameter<Instant> page);
 }

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
@@ -2,10 +2,10 @@ package io.spring.infrastructure.mybatis.readservice;
 
 import io.spring.application.CursorPageParameter;
 import io.spring.application.data.CommentData;
+import java.time.Instant;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.joda.time.DateTime;
 
 @Mapper
 public interface CommentReadService {
@@ -14,5 +14,5 @@ public interface CommentReadService {
   List<CommentData> findByArticleId(@Param("articleId") String articleId);
 
   List<CommentData> findByArticleIdWithCursor(
-      @Param("articleId") String articleId, @Param("page") CursorPageParameter<DateTime> page);
+      @Param("articleId") String articleId, @Param("page") CursorPageParameter<Instant> page);
 }

--- a/src/test/java/io/spring/TestHelper.java
+++ b/src/test/java/io/spring/TestHelper.java
@@ -4,13 +4,13 @@ import io.spring.application.data.ArticleData;
 import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
 import io.spring.core.user.User;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.joda.time.DateTime;
 
 public class TestHelper {
   public static ArticleData articleDataFixture(String seed, User user) {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     return new ArticleData(
         seed + "id",
         "title-" + seed,

--- a/src/test/java/io/spring/api/ArticleApiTest.java
+++ b/src/test/java/io/spring/api/ArticleApiTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.DateTimeFormats;
 import io.spring.JacksonCustomizations;
 import io.spring.TestHelper;
 import io.spring.api.security.WebSecurityConfig;
@@ -19,13 +20,12 @@ import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
 import io.spring.core.article.ArticleRepository;
 import io.spring.core.user.User;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +55,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
   @Test
   public void should_read_article_success() throws Exception {
     String slug = "test-new-article";
-    DateTime time = new DateTime();
+    Instant time = Instant.now();
     Article article =
         new Article(
             "Test New Article",
@@ -74,7 +74,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
         .statusCode(200)
         .body("article.slug", equalTo(slug))
         .body("article.body", equalTo(articleData.getBody()))
-        .body("article.createdAt", equalTo(ISODateTimeFormat.dateTime().withZoneUTC().print(time)));
+        .body("article.createdAt", equalTo(DateTimeFormats.UTC_DATE_TIME_FORMATTER.format(time)));
   }
 
   @Test
@@ -131,7 +131,7 @@ public class ArticleApiTest extends TestWithCurrentUser {
         new Article(
             title, description, body, Arrays.asList("java", "spring", "jpg"), anotherUser.getId());
 
-    DateTime time = new DateTime();
+    Instant time = Instant.now();
     ArticleData articleData =
         new ArticleData(
             article.getId(),

--- a/src/test/java/io/spring/api/ArticlesApiTest.java
+++ b/src/test/java/io/spring/api/ArticlesApiTest.java
@@ -16,11 +16,11 @@ import io.spring.application.article.ArticleCommandService;
 import io.spring.application.data.ArticleData;
 import io.spring.application.data.ProfileData;
 import io.spring.core.article.Article;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,8 +63,8 @@ public class ArticlesApiTest extends TestWithCurrentUser {
             body,
             false,
             0,
-            new DateTime(),
-            new DateTime(),
+            Instant.now(),
+            Instant.now(),
             tagList,
             new ProfileData("userid", user.getUsername(), user.getBio(), user.getImage(), false));
 
@@ -132,8 +132,8 @@ public class ArticlesApiTest extends TestWithCurrentUser {
             body,
             false,
             0,
-            new DateTime(),
-            new DateTime(),
+            Instant.now(),
+            Instant.now(),
             asList(tagList),
             new ProfileData("userid", user.getUsername(), user.getBio(), user.getImage(), false));
 

--- a/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
+++ b/src/test/java/io/spring/application/article/ArticleQueryServiceTest.java
@@ -19,9 +19,10 @@ import io.spring.infrastructure.DbTestBase;
 import io.spring.infrastructure.repository.MyBatisArticleFavoriteRepository;
 import io.spring.infrastructure.repository.MyBatisArticleRepository;
 import io.spring.infrastructure.repository.MyBatisUserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
     userRepository.save(user);
     article =
         new Article(
-            "test", "desc", "body", Arrays.asList("java", "spring"), user.getId(), new DateTime());
+            "test", "desc", "body", Arrays.asList("java", "spring"), user.getId(), Instant.now());
     articleRepository.save(article);
   }
 
@@ -92,7 +93,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             "body",
             Arrays.asList("test"),
             user.getId(),
-            new DateTime().minusHours(1));
+            Instant.now().minus(1, ChronoUnit.HOURS));
     articleRepository.save(anotherArticle);
 
     ArticleDataList recentArticles =
@@ -116,7 +117,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             "body",
             Arrays.asList("test"),
             user.getId(),
-            new DateTime().minusHours(1));
+            Instant.now().minus(1, ChronoUnit.HOURS));
     articleRepository.save(anotherArticle);
 
     CursorPager<ArticleData> recentArticles =
@@ -130,7 +131,7 @@ public class ArticleQueryServiceTest extends DbTestBase {
             null,
             null,
             null,
-            new CursorPageParameter<DateTime>(
+            new CursorPageParameter<Instant>(
                 DateTimeCursor.parse(recentArticles.getEndCursor().toString()), 20, Direction.NEXT),
             user);
     Assertions.assertEquals(nodata.getData().size(), 0);


### PR DESCRIPTION
## Summary

Workstream D of the modernization: drops `joda-time` and moves every timestamp to `java.time.Instant`. Stacked on #1005 (Boot 3 / Jakarta / Security 6), so review that one first.

`Instant` rather than `LocalDateTime` because the old code already treated every timestamp as a UTC instant (`new DateTime(timestamp.getTime())`, `withZoneUTC()`), and `Instant` is the type that keeps that unambiguous across the MyBatis, Jackson, and cursor boundaries.

The one thing worth attention: **the wire format had to stay byte-identical**, and `Instant`'s default rendering does not match Joda's. `ISODateTimeFormat.dateTime()` always prints exactly 3 fractional digits (`...T09:38:51.300Z`), whereas `Instant.toString()`/`DateTimeFormatter.ISO_INSTANT` truncate trailing zeros and can print 0, 3, 6 or 9 digits — so a plain swap would have silently changed API output. Hence one shared formatter, used by every rendering site:

```java
// io.spring.DateTimeFormats
UTC_DATE_TIME_FORMATTER =
    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
```

Applied in `JacksonCustomizations` (serializer now registered for `Instant.class`), `ArticleDatafetcher`/`CommentDatafetcher`, and the REST date assertion in `ArticleApiTest`.

`DateTimeHandler` stays a hand-written handler rather than deferring to MyBatis' built-in `Instant` support, because the existing read/write path pins the driver to a UTC `Calendar` and SQLite has no timestamp type — keeping the handler keeps that round-trip exactly as it was, just retyped:

```diff
-@MappedTypes(DateTime.class)  ... new Timestamp(parameter.getMillis()) / new DateTime(ts.getTime())
+@MappedTypes(Instant.class)   ... Timestamp.from(parameter)            / ts.toInstant()
```

Cursor pagination is now epoch-millis in / epoch-millis out (`toEpochMilli()` ↔ `Instant.ofEpochMilli`), which also removes the odd `new DateTime().withMillis(...)` construction. `CursorPageParameter` was raw in two `ArticleReadService` signatures and is now parameterized as `CursorPageParameter<Instant>`.

## Verification

- `./gradlew build` — pass, all tests
- `./gradlew spotlessCheck` — pass
- `grep -r org.joda src` — no matches
- Runtime smoke against a live instance: article create + read (REST) and article query (GraphQL) return identical timestamp strings with exactly 3 fractional digits (`2026-08-19T09:38:51.300Z`)


Link to Devin session: https://app.devin.ai/sessions/f3748fb4cdcc4cbdb98f2746decd3710
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/1006?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/1006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/1006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->