### PR TITLE
Harden security: mandatory JWT_SECRET, configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,18 @@ And the code is organized as this:
 
 Integration with Spring Security and add other filter for jwt token process.
 
-The secret key is stored in `application.properties`.
+The application requires the `JWT_SECRET` environment variable. It must contain at least
+64 bytes of key material for HS512; generate a suitable value with:
+
+    export JWT_SECRET="$(openssl rand -hex 64)"
+
+There is no default JWT secret. The application fails during startup if `JWT_SECRET` is missing.
+
+The CORS origins are configured by the `cors.allowed-origins` property. The local development
+default is `http://localhost:3000,http://localhost:8080`; override it at deployment time, for
+example:
+
+    ./gradlew bootRun --args='--cors.allowed-origins=https://app.example.com'
 
 # Database
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 You'll need Java 17 installed.
 
-    ./gradlew bootRun
+    JWT_SECRET="$(openssl rand -hex 64)" ./gradlew bootRun
 
 To test that it works, open a browser tab at http://localhost:8080/tags .  
 Alternatively, you can run
@@ -69,7 +69,7 @@ Alternatively, you can run
 You'll need Docker installed.
 	
     ./gradlew bootBuildImage --imageName spring-boot-realworld-example-app
-    docker run -p 8081:8080 spring-boot-realworld-example-app
+    docker run -e JWT_SECRET="$(openssl rand -hex 64)" -p 8081:8080 spring-boot-realworld-example-app
 
 # Try it out with a RealWorld frontend
 

