### PR TITLE
docs: README requires Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It uses a ~~H2 in-memory database~~ sqlite database (for easy local test without
 
 # Getting started
 
-You'll need Java 11 installed.
+You'll need Java 17 installed.
 
     ./gradlew bootRun
 


### PR DESCRIPTION
## Summary
Documentation half of the coordinated Java 11 -> 17 upgrade: README now states Java 17 as the required JDK (`You'll need Java 11 installed.` -> `You'll need Java 17 installed.`). That was the only Java/JDK version reference in the file; no build files touched.

Link to Devin session: https://app.devin.ai/sessions/ade4ccaa4ede4b7291423dd27fd892de
Requested by: @araza-cog
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/1014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->