### PR TITLE
Child C: Spring Security 6 rewrite of WebSecurityConfig

### DIFF
--- a/src/main/java/io/spring/api/security/WebSecurityConfig.java
+++ b/src/main/java/io/spring/api/security/WebSecurityConfig.java
@@ -6,12 +6,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -20,7 +21,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+public class WebSecurityConfig {
 
   @Bean
   public JwtTokenFilter jwtTokenFilter() {
@@ -32,36 +33,32 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     return new BCryptPasswordEncoder();
   }
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .cors(Customizer.withDefaults())
+        .exceptionHandling(
+            eh -> eh.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.OPTIONS)
+                    .permitAll()
+                    .requestMatchers("/graphiql")
+                    .permitAll()
+                    .requestMatchers("/graphql")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/articles/feed")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.POST, "/users", "/users/login")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/articles/**", "/profiles/**", "/tags")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .addFilterBefore(jwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);
 
-    http.csrf()
-        .disable()
-        .cors()
-        .and()
-        .exceptionHandling()
-        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
-        .and()
-        .sessionManagement()
-        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        .and()
-        .authorizeRequests()
-        .antMatchers(HttpMethod.OPTIONS)
-        .permitAll()
-        .antMatchers("/graphiql")
-        .permitAll()
-        .antMatchers("/graphql")
-        .permitAll()
-        .antMatchers(HttpMethod.GET, "/articles/feed")
-        .authenticated()
-        .antMatchers(HttpMethod.POST, "/users", "/users/login")
-        .permitAll()
-        .antMatchers(HttpMethod.GET, "/articles/**", "/profiles/**", "/tags")
-        .permitAll()
-        .anyRequest()
-        .authenticated();
-
-    http.addFilterBefore(jwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);
+    return http.build();
   }
 
   @Bean


### PR DESCRIPTION
## Summary

`WebSecurityConfig` no longer `extends WebSecurityConfigurerAdapter` (removed in Spring Security 6). The `configure(HttpSecurity)` override becomes a `@Bean SecurityFilterChain filterChain(HttpSecurity http)` ending in `return http.build();`, using the lambda DSL, `authorizeHttpRequests`, and `requestMatchers` (`authorizeRequests`/`antMatchers` are gone in 6.x). `JwtTokenFilter`, `PasswordEncoder`, and `CorsConfigurationSource` beans are unchanged.

Rule-for-rule mapping (order preserved, so `GET /articles/feed` still shadows `GET /articles/**`):

| before | after |
| --- | --- |
| `csrf().disable()` | `csrf(csrf -> csrf.disable())` |
| `.cors()` | `.cors(Customizer.withDefaults())` |
| `exceptionHandling().authenticationEntryPoint(new HttpStatusEntryPoint(UNAUTHORIZED))` | `exceptionHandling(eh -> eh.authenticationEntryPoint(new HttpStatusEntryPoint(UNAUTHORIZED)))` |
| `sessionManagement().sessionCreationPolicy(STATELESS)` | `sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))` |
| `authorizeRequests()` | `authorizeHttpRequests(auth -> ...)` |
| `antMatchers(OPTIONS).permitAll()` | `requestMatchers(OPTIONS).permitAll()` |
| `antMatchers("/graphiql").permitAll()` | `requestMatchers("/graphiql").permitAll()` |
| `antMatchers("/graphql").permitAll()` | `requestMatchers("/graphql").permitAll()` |
| `antMatchers(GET, "/articles/feed").authenticated()` | `requestMatchers(GET, "/articles/feed").authenticated()` |
| `antMatchers(POST, "/users", "/users/login").permitAll()` | `requestMatchers(POST, "/users", "/users/login").permitAll()` |
| `antMatchers(GET, "/articles/**", "/profiles/**", "/tags").permitAll()` | same with `requestMatchers` |
| `anyRequest().authenticated()` | unchanged |
| `http.addFilterBefore(jwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)` | same, chained into the builder |

No rules added, dropped, or reordered. The file had no `javax.*` imports, so nothing to jakarta-ify here (`JwtTokenFilter` is Child B's).

Test classes only `@Import(WebSecurityConfig.class)` into `@WebMvcTest` slices — a `SecurityFilterChain` bean is picked up the same way an adapter was, so no test edits were needed.

## Verification

Compilation is not possible on this branch alone: it is still Spring Boot 2.6.3 / Spring Security 5, where `authorizeHttpRequests`/`requestMatchers` do not exist. `./gradlew compileJava` is expected to fail until Child A's Boot 3 / Security 6 bump lands. Verified by review against the Spring Security 6 API and by the rule-for-rule table above.


Link to Devin session: https://app.devin.ai/sessions/65cdcebb78344fa389e9deee6daa2ebe
Requested by: @kylie-chang
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/spring-boot-realworld-example-app/pull/1031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->