--- a/src/main/java/io/spring/api/security/WebSecurityConfig.java
+++ b/src/main/java/io/spring/api/security/WebSecurityConfig.java
@@ -2,6 +2,9 @@ package io.spring.api.security;
 
 import static java.util.Arrays.asList;
 
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -21,6 +24,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
+  private final String allowedOrigins;
+
+  public WebSecurityConfig(@Value("${cors.allowed-origins}") String allowedOrigins) {
+    this.allowedOrigins = allowedOrigins;
+  }
 
   @Bean
   public JwtTokenFilter jwtTokenFilter() {
@@ -67,7 +75,12 @@ public class WebSecurityConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     final CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(asList("*"));
+    List<String> origins =
+        Arrays.stream(allowedOrigins.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .toList();
+    configuration.setAllowedOrigins(origins);
     configuration.setAllowedMethods(asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
     // setAllowCredentials(true) is important, otherwise:
     // The value of the 'Access-Control-Allow-Origin' header in the response must not be the

--- a/src/main/java/io/spring/api/security/WebSecurityConfig.java
+++ b/src/main/java/io/spring/api/security/WebSecurityConfig.java
@@ -2,7 +2,6 @@ package io.spring.api.security;
 
 import static java.util.Arrays.asList;
 
-import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -24,9 +23,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
-  private final String allowedOrigins;
+  private final List<String> allowedOrigins;
 
-  public WebSecurityConfig(@Value("${cors.allowed-origins}") String allowedOrigins) {
+  public WebSecurityConfig(@Value("${cors.allowed-origins}") List<String> allowedOrigins) {
     this.allowedOrigins = allowedOrigins;
   }
 
@@ -75,12 +74,7 @@ public class WebSecurityConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     final CorsConfiguration configuration = new CorsConfiguration();
-    List<String> origins =
-        Arrays.stream(allowedOrigins.split(","))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .toList();
-    configuration.setAllowedOrigins(origins);
+    configuration.setAllowedOrigins(allowedOrigins);
     configuration.setAllowedMethods(asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
     // setAllowCredentials(true) is important, otherwise:
     // The value of the 'Access-Control-Allow-Origin' header in the response must not be the

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,2 +1,0 @@
-spring.datasource.url=jdbc:sqlite::memory:
-jwt.secret=050008197a0fb09bb646f302acb47c01427ea0f4b040e934f8e1c73da08b710efaceff3ac8cac311413fb3590b29898f44c0057b9386312347f5ee776f6f0027

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,1 +1,2 @@
 spring.datasource.url=jdbc:sqlite::memory:
+jwt.secret=050008197a0fb09bb646f302acb47c01427ea0f4b040e934f8e1c73da08b710efaceff3ac8cac311413fb3590b29898f44c0057b9386312347f5ee776f6f0027

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,8 +6,10 @@ spring.jackson.deserialization.UNWRAP_ROOT_VALUE=true
 
 image.default=https://static.productionready.io/images/smiley-cyrus.jpg
 
-jwt.secret=nRvyYC4soFxBdZ-F-5Nnzz5USXstR1YylsTd-mA0aKtI9HUlriGrtkf-TiuDapkLiUCogO3JOK7kwZisrHp6wA
+jwt.secret=${JWT_SECRET}
 jwt.sessionTime=86400
+
+cors.allowed-origins=http://localhost:3000,http://localhost:8080
 
 mybatis.configuration.cache-enabled=true
 mybatis.configuration.default-statement-timeout=3000

--- a/src/test/java/io/spring/RealworldApplicationTests.java
+++ b/src/test/java/io/spring/RealworldApplicationTests.java
@@ -2,7 +2,9 @@ package io.spring;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 public class RealworldApplicationTests {
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,2 @@
+spring.datasource.url=jdbc:sqlite::memory:
+jwt.secret=acf26d27cd26b2cb6ecc4601c94a2de47da903f1abee04a0ecbc1da6a94fb7546c7778f5d56c4a5f942a775ab42761b9bac10e8322462cbbb70b6e63c8dac9eb


### PR DESCRIPTION
## Summary

Workstream F, top of the stack (on top of #1006 → #1005). Two hardening changes; no API or behavior change for a correctly-configured deployment.

**The JWT secret is now mandatory and has no default.** `application.properties` shipped a real signing key in the repo, which means every deployment of this app that never changed it shares a publicly-known key — anyone can mint a valid token for any user id. The fix is deliberately fail-fast rather than a fallback:

```diff
-jwt.secret=<literal key committed in the repo>
+jwt.secret=${JWT_SECRET}
```

A default (even a "dev-only" one) is the vulnerability itself, since it's the value that survives to production, so an unset `JWT_SECRET` now aborts startup with `Could not resolve placeholder 'JWT_SECRET' in value "${JWT_SECRET}"` instead of booting with a weak key. The old committed value is gone from source, tests and docs — treat it as compromised and rotate anywhere it was deployed.

Tests keep passing with no env var: `application-test.properties` carries a throwaway secret and `RealworldApplicationTests` gains `@ActiveProfiles("test")`. That file also **moves from `src/main/resources` to `src/test/resources`** — in main resources it is packaged into the jar, so a stray `SPRING_PROFILES_ACTIVE=test` in a deployment would have re-introduced a publicly-known signing key, defeating the change above. The value is 64 bytes of hex because jjwt 0.12 enforces HS512's 512-bit minimum, which is also what the README's `openssl rand -hex 64` produces.

**CORS origins are property-driven instead of `*`:**

```diff
-configuration.setAllowedOrigins(asList("*"));
+configuration.setAllowedOrigins(allowedOrigins);  // @Value("${cors.allowed-origins}") List<String>
```

Default is `http://localhost:3000,http://localhost:8080` (the RealWorld frontends), overridable per deployment with `--cors.allowed-origins=https://app.example.com`. Comma splitting is Spring's conversion service, not hand-rolled. `setAllowCredentials(false)` and the allowed methods/headers are unchanged. Setting the property to an empty value yields deny-all (preflight → 403, no `Access-Control-Allow-Origin`) — no wildcard fallback by design.

README documents the required variable and how to generate it, and the quick-start and Docker snippets now pass it through (`docker run -e JWT_SECRET=...`) since bare `./gradlew bootRun` no longer boots.

## Verification

- `./gradlew build` with no `JWT_SECRET` exported — pass, full suite
- `./gradlew spotlessCheck` — pass
- Packaged jar contains no `application-test.properties` and no `jwt.secret` value; `application.properties` in the artifact holds only the placeholder
- Startup with no `JWT_SECRET` — fails fast with the placeholder error above
- Runtime with a generated secret: `POST /users` → 201, `POST /users/login` → 200 with token, authenticated `GET /user` → 200
- CORS: `GET /tags` with `Origin: http://localhost:3000` → 200 with matching `Access-Control-Allow-Origin`; same request with the property emptied → 403, no header


Link to Devin session: https://app.devin.ai/sessions/f3748fb4cdcc4cbdb98f2746decd3710
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/1008?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/spring-boot-realworld-example-app/pull/1008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/1008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